### PR TITLE
ci: retain version prefix in release notes path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Build exact release archives
         run: |
           release_dir="$RUNNER_TEMP/release"
-          notes="RELEASE-NOTES-${GITHUB_REF_NAME#v}.md"
+          notes="RELEASE-NOTES-${GITHUB_REF_NAME}.md"
           test -f "$notes"
           ./tools/release-build.sh "$GITHUB_REF_NAME" "$release_dir"
           (cd "$release_dir" && sha256sum --check SHA256SUMS)

--- a/deploy/workflow_release_contract_test.go
+++ b/deploy/workflow_release_contract_test.go
@@ -33,6 +33,7 @@ func TestReleaseWorkflowContract(t *testing.T) {
 		"echo \"$image:$stable\"",
 		"echo \"$image:$minor\"",
 		"echo \"$image:latest\"",
+		"notes=\"RELEASE-NOTES-${GITHUB_REF_NAME}.md\"",
 		"./tools/release-build.sh \"$GITHUB_REF_NAME\" \"$release_dir\"",
 		"path: ${{ runner.temp }}/release/*",
 		"--notes-file dist/RELEASE-NOTES.md",
@@ -50,6 +51,9 @@ func TestReleaseWorkflowContract(t *testing.T) {
 	}
 	if strings.Contains(release, "\n  archives:\n") {
 		t.Error("release archives must be built once in the gate, not rebuilt for publication")
+	}
+	if strings.Contains(release, `notes="RELEASE-NOTES-${GITHUB_REF_NAME#v}.md"`) {
+		t.Error("release notes filename must retain the tag's leading v")
 	}
 
 	ci := readWorkflow(t, "../.github/workflows/ci.yml")


### PR DESCRIPTION
The first v0.1.0 release run stopped safely before publication because the archive step stripped the tag's leading `v` and looked for `RELEASE-NOTES-0.1.0.md`. The tracked file is `RELEASE-NOTES-v0.1.0.md`.

This changes the lookup to `RELEASE-NOTES-${GITHUB_REF_NAME}.md` and adds a workflow contract regression that requires the correct form and rejects the stripped form.

Validation:
- exact `v0.1.0` shell expansion and file check pass
- `go test ./deploy -count=1` pass
- release workflow YAML parses
- tree secret scan pass
- `git diff --check` pass

No runtime or product code changes.