### PR TITLE
build: automate v0.1.0 release candidates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,5 +23,6 @@ node_modules/
 **/node_modules/
 ui/node_modules/
 ui/dist/
+dist/
 oonfeewrtd
 *.test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,138 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go:
+    name: Go / test, vet, modules
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Verify modules
+        run: go mod verify
+      - name: Check module tidiness
+        run: go mod tidy -diff
+      - name: Test
+        run: go test -count=1 ./...
+      - name: Vet
+        run: go vet ./...
+
+  go-race:
+    name: Go / race
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Test with race detector
+        run: go test -race -count=1 ./...
+
+  ui:
+    name: UI / test, build, budget
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - name: Install dependencies
+        run: npm --prefix ui ci
+      - name: Test
+        run: npm --prefix ui test
+      - name: Build
+        run: npm --prefix ui run build
+      - name: Check bundle budget
+        run: ./tools/budget_check.sh
+
+  release-build:
+    name: Release / build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - name: Build and verify archives
+        run: |
+          ./tools/release-build.sh v0.0.0-ci "$RUNNER_TEMP/release"
+          (cd "$RUNNER_TEMP/release" && sha256sum --check SHA256SUMS)
+          mkdir "$RUNNER_TEMP/release-extract"
+          tar -xzf "$RUNNER_TEMP/release/oonfeewrt_0.0.0-ci_linux_amd64.tar.gz" \
+            -C "$RUNNER_TEMP/release-extract"
+          test "$("$RUNNER_TEMP/release-extract/oonfeewrt_0.0.0-ci_linux_amd64/oonfeewrtd" -version)" = v0.0.0-ci
+          test -x "$RUNNER_TEMP/release-extract/oonfeewrt_0.0.0-ci_linux_amd64/oonfeewrt-recoverycheck"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Build multi-platform image without publishing
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: deploy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          outputs: type=oci,dest=${{ runner.temp }}/oonfeewrt.oci.tar
+          build-args: VERSION=v0.0.0-ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  secrets:
+    name: Security / secret scan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out complete history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Scan tree and history
+        run: ./tools/secret-scan.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,164 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  policy:
+    name: Release policy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require SemVer tag on main
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          semver='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?$'
+          [[ "$REF_NAME" =~ $semver ]] || {
+            echo "release: tag is not strict SemVer without build metadata: $REF_NAME" >&2
+            exit 1
+          }
+          git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main || {
+            echo "release: tagged commit is not on main" >&2
+            exit 1
+          }
+
+  archives:
+    name: Binary archives
+    needs: policy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - name: Build release archives
+        run: |
+          make release-check RELEASE_VERSION="$GITHUB_REF_NAME"
+          ./tools/release-build.sh "$GITHUB_REF_NAME" dist
+      - name: Upload release files
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-files
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 7
+
+  github-release:
+    name: GitHub release
+    needs: [archives, container]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Download release files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-files
+          path: dist
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          options="--repo $GITHUB_REPOSITORY --verify-tag --generate-notes --title $GITHUB_REF_NAME"
+          case "$GITHUB_REF_NAME" in
+            *-*) options="$options --prerelease" ;;
+          esac
+          # Release and repository names cannot contain shell whitespace.
+          # shellcheck disable=SC2086
+          gh release create "$GITHUB_REF_NAME" dist/* $options
+
+  container:
+    name: Multi-platform container
+    needs: policy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set image coordinates
+        id: image
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          echo "name=ghcr.io/${REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+          echo "version=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Sign in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Build and publish image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: deploy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.image.outputs.name }}:${{ steps.image.outputs.version }}
+          build-args: VERSION=${{ github.ref_name }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Verify anonymous multi-platform pull
+        env:
+          IMAGE: ${{ steps.image.outputs.name }}
+          VERSION: ${{ steps.image.outputs.version }}
+        run: |
+          anonymous=$(mktemp -d)
+          inspect="$RUNNER_TEMP/oonfeewrt-image-inspect.txt"
+          trap 'rm -rf "$anonymous"' EXIT
+          for attempt in 1 2 3 4 5 6; do
+            if DOCKER_CONFIG="$anonymous" docker buildx imagetools inspect \
+              "$IMAGE:$VERSION" > "$inspect"; then
+              break
+            fi
+            if [ "$attempt" -eq 6 ]; then
+              echo "release: image is not anonymously readable" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          grep -Eq 'Platform:[[:space:]]+linux/amd64([[:space:]]|$)' "$inspect"
+          grep -Eq 'Platform:[[:space:]]+linux/arm64([[:space:]]|$)' "$inspect"

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ __pycache__/
 # Go
 *.test
 /oonfeewrtd
+/dist/

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ SHELL := /bin/sh
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || printf dev)
 IMAGE ?= oonfeewrt:$(VERSION)
 PLATFORMS ?= linux/amd64,linux/arm64
+RELEASE_DIR ?= dist
 
-.PHONY: help ui build test check image release-check
+.PHONY: help ui build test check image release release-check
 
 help:
 	@printf '%s\n' \
@@ -14,6 +15,7 @@ help:
 		'make test                            run Go and UI tests' \
 		'make check                           run the local release gates' \
 		'make image                           build the amd64/arm64 OCI image' \
+		'make release RELEASE_VERSION=        package four release binaries' \
 		'make release-check RELEASE_VERSION=  require a clean, reproducible release tree'
 
 ui:
@@ -41,6 +43,12 @@ check: ui
 image:
 	docker buildx build --platform $(PLATFORMS) \
 		--build-arg VERSION=$(VERSION) -f deploy/Dockerfile -t $(IMAGE) .
+
+release:
+	@test -n "$(RELEASE_VERSION)" || { \
+		echo 'release: set RELEASE_VERSION (for example v0.1.0-rc.1)' >&2; exit 2; \
+	}
+	./tools/release-build.sh "$(RELEASE_VERSION)" "$(RELEASE_DIR)"
 
 release-check:
 	@test -n "$(RELEASE_VERSION)" || { \

--- a/README.md
+++ b/README.md
@@ -5,8 +5,13 @@ A UniFi-grade management interface for the OpenWrt you already run.
 Not a fork. Not a firmware. Not a distribution. **A front end that connects to
 stock OpenWrt over its existing API and makes it manageable the way UniFi is.**
 
-**Status:** Phase 4's schema-17 fresh-start hardware flow is verified. The v40
-final release candidate is merge-ready; it is not tagged or published.
+**Status:** Phase 4's schema-17 fresh-start hardware flow is verified. Tagged
+artifacts are produced by the [Release workflow](.github/workflows/release.yml)
+only after its binary and multi-platform container jobs pass. [GitHub
+Releases](https://github.com/aiden0rchad/oonfeeWRT/releases) is the source of
+truth for whether `v0.1.0-rc.1` is published. Once it appears there, follow
+[`docs/INSTALL.md`](docs/INSTALL.md); clean-install verification is reported
+separately after the published artifacts are tested.
 
 **Current validation checkpoint (2026-08-22):** both test routers were factory
 reset, re-adopted through the default-off ACL/login disclosure, and restored to
@@ -36,10 +41,10 @@ access-controlled final-RC recovery pair independently passed
 owned sections, one WLAN and no mesh; its passphrase and lab identifiers are
 intentionally excluded from the repository.
 
-This is final release-candidate evidence, not a tagged or published release.
-Building, restarting, checking, and copying recovery evidence changed no router
-state. FS-117 retains the superseded v39 runtime checkpoint rather than erasing
-that history.
+This v40 artifact is local release-candidate evidence, not itself a Git tag or
+published release asset. Building, restarting, checking, and copying recovery
+evidence changed no router state. FS-117 retains the superseded v39 runtime
+checkpoint rather than erasing that history.
 
 The Phase-4 completion and hardening work was merged through
 [PR #1](https://github.com/aiden0rchad/oonfeewrt/pull/1) as `ee15e2f`. At that
@@ -55,10 +60,10 @@ asserts exactly that against real hardware. Devices are adopted, polled, charted
 and applied to today, on a Linksys WRT3200ACM and a TP-Link Archer C6 running
 OpenWrt 25.12.5.
 
-What that does **not** mean: it has never run on more than two devices, several
-features have never met the hardware they are for, and nothing here has been
-packaged or released. The section below says exactly which parts are unverified,
-and it is worth reading before the install instructions rather than after.
+What that does **not** mean: it has never run on more than two devices, and
+several features have never met the hardware they are for. Packaging the release
+candidate does not close those proof gaps. The section below says exactly which
+parts are unverified, and it is worth reading before installation.
 
 ---
 
@@ -236,6 +241,10 @@ The controller is required; router packages are optional and default-off. Every
 step below is what the code actually does today, verified against stock OpenWrt
 25.12.5 on two hardware classes.
 
+For checksummed release binaries, the multi-platform container, persistence,
+backup, upgrade and reverse-proxy instructions, use
+[`docs/INSTALL.md`](docs/INSTALL.md). The shorter path below builds from source.
+
 ### The router: no controller-authored executable
 
 There is no oonfeeWRT package, custom feed, init script, firmware, or agent. A
@@ -393,6 +402,7 @@ the proxy sends `X-Forwarded-Proto: https`.
 
 | File | What's in it |
 |---|---|
+| [`docs/INSTALL.md`](docs/INSTALL.md) | Binary and container installation, exact router opt-ins, persistence, TLS and recovery |
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Components, transport, data model, provisioning + rollback, telemetry, capability probing |
 | [`docs/DEVICE-BUDGET.md`](docs/DEVICE-BUDGET.md) | Target hardware classes, hard resource budgets, where the cost actually is |
 | [`docs/PARITY-MATRIX.md`](docs/PARITY-MATRIX.md) | Every UniFi screen → OpenWrt source → verdict, with dependency tier |

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,7 @@ through **2026-08-22**, with the earlier Phase-3 hardware endpoint in §5bg, the
 schema-15/16 source-only checkpoint in §5bh, the read-only live schema-16
 Phase-4 pass under the retained router ACLs in §5bi, the superseded no-change
 checkpoint in §5bj, the corrected Phase-4 runtime/recovery checkpoint in §5bk,
-and the current fresh-start/schema-17 final-RC boundary in §5bl/FS-118. Sections
+and the fresh-start/schema-17 hardware boundary in §5bl/FS-118. Sections
 through §5ax record the earlier
 committed/hardware baseline; §5ay is product research, §5az is the two-router
 no-install capability pass, §5ba records the post-audit behavior, §5bb the
@@ -17,6 +17,13 @@ no-change checkpoint, §5bk the Phase-4 completion boundary, and §5bl the curre
 validation boundary.
 
 Repo: <https://github.com/aiden0rchad/oonfeewrt> · License: Apache-2.0
+
+This handoff records source and hardware evidence; it does not infer release
+publication from a branch or tag. The tag-triggered Release workflow publishes
+the binaries and container, and [GitHub
+Releases](https://github.com/aiden0rchad/oonfeeWRT/releases) is the publication
+source of truth. A clean-install pass is claimed only after downloaded release
+artifacts have been tested and that result is recorded.
 
 ---
 
@@ -5953,8 +5960,9 @@ the keyring is 275 bytes with SHA-256
 `recoverycheck` passed with
 `schema=17 devices=2 credentials=2 owned_sections=4 wlans=1 meshes=0`; its
 transient zero-byte WAL and 32,768-byte SHM were removed. Building, restarting,
-checking, and creating the recovery pair changed no router state. This evidence
-is merge-ready, but it is not a tagged or published release.
+checking, and creating the recovery pair changed no router state. This v40
+evidence was a merge-ready local checkpoint; it is not itself a Git tag or
+published release asset.
 
 ---
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -10,7 +10,7 @@
 # Pinned to the BUILD platform on purpose: without it, buildx runs this whole
 # stage under QEMU once per target arch, and `npm ci` under emulation is both
 # slow and flaky. The output is static assets, so it is arch-independent.
-FROM --platform=$BUILDPLATFORM node:22-alpine AS ui
+FROM --platform=$BUILDPLATFORM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS ui
 WORKDIR /src/ui
 COPY ui/package.json ui/package-lock.json ./
 RUN npm ci
@@ -24,7 +24,7 @@ RUN npm run build
 # GOOS/GOARCH below, which is what decision D3 (CGO off) buys us. Leaving this
 # unpinned would emulate the whole toolchain and make TARGETOS/TARGETARCH a
 # no-op, since they would just restate the emulated platform.
-FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -40,19 +40,10 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
 # see the /data note below.
 RUN mkdir -p /emptydirs/data /emptydirs/tmp
 
-# ---- stage 2b: timezone database ------------------------------------------
-# tzdata is a separate package; the alpine BASE image ships no /usr/share/
-# zoneinfo, so copying it straight from `alpine:3.20` fails the build outright.
-# Alternative worth taking once cmd/oonfeewrtd exists: a blank `time/tzdata`
-# import embeds the database in the binary (~450 KB) and removes this stage.
-FROM alpine:3.20 AS tz
-RUN apk add --no-cache tzdata
-
 # ---- stage 3: runtime -----------------------------------------------------
 FROM scratch
-# CA roots (device HTTPS + webhook notifications) and timezone data (schedules).
+# CA roots support device HTTPS and webhook notifications.
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=tz /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=build /oonfeewrtd /oonfeewrtd
 
 # scratch has no /data, so Docker would create the mount point as root:root and
@@ -68,3 +59,4 @@ ENV OONFEE_DATA_DIR=/data \
     OONFEE_LISTEN=:8080
 EXPOSE 8080
 ENTRYPOINT ["/oonfeewrtd"]
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD ["/oonfeewrtd", "-healthcheck"]

--- a/deploy/release_contract_test.go
+++ b/deploy/release_contract_test.go
@@ -15,6 +15,9 @@ func TestReleaseBuildContract(t *testing.T) {
 		"ARG TARGETOS TARGETARCH VERSION=dev",
 		"go build -trimpath -buildvcs=false",
 		"-buildid= -X main.version=$VERSION",
+		"node:22-alpine@sha256:",
+		"golang:1.26.6-alpine@sha256:",
+		`HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD ["/oonfeewrtd", "-healthcheck"]`,
 	} {
 		if !strings.Contains(string(dockerfile), required) {
 			t.Errorf("Dockerfile lost release build contract %q", required)
@@ -31,7 +34,7 @@ func TestReleaseBuildContract(t *testing.T) {
 	}
 	for _, required := range []string{
 		".git/", ".run/", "data/", "**/passphrase", "**/keyring.json", "**/*.db", "**/*.db-*", "**/*.key", "**/*.pem",
