### PR TITLE
test: synchronize live connection registration

### DIFF
--- a/internal/api/live_test.go
+++ b/internal/api/live_test.go
@@ -136,7 +136,11 @@ func TestViewerMayUseLiveChannel(t *testing.T) {
 
 func TestLiveConnectionDoesNotHoldRestoreOperationLease(t *testing.T) {
 	h, base := liveHarness(t)
-	dialLive(t, h, base)
+	ws := dialLive(t, h, base)
+	send(t, ws, map[string]any{"type": "ping"})
+	if m := recv(t, ws); m["type"] != "pong" {
+		t.Fatalf("ping response = %v", m)
+	}
 	if h.srv.Hub.Connections() != 1 {
 		t.Fatalf("live connections = %d", h.srv.Hub.Connections())
 	}


### PR DESCRIPTION
Fix the test-only scheduling race found by post-merge main CI.

`websocket.Dial` can complete after HTTP 101 but before `Hub.serve` records the connection. A ping/pong protocol round trip now establishes a happens-before edge before asserting `Connections() == 1`. Production code is unchanged.

Validated locally:
- targeted test: 500/500 pass
- targeted race test: 100/100 pass
- full `internal/api` test pass
- `go vet ./internal/api` pass
- `git diff --check` pass