-		".env", ".env.*", "**/.env", "**/.env.*", "**/node_modules/", "ui/dist/",
+		".env", ".env.*", "**/.env", "**/.env.*", "**/node_modules/", "ui/dist/", "dist/",
 	} {
 		if !lines[required] {
 			t.Errorf(".dockerignore does not exclude %q", required)
@@ -41,27 +44,28 @@ func TestReleaseBuildContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, secret := range []string{"keyring.json", "*.db", "*.db-*", ".env", ".env.*"} {
+	for _, secret := range []string{"keyring.json", "*.db", "*.db-*", ".env", ".env.*", "/dist/"} {
 		if !strings.Contains(string(gitignore), secret+"\n") {
 			t.Errorf(".gitignore does not exclude %q", secret)
 		}
-	}
-
-	info, err := os.Stat("../tools/reproducible-build-check.sh")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode()&0o111 == 0 {
-		t.Error("reproducible-build-check.sh is not executable")
 	}
 
 	makefile, err := os.ReadFile("../Makefile")
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, target := range []string{"ui:", "build: ui", "test: ui", "check: ui", "image:", "release-check:"} {
+	for _, target := range []string{"ui:", "build: ui", "test: ui", "check: ui", "image:", "release:", "release-check:"} {
 		if !strings.Contains(string(makefile), target) {
 			t.Errorf("Makefile lost documented target %q", target)
+		}
+	}
+	for _, script := range []string{"../tools/release-build.sh", "../tools/reproducible-build-check.sh"} {
+		info, err := os.Stat(script)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode()&0o111 == 0 {
+			t.Errorf("%s is not executable", script)
 		}
 	}
 	if _, err := os.Stat("../ui/dist/.gitkeep"); err != nil {

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -24,7 +24,7 @@ screen. `BUILD-PROMPT.md` explains how to drive a build session.
 | D7 | **The controller is a self-hosted container (Omada-style)** — Docker/Podman image, amd64+arm64, one persistent volume, compose file provided. Managed devices remain agentless stock OpenWrt; the WRT3200ACM is a *managed device*, never the host. Discovery is a convenience layer (host networking gets full discovery; bridge/Desktop gets add-by-IP, which must be first-class UI). A sweep whose every dial reports `EHOSTUNREACH`/`ENETUNREACH` is an explicit per-network failure, never an empty result. | D1, D5 |
 | D8 | **Optional router packages are two-stage, per-feature root actions.** Resolve and display the package manager's exact plan, bind it, then require a second unchecked acknowledgement. Persist the before-state and actual package diff; rollback removes that exact added set while preserving pre-existing packages, and un-adoption stays blocked until rollback succeeds. Adoption never selects a package. The first capability is official-feed `lldpd`. | previously documented future tier-2 flow |
 
-### Current live checkpoint (2026-08-22)
+### Hardware validation checkpoint (2026-08-22)
 
 The build expects schema **17**. Do not collapse its four recent compatibility
 epochs: v14 is the one-time secret-sealing/scrub boundary, v15 makes the
@@ -45,7 +45,12 @@ not stored. Final release-candidate artifact
 `dev-schema17-fresh-start-transparent-v40` (15,312,098 bytes; SHA-256
 `9c3a797c1470d8630f42dc77619007370aad553fae00078716a5a5a457c6b4cc`)
 passed the signed-in deep-link, settled regression, recovery, secret and
-reproducibility gates. It is merge-ready, not tagged or published.
+reproducibility gates. This v40 artifact is a merge-ready local evidence
+checkpoint, not itself a Git tag or published release asset. Publication is
+performed by the tag-triggered Release workflow; [GitHub
+Releases](https://github.com/aiden0rchad/oonfeeWRT/releases) is the source of
+truth. A clean-install pass is not part of the v40 claim and must be recorded
+after testing downloaded release artifacts.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,225 @@
+# Install oonfeeWRT
+
+oonfeeWRT is a controller that runs on a computer, NAS, or server. It does not
+replace OpenWrt firmware and no controller binary runs on a router.
+
+This guide targets the `v0.1.0-rc.1` release candidate. Use its artifacts only
+after [GitHub Releases](https://github.com/aiden0rchad/oonfeeWRT/releases) lists
+that tag; source documentation alone does not prove publication succeeded. Back
+up both the controller and each router before using it on a network you cannot
+afford to interrupt.
+
+## What can change a router
+
+Nothing is installed merely by starting the controller, scanning, or adding a
+device address. Router changes are separate, default-off actions:
+
+1. **Controller access payload during adoption:** after an explicit prompt,
+   one rpcd ACL JSON file and one scoped `oonfeewrt` login are added. This is not
+   a package, executable, daemon, service, or firmware change. The supplied
+   administrator credential is used for that SSH action and is not stored.
+2. **LLDP capability:** after adoption, a separate workflow may install the
+   official OpenWrt `lldpd` package and its feed dependencies. Refreshing the
+   package index, installing the displayed exact plan, and configuring physical
+   interfaces each require their own acknowledgement. Rollback restores the
+   recorded configuration and service state and removes only packages recorded
+   as additions.
+3. **Network configuration:** WLAN, network, DHCP, and firewall changes occur
+   only after Preview and Apply. They are controller desired state, not hidden
+   adoption side effects.
+
+Un-adoption removes the scoped login and ACL. It is blocked until any recorded
+LLDP capability is rolled back, so package residue cannot be silently orphaned.
+
+## Choose a controller host
+
+Use a supported 64-bit Linux or macOS host on the management LAN:
+
+- `linux/amd64`, `linux/arm64`, `darwin/amd64`, or `darwin/arm64` for binaries;
+- `linux/amd64` or `linux/arm64` for the container image;
+- network reachability from the controller to each OpenWrt management address.
+
+The controller's HTTP listener has no native TLS. Bind it to loopback by
+default. Use a trusted reverse proxy for TLS or deliberately bind to a trusted,
+isolated management LAN.
+
+## Install the binary
+
+Set the release and platform. On macOS, `uname -m` reports `x86_64` rather than
+the archive's `amd64`, so normalize it:
+
+```sh
+VERSION=v0.1.0-rc.1
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$(uname -m)" in
+  x86_64) ARCH=amd64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+NAME="oonfeewrt_${VERSION#v}_${OS}_${ARCH}"
+BASE="https://github.com/aiden0rchad/oonfeeWRT/releases/download/$VERSION"
+
+curl --fail --location --remote-name "$BASE/$NAME.tar.gz"
+curl --fail --location --remote-name "$BASE/SHA256SUMS"
+grep "  $NAME.tar.gz\$" SHA256SUMS > "$NAME.sha256"
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum --check "$NAME.sha256"
+else
+  shasum -a 256 --check "$NAME.sha256"
+fi
+tar -xzf "$NAME.tar.gz"
+"$NAME/oonfeewrtd" -version
+```
+
+The release-candidate macOS binaries are not Developer ID signed or notarized.
+Use the checksum-verified archive above; do not bypass a checksum mismatch.
+
+Keep the extracted binary in that directory or install it on `PATH`:
+
+```sh
+sudo install -m 0755 "$NAME/oonfeewrtd" /usr/local/bin/oonfeewrtd
+sudo install -m 0755 "$NAME/oonfeewrt-recoverycheck" \
+  /usr/local/bin/oonfeewrt-recoverycheck
+```
+
+Create separate private directories for persistent state and the unattended
+passphrase. The database and `keyring.json` are created in the data directory.
+
+```sh
+install -d -m 0700 "$HOME/.local/share/oonfeewrt" "$HOME/.config/oonfeewrt"
+umask 077
+head -c 32 /dev/urandom | base64 > "$HOME/.config/oonfeewrt/passphrase"
+chmod 600 "$HOME/.config/oonfeewrt/passphrase"
+
+oonfeewrtd \
+  -data-dir "$HOME/.local/share/oonfeewrt" \
+  -passphrase-file "$HOME/.config/oonfeewrt/passphrase" \
+  -listen 127.0.0.1:8080
+```
+
+Open `http://127.0.0.1:8080` and create the first administrator. The generated
+passphrase enables unattended restarts: it is no longer an independent second
+factor, so protect it with host permissions and backups. Setting
+`OONFEE_PASSPHRASE` is rejected; secrets never belong in environment values.
+
+For an interactive start, omit `-passphrase-file`. A terminal prompts twice on
+first run and once after each restart.
+
+## Run the container
+
+After the tag workflow succeeds, its image is
+`ghcr.io/aiden0rchad/oonfeewrt:v0.1.0-rc.1`. It is multi-platform, defaults to
+UID `65532`, and has no shell or package manager. The command below instead uses
+your non-root host UID with bind-mounted state, which keeps permissions and
+backups straightforward on both Linux and Docker Desktop.
+
+```sh
+[ "$(id -u)" -ne 0 ] || { echo "run Docker as a non-root user" >&2; exit 1; }
+install -d -m 0700 \
+  "$HOME/.config/oonfeewrt" \
+  "$HOME/.local/share/oonfeewrt-container"
+umask 077
+head -c 32 /dev/urandom | base64 > "$HOME/.config/oonfeewrt/passphrase"
+chmod 600 "$HOME/.config/oonfeewrt/passphrase"
+```
+
+Bridge mode works on Linux and Docker Desktop. It intentionally publishes only
+to host loopback. Layer-2 discovery does not cross the bridge; adopt by address.
+
+```sh
+docker run -d \
+  --name oonfeewrt \
+  --restart unless-stopped \
+  --read-only \
+  --user "$(id -u):$(id -g)" \
+  --cap-drop ALL \
+  --security-opt no-new-privileges:true \
+  --stop-timeout 150 \
+  --tmpfs "/tmp:rw,noexec,nosuid,nodev,uid=$(id -u),gid=$(id -g),mode=0700" \
+  -p 127.0.0.1:8080:8080 \
+  --mount "type=bind,source=$HOME/.local/share/oonfeewrt-container,target=/data" \
+  --mount "type=bind,source=$HOME/.config/oonfeewrt/passphrase,target=/run/secrets/oonfee-passphrase,readonly" \
+  -e OONFEE_DATA_DIR=/data \
+  -e OONFEE_LISTEN=:8080 \
+  -e OONFEE_PASSPHRASE_FILE=/run/secrets/oonfee-passphrase \
+  ghcr.io/aiden0rchad/oonfeewrt:v0.1.0-rc.1
+```
+
+On Linux, full ARP/mDNS discovery requires host networking. Replace the `-p`
+line with `--network host` and set
+`-e OONFEE_LISTEN=127.0.0.1:8080`. Add-by-address works in either mode.
+
+## Put TLS in front
+
+Keep the controller on loopback and proxy it from the same host. A minimal Caddy
+site is:
+
+```caddyfile
+oonfeewrt.example.internal {
+    reverse_proxy 127.0.0.1:8080
+}
+```
+
+Use a name and certificate trusted by your clients. Preserve WebSocket upgrades
+and `X-Forwarded-Proto: https`; Caddy does both by default. The controller then
+marks session cookies `Secure`. Do not expose port 8080 directly to the Internet.
+
+## Back up and upgrade
+
+`oonfeewrt.db` and its sibling `keyring.json` are one recovery unit. A copied
+database without its matching keyring cannot reveal sealed credentials, even
+with the passphrase. Back up the passphrase separately.
+
+For a live binary install, use SQLite's backup API rather than copying a
+WAL-mode database file directly:
+
+```sh
+install -d -m 0700 /path/to/private-backup
+sqlite3 "$HOME/.local/share/oonfeewrt/oonfeewrt.db" \
+  ".backup '/path/to/private-backup/oonfeewrt.db'"
+cp -p "$HOME/.local/share/oonfeewrt/keyring.json" \
+  /path/to/private-backup/keyring.json
+```
+
+Verify a restore pair before depending on it:
+
+```sh
+OONFEE_PASSPHRASE_FILE="$HOME/.config/oonfeewrt/passphrase" \
+  oonfeewrt-recoverycheck /path/to/private-backup/oonfeewrt.db
+```
+
+For a container install, stop it cleanly before copying the bind-mounted state.
+This avoids requiring SQLite tooling inside the scratch image:
+
+```sh
+docker stop --time 150 oonfeewrt
+install -d -m 0700 /path/to/private-backup
+cp -p "$HOME/.local/share/oonfeewrt-container/oonfeewrt.db" \
+  "$HOME/.local/share/oonfeewrt-container/keyring.json" \
+  /path/to/private-backup/
+docker start oonfeewrt
+```
+
+Verify the copied pair with the release archive's `oonfeewrt-recoverycheck`
+before restarting after a real restore.
+
+To upgrade, retain that backup, stop the old process cleanly, replace the binary
+or container tag, and restart with the same data volume and passphrase file. The
+controller migrates its database on startup and refuses an unsupported downgrade.
+
+## First adoption
+
+1. Set a root password in LuCI before adoption. A factory-default passwordless
+   OpenWrt account is unsafe.
+2. Open **Devices**, scan or add the router by management address, and inspect
+   the reported model, firmware, SSH host key, and warnings.
+3. Read the controller-access-payload disclosure. Select it only if you accept
+   the ACL file and scoped-login changes described above.
+4. Enter the router credential only when prompted. Confirm the post-adoption
+   capability report before applying any network configuration.
+5. Leave LLDP off unless measured physical topology is worth installing an
+   official router package. If enabled, review every package and interface plan.
+
+The controller never needs a custom OpenWrt image or controller-authored router
+package. See [`FRESH-START-VALIDATION.md`](FRESH-START-VALIDATION.md) in this
+release archive for the factory-reset proof and known evidence gaps.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -294,8 +294,12 @@ UI, in under a minute, and have it verifiably enforced.
 
 The screens that make people *enjoy* the tool.
 
-**Live status through 2026-08-22: both explicit capability paths are exercised;
-release hardening remains open.** The controller is promoted to schema 17. An
+**Hardware status through 2026-08-22: both explicit capability paths are
+exercised.** The controller is promoted to schema 17. Release publication is a
+separate tag-triggered workflow; [GitHub
+Releases](https://github.com/aiden0rchad/oonfeeWRT/releases) is its source of
+truth, and this roadmap does not claim that published artifacts have passed a
+clean installation. An
 initial signed-in schema-16 pass
 used the routers' older ACLs; that no-router-change checkpoint was superseded
 when the operator explicitly acknowledged ACL refresh for both routers at
@@ -385,8 +389,9 @@ or site latency/loss—without touching a terminal and without inventing a metri
 the hardware did not supply.
 
 > **Status: hardware-verified with the optional ACL and LLDP capability paths
-> explicitly exercised; final release-candidate gates pass.** The result is
-> merge-ready, not tagged or published. The schema-17 joined
+> explicitly exercised; final release-candidate gates pass.** The v40 result is
+> a merge-ready local evidence checkpoint, not itself a Git tag or published
+> release asset. The schema-17 joined
 > surface, topology/history, Radios, General
 > Logs and Audit interaction are live-rendered. ACL refresh remains default-off.
 > The separate LLDP workflow proved exact official-feed plans, installation,

--- a/tools/release-build.sh
+++ b/tools/release-build.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Build the embedded UI once, then package deterministic static binaries.
+set -eu
+
+cd "$(dirname "$0")/.."
+
+version=${1:-}
+out=${2:-dist}
+case "$version" in
+  ''|*[!A-Za-z0-9._+-]*)
+    echo "usage: tools/release-build.sh <version> [empty-output-directory]" >&2
+    exit 2
+    ;;
+esac
+if [ -L "$out" ] || { [ -d "$out" ] && [ -n "$(find "$out" -mindepth 1 -maxdepth 1 -print -quit)" ]; }; then
+  echo "release build: output must be a new or empty directory: $out" >&2
+  exit 1
+fi
+
+epoch=${SOURCE_DATE_EPOCH:-$(git log -1 --format=%ct 2>/dev/null || date +%s)}
+case "$epoch" in
+  ''|*[!0-9]*) echo "release build: SOURCE_DATE_EPOCH must be an integer" >&2; exit 2 ;;
+esac
+
+mkdir -p "$out"
+out=$(cd "$out" && pwd)
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/oonfeewrt-package.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+npm --prefix ui ci
+npm --prefix ui run build
+test -f ui/dist/index.html || {
+  echo "release build: UI build produced no index.html" >&2
+  exit 1
+}
+
+for target in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64; do
+  os=${target%-*}
+  arch=${target#*-}
+  name="oonfeewrt_${version#v}_${os}_${arch}"
+  stage="$tmp/$name"
+  mkdir "$stage"
+  CGO_ENABLED=0 GOOS=$os GOARCH=$arch go build -trimpath -buildvcs=false \
+    -ldflags "-s -w -buildid= -X main.version=$version" \
+    -o "$stage/oonfeewrtd" ./cmd/oonfeewrtd
+  CGO_ENABLED=0 GOOS=$os GOARCH=$arch go build -trimpath -buildvcs=false \
+    -ldflags "-s -w -buildid=" \
+    -o "$stage/oonfeewrt-recoverycheck" ./tools/recoverycheck
+  cp LICENSE NOTICE docs/INSTALL.md docs/FRESH-START-VALIDATION.md "$stage/"
+
+  python3 - "$stage" "$out/$name.tar.gz" "$epoch" "$name" <<'PY'
+import gzip
+import pathlib
+import sys
+import tarfile
+
+stage, archive, epoch, prefix = pathlib.Path(sys.argv[1]), sys.argv[2], int(sys.argv[3]), sys.argv[4]
+with open(archive, "wb") as raw, gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=epoch) as gz:
+    with tarfile.open(fileobj=gz, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+        root = tarfile.TarInfo(prefix)
+        root.type, root.mode, root.mtime = tarfile.DIRTYPE, 0o755, epoch
+        tar.addfile(root)
+        for path in sorted(stage.iterdir(), key=lambda item: item.name):
+            info = tar.gettarinfo(str(path), f"{prefix}/{path.name}")
+            info.uid = info.gid = 0
+            info.uname = info.gname = "root"
+            info.mtime = epoch
+            info.mode = 0o755 if path.name in {"oonfeewrtd", "oonfeewrt-recoverycheck"} else 0o644
+            with path.open("rb") as source:
+                tar.addfile(info, source)
+PY
+done
+
+(
+  cd "$out"
+  if command -v sha256sum >/dev/null 2>&1; then
+    LC_ALL=C sha256sum ./*.tar.gz | sed 's| \./| |' > SHA256SUMS
+  else
+    LC_ALL=C shasum -a 256 ./*.tar.gz | sed 's| \./| |' > SHA256SUMS
+  fi
+)
+
+printf 'release build: %s\n' "$out"

--- a/tools/reproducible-build-check.sh
+++ b/tools/reproducible-build-check.sh
@@ -34,7 +34,7 @@ toolchain=$(awk '$1 == "toolchain" { sub(/^go/, "", $2); print $2 }' go.mod)
   echo "release check: go.mod must pin a toolchain" >&2
   exit 1
 }
-grep -Fq "golang:$toolchain-alpine AS build" deploy/Dockerfile || {
+grep -Eq "golang:$toolchain-alpine@sha256:[0-9a-f]{64} AS build" deploy/Dockerfile || {
   echo "release check: deploy/Dockerfile Go image does not match go.mod toolchain go$toolchain" >&2
   exit 1
 }


### PR DESCRIPTION
## Summary

- add immutable-SHA GitHub Actions checks for Go, race, UI, secrets, release archives, and a no-push multi-platform image build
- add a strict tag release workflow for deterministic four-platform archives, checksums, GHCR amd64/arm64 image, SBOM/provenance, and fail-closed anonymous image verification
- add the binary/container install and recovery guide with explicit, default-off router mutation disclosures

## Validation

- `go test -count=1 ./...`
- `go vet ./...`
- `go mod verify` and `go mod tidy -diff`
- UI: 274/274 tests, production build, bundle budget
- tree/history secret scan and `git diff --check`
- two independent archive builds: byte-identical, all checksums valid
- extracted binary/recovery tool and clean fresh-state startup
- linux/amd64 + linux/arm64 OCI build and hardened container smoke test
- workflow YAML, shell syntax, actionlint, and upstream Action SHA verification

No router, live controller database, or live browser state was changed by this release work.
