### PR TITLE
fix: bound log noise and polish responsive UI

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -683,8 +683,8 @@ never raw samples:
 |---|---|---|
 | 5m avg/min/max/count | 14d | ranges up to 7d |
 | 1h avg/min/max/count | 13mo (396d) | longer ranges |
-| OpenWrt `logd` events | 24h, at most 50,000/device and 100,000 total | General Logs and client incidents |
-| Controller/audit events | newest 100,000 rows | Audit and controller history |
+| OpenWrt `logd` events | 24h, at most 50,000/device and 100,000 total; exact repeated odhcpd IPv6-RA/no-default-route warnings condense per producer epoch without changing warning severity | General Logs and client incidents |
+| Controller/audit events | newest 100,000 rows; every event has a 64 KiB aggregate stored-text/detail limit | Audit and controller history |
 | Closed topology intervals | 31d; active intervals do not expire | current graph and replay |
 | RF scan runs/BSS rows | newest terminal run per `(device_id,radio_key)`; pending/running preserved; BSS cascade | newest explicit scan per radio |
 

--- a/docs/DEVICE-BUDGET.md
+++ b/docs/DEVICE-BUDGET.md
@@ -213,8 +213,8 @@ These are memory/query/retention limits, not managed-router work to spend:
 |---|---|
 | raw telemetry | RAM ring only; SQLite receives one transaction of completed 5m rollups |
 | durable metric history | 5m for 14d; 1h for 396d; client query uses 5m through 7d and 1h beyond |
-| OpenWrt log events | 24h, 50,000/device, 100,000 global; decoder 4,096 rows × 4,096-byte messages |
-| controller/audit events | newest 100,000 rows, independently of router-log caps |
+| OpenWrt log events | 24h, 50,000/device, 100,000 global; decoder 4,096 rows × 4,096-byte messages; exact repeated odhcpd IPv6-RA/no-default-route warnings condense per producer epoch |
+| controller/audit events | newest 100,000 rows, independently of router-log caps; all event text plus encoded detail is capped at 64 KiB/row |
 | General event coverage | producer poll once/minute; stale after 3m; missing, observed-empty and retained gaps are distinct |
 | topology | source cadence 15m; current source stale after 31m; closed history/range 31d; 10,000 intervals/response |
 | client incident response | 31d range; 2,000 exact events; 64 paths and 2,048 path visits |

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -538,13 +538,18 @@ on that schema.
 
 Maintenance runs every 5 minutes. The RAM-ring flush writes its completed
 `rollup_5m` rows in one transaction; hourly folding is count-weighted and never
-overwrites a fuller hour with a pruned partial; then retention pruning runs.
+overwrites a fuller hour with a pruned partial. Event retention runs first in
+an independent transaction and also runs before the daemon begins serving, so
+a rollup failure or short restart cycle cannot leave event history unbounded.
 Defaults are 5m→14d, 1h→396d, OpenWrt events→24h plus 50k/device and 100k
 global, non-OpenWrt events→100k, and closed topology intervals→31d. Active
 topology intervals do not expire. Terminal RF scans are capped to the newest
 run per `(device_id,radio_key)`; pending/running rows are excluded and pruned
 parents cascade to `radio_scan_bss`. Do not regress to per-sample inserts or
-unbounded scan history.
+unbounded scan history. Every event is limited to 64 KiB across its stored text
+and encoded detail. Exact repeated odhcpd IPv6-RA/no-default-route warnings are
+kept as one warning condition per router-log epoch with an occurrence count and
+first/latest source evidence; unrelated router warnings remain individual rows.
 
 ---
 

--- a/internal/daemon/apply_operation_test.go
+++ b/internal/daemon/apply_operation_test.go
@@ -176,6 +176,51 @@ END`); err != nil {
 	}
 }
 
+func TestApplyOperationPreservesRouterOutcomeWhenAuditRecordingFails(t *testing.T) {
+	d, dev, preview := operationApplyFixture(t)
+	beginDaemonApplyOperation(t, d, daemonApplyOperationID)
+	before := bindingConfigFingerprint(t, d, dev.ID)
+	if _, err := d.Store.SQL().Exec(`
+CREATE TRIGGER fail_apply_audit
+BEFORE INSERT ON events WHEN NEW.event = 'config.apply'
+BEGIN
+  SELECT RAISE(ABORT, 'test apply audit failure');
+END`); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := d.ApplySite(context.Background(), api.ApplyRequest{
+		OperationID: daemonApplyOperationID, PreviewToken: preview.PreviewToken,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Aborted || len(result.Devices) != 1 ||
+		result.Devices[0].Outcome != "error" ||
+		result.Devices[0].RouterOutcome != "applied" ||
+		!strings.Contains(result.Devices[0].Reason, "audit recording failed") {
+		t.Fatalf("audit failure result = %+v", result)
+	}
+	if after := bindingConfigFingerprint(t, d, dev.ID); after == before {
+		t.Fatal("fixture never reached a confirmed router write")
+	}
+	op, err := d.Store.ApplyOperation(context.Background(), daemonApplyOperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	device := op.Devices[0]
+	if op.WriteState != store.ApplyWriteStatePossible ||
+		device.State != store.ApplyOperationDeviceFailed ||
+		device.WriteState != store.ApplyWriteStatePossible ||
+		device.RouterOutcome != "applied" || device.Outcome != "error" {
+		t.Fatalf("audit failure durability = %+v", op)
+	}
+	if events, err := d.Store.DeviceEvents(context.Background(), dev.ID,
+		"config.apply", 1); err != nil || len(events) != 0 {
+		t.Fatalf("rejected audit unexpectedly persisted: events=%+v err=%v", events, err)
+	}
+}
+
 func TestDaemonStartupRecoversUnfinishedApplyOperations(t *testing.T) {
 	ctx := context.Background()
 	cfg := testConfig(t, "apply recovery passphrase")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -287,6 +287,26 @@ func open(ctx context.Context, cfg Config, log *slog.Logger,
 		ln.Close()
 		return nil, fmt.Errorf("daemon: secure database file %s: %w", path, err)
 	}
+	prunedEvents, err := db.PruneEvents(ctx, time.Now(), store.DefaultRetention())
+	if err != nil {
+		db.Close()
+		d.Keys.Close()
+		ln.Close()
+		return nil, fmt.Errorf("daemon: prune retained events at startup: %w", err)
+	}
+	if prunedEvents > 0 {
+		log.Info("pruned retained events at startup", "events", prunedEvents)
+	}
+	compactedEvents, err := db.CompactOpenWRTIPv6RANoDefaultRouteEvents(ctx)
+	if err != nil {
+		db.Close()
+		d.Keys.Close()
+		ln.Close()
+		return nil, fmt.Errorf("daemon: compact repeated IPv6 RA events at startup: %w", err)
+	}
+	if compactedEvents > 0 {
+		log.Info("condensed repeated IPv6 RA warnings at startup", "events", compactedEvents)
+	}
 	d.Store = db
 	if err := d.recordAppliedRestore(ctx); err != nil {
 		db.Close()

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -163,6 +164,159 @@ func testConfig(t *testing.T, passphrase string) Config {
 	cfg.ShutdownGrace = 2 * time.Second
 	cfg.ApplyDrain = 2 * time.Second
 	return cfg
+}
+
+func TestOpenPrunesExpiredEventsBeforeServing(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig(t, "startup event prune")
+	d, err := Open(ctx, cfg, quietLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := d.Store.LogEvent(ctx, store.Event{TS: old.Unix(), IngestedAt: old.UnixMilli(),
+		Category: "system", Severity: "warning", Event: "expired",
+		Source: "openwrt-logd"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err = Open(ctx, cfg, quietLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	var count int
+	if err := d.Store.SQL().QueryRowContext(ctx, `SELECT COUNT(*) FROM events`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("startup retained %d expired events", count)
+	}
+}
+
+func TestOpenCompactsRetainedIPv6RAWarningsBeforeServing(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig(t, "startup IPv6 RA compaction")
+	d, err := Open(ctx, cfg, quietLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	device := &store.Device{MAC: "02:00:00:00:00:72", Host: "192.0.2.72", Name: "legacy"}
+	if err := d.Store.UpsertDevice(ctx, device); err != nil {
+		t.Fatal(err)
+	}
+	boot := "boot:81:0"
+	now := time.Now()
+	events := make([]store.Event, 0, 9)
+	for id := 1; id <= 9; id++ {
+		sourceTime := now.Add(time.Duration(id) * time.Millisecond).UnixMilli()
+		events = append(events, store.Event{
+			TS: sourceTime / 1000, IngestedAt: sourceTime, DeviceID: &device.ID,
+			Category: "system", Severity: "warning", Event: "openwrt.log",
+			Source: openWRTLogSource, SourceBoot: boot, SourceID: fmt.Sprint(id),
+			Detail: map[string]any{
+				"message":  "odhcpd[81]: No default route present, setting ra_lifetime to 0!",
+				"facility": uint32(3), "priority": uint32(28), "source_time_ms": sourceTime,
+			},
+		})
+	}
+	cursor := store.IngestCursor{DeviceID: device.ID, Source: openWRTLogSource,
+		BootID: boot, Cursor: "9:" + fmt.Sprint(now.Add(9*time.Millisecond).UnixMilli()),
+		UpdatedAt: now.Add(10 * time.Millisecond).UnixMilli()}
+	if inserted, err := d.Store.AppendEventsAndCursor(ctx, events, cursor); err != nil || inserted != 9 {
+		t.Fatalf("seed inserted=%d err=%v", inserted, err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err = Open(ctx, cfg, quietLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	var raw, conditions, occurrences int64
+	if err := d.Store.SQL().QueryRowContext(ctx, `SELECT
+  SUM(CASE WHEN event='openwrt.log' THEN 1 ELSE 0 END),
+  SUM(CASE WHEN event=? THEN 1 ELSE 0 END),
+  COALESCE(MAX(CASE WHEN event=? THEN json_extract(detail_json,'$.occurrences') END),0)
+FROM events`, store.EventOpenWRTIPv6RANoDefaultRoute,
+		store.EventOpenWRTIPv6RANoDefaultRoute).Scan(&raw, &conditions, &occurrences); err != nil {
+		t.Fatal(err)
+	}
+	if raw != 0 || conditions != 1 || occurrences != 9 {
+		t.Fatalf("startup compaction raw=%d conditions=%d occurrences=%d", raw, conditions, occurrences)
+	}
+}
+
+func TestOpenFailsWhenIPv6RACompactionCannotCommit(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig(t, "startup IPv6 RA compaction failure")
+	d, err := Open(ctx, cfg, quietLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	device := &store.Device{MAC: "02:00:00:00:00:73", Host: "192.0.2.73", Name: "legacy"}
+	if err := d.Store.UpsertDevice(ctx, device); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UnixMilli()
+	cursor := store.IngestCursor{DeviceID: device.ID, Source: openWRTLogSource,
+		BootID: "boot:81:0", Cursor: "1:" + fmt.Sprint(now), UpdatedAt: now}
+	event := store.Event{TS: now / 1000, IngestedAt: now, DeviceID: &device.ID,
+		Category: "system", Severity: "warning", Event: "openwrt.log",
+		Source: openWRTLogSource, SourceBoot: cursor.BootID, SourceID: "1",
+		Detail: map[string]any{
+			"message":  "odhcpd[81]: No default route present, setting ra_lifetime to 0!",
+			"facility": uint32(3), "priority": uint32(28), "source_time_ms": now,
+		}}
+	if inserted, err := d.Store.AppendEventsAndCursor(ctx, []store.Event{event}, cursor); err != nil || inserted != 1 {
+		t.Fatalf("seed inserted=%d err=%v", inserted, err)
+	}
+	if _, err := d.Store.SQL().ExecContext(ctx, `CREATE TRIGGER reject_ipv6_ra_compaction
+BEFORE DELETE ON events WHEN OLD.event='openwrt.log'
+BEGIN SELECT RAISE(ABORT,'blocked compaction'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Open(ctx, cfg, quietLogger()); err == nil ||
+		!strings.Contains(err.Error(), "daemon: compact repeated IPv6 RA events at startup:") ||
+		!strings.Contains(err.Error(), "blocked compaction") {
+		t.Fatalf("startup compaction error=%v", err)
+	}
+}
+
+func TestOpenFailsWhenStartupEventPruneFails(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig(t, "startup event prune failure")
+	d, err := Open(ctx, cfg, quietLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := d.Store.LogEvent(ctx, store.Event{TS: old.Unix(), IngestedAt: old.UnixMilli(),
+		Category: "system", Severity: "warning", Event: "expired",
+		Source: "openwrt-logd"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Store.SQL().ExecContext(ctx, `CREATE TRIGGER reject_startup_event_prune
+BEFORE DELETE ON events BEGIN SELECT RAISE(ABORT,'blocked'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Open(ctx, cfg, quietLogger()); err == nil ||
+		!strings.Contains(err.Error(), "daemon: prune retained events at startup: store: prune OpenWrt logd events:") ||
+		!strings.Contains(err.Error(), "blocked") {
+		t.Fatalf("startup prune error=%v", err)
+	}
 }
 
 func TestConfigFromEnv(t *testing.T) {

--- a/internal/daemon/log_ingest.go
+++ b/internal/daemon/log_ingest.go
@@ -229,8 +229,9 @@ func (l *logIngestor) cursor(ctx context.Context, deviceID int64) (observability
 
 func logStoreEvent(deviceID, ingestedAt int64, sourceBoot string,
 	row observability.LogEntry, correlator *observability.AssociationCorrelator) store.Event {
+	message := observability.SanitizeLogMessage(row.Message)
 	detail := map[string]any{
-		"message":        observability.SanitizeLogMessage(row.Message),
+		"message":        message,
 		"facility":       row.Facility(),
 		"priority":       row.Priority,
 		"source_time_ms": row.TimeMS,
@@ -246,6 +247,19 @@ func logStoreEvent(deviceID, ingestedAt int64, sourceBoot string,
 		SourceID:   row.SourceID(),
 		SourceBoot: sourceBoot,
 		IngestedAt: ingestedAt,
+	}
+	if store.IsOpenWRTIPv6RANoDefaultRouteLog(row.Priority, message) {
+		event.Event = store.EventOpenWRTIPv6RANoDefaultRoute
+		event.SourceID = store.EventOpenWRTIPv6RANoDefaultRouteSourceID
+		detail["condition"] = "ipv6_ra_no_default_route"
+		detail["occurrences"] = 1
+		detail["first_source_time_ms"] = row.TimeMS
+		detail["last_source_time_ms"] = row.TimeMS
+		detail["first_source_id"] = row.SourceID()
+		detail["last_source_id"] = row.SourceID()
+		detail["address_family"] = "ipv6"
+		detail["router_advertisement_lifetime"] = 0
+		return event
 	}
 	wireless, ok := observability.ParseWirelessLog(row.Message)
 	if !ok {

--- a/internal/daemon/log_ingest_test.go
+++ b/internal/daemon/log_ingest_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -207,6 +208,112 @@ func TestLogIngestMarksGapsAndRedactsMessages(t *testing.T) {
 		if strings.Contains(string(blob), "persist-sentinel") || strings.Contains(string(blob), "PRIVATE KEY") {
 			t.Fatalf("durable detail retained secret material: %s", blob)
 		}
+	}
+}
+
+func TestLogIngestClassifiesOnlyTheKnownIPv6RAWarning(t *testing.T) {
+	deviceID := int64(7)
+	correlator := observability.NewAssociationCorrelator()
+	for _, tc := range []struct {
+		name     string
+		priority uint32
+		message  string
+		want     string
+	}{
+		{
+			name: "current OpenWrt wording", priority: 28,
+			message: "odhcpd[81]: No default route present, setting ra_lifetime to 0!",
+			want:    store.EventOpenWRTIPv6RANoDefaultRoute,
+		},
+		{
+			name: "alternate OpenWrt wording", priority: 28,
+			message: "odhcpd: No default route present, overriding ra_lifetime!",
+			want:    store.EventOpenWRTIPv6RANoDefaultRoute,
+		},
+		{
+			name: "same words at error priority remain raw", priority: 27,
+			message: "odhcpd[81]: No default route present, setting ra_lifetime to 0!",
+			want:    "openwrt.log",
+		},
+		{
+			name: "other odhcpd warning remains raw", priority: 28,
+			message: "odhcpd[81]: unable to send router advertisement",
+			want:    "openwrt.log",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			event := logStoreEvent(deviceID, 101_000, "boot:81:0", observability.LogEntry{
+				ID: 9, TimeMS: 100_000, Priority: tc.priority, Message: tc.message,
+			}, correlator)
+			if event.Event != tc.want {
+				t.Fatalf("event=%q, want %q", event.Event, tc.want)
+			}
+			if tc.want == store.EventOpenWRTIPv6RANoDefaultRoute {
+				detail := event.Detail.(map[string]any)
+				if event.Severity != "warning" ||
+					event.SourceID != store.EventOpenWRTIPv6RANoDefaultRouteSourceID ||
+					detail["priority"] != uint32(28) ||
+					detail["occurrences"] != 1 || detail["condition"] != "ipv6_ra_no_default_route" ||
+					detail["message"] != tc.message {
+					t.Fatalf("classified event lost source truth: %+v", event)
+				}
+			}
+		})
+	}
+}
+
+func TestLogIngestCoalescingAdvancesAcrossUint32Wrap(t *testing.T) {
+	ctx := context.Background()
+	d, err := Open(ctx, testConfig(t, "log wrap condition"), quietLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	device := &store.Device{MAC: "02:00:00:00:00:71", Host: "192.0.2.71", Name: "wrap"}
+	if err := d.Store.UpsertDevice(ctx, device); err != nil {
+		t.Fatal(err)
+	}
+	epoch := observability.LogEpoch{
+		BootID: "11111111-2222-4333-8444-555555555555", PID: 81,
+	}
+	message := "odhcpd[81]: No default route present, setting ra_lifetime to 0!"
+	row := func(id uint32, at uint64) observability.LogEntry {
+		return observability.LogEntry{ID: id, TimeMS: at, Priority: 28, Message: message}
+	}
+	ingestor := newLogIngestor(d.Store)
+	initial := row(math.MaxUint32-1, 100_000)
+	if err := ingestor.record(ctx, device.ID, time.UnixMilli(101_000), epoch,
+		[]observability.LogEntry{initial}); err != nil {
+		t.Fatal(err)
+	}
+	page := []observability.LogEntry{
+		initial,
+		row(math.MaxUint32, 101_000),
+		row(0, 102_000),
+		row(1, 103_000),
+	}
+	if err := ingestor.record(ctx, device.ID, time.UnixMilli(104_000), epoch, page); err != nil {
+		t.Fatal(err)
+	}
+	if err := ingestor.record(ctx, device.ID, time.UnixMilli(105_000), epoch, page); err != nil {
+		t.Fatal(err)
+	}
+
+	wrappedBoot := (observability.LogCursor{Epoch: epoch, Generation: 1}).SourceBoot()
+	var count int64
+	var lastID string
+	if err := d.Store.SQL().QueryRowContext(ctx, `
+SELECT json_extract(detail_json,'$.occurrences'), json_extract(detail_json,'$.last_source_id')
+  FROM events WHERE event=? AND source_boot=?`,
+		store.EventOpenWRTIPv6RANoDefaultRoute, wrappedBoot).Scan(&count, &lastID); err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 || lastID != "1" {
+		t.Fatalf("wrapped condition occurrences=%d last_source_id=%q", count, lastID)
+	}
+	cursor, err := d.Store.LoadIngestCursor(ctx, device.ID, openWRTLogSource)
+	if err != nil || cursor.BootID != wrappedBoot || cursor.Cursor != "1:103000" {
+		t.Fatalf("wrapped cursor=%+v err=%v", cursor, err)
 	}
 }
 

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/aiden0rchad/oonfeewrt/internal/applyengine"
 	"github.com/aiden0rchad/oonfeewrt/internal/capability"
@@ -76,6 +77,15 @@ type Reconciler struct {
 	Engine *applyengine.Engine
 	Now    func() time.Time
 }
+
+const (
+	applyAuditPersistTimeout         = 5 * time.Second
+	applyAuditMaxTextBytes           = 1024
+	applyAuditMaxOmissions           = 8
+	applyAuditMaxOmissionWLANBytes   = 128
+	applyAuditMaxOmissionReasonBytes = 512
+	applyAuditMaxOmissionKindBytes   = 32
+)
 
 // New returns a Reconciler with sensible defaults.
 func New(db *store.DB) *Reconciler {
@@ -345,8 +355,7 @@ func (r *Reconciler) Apply(ctx context.Context, c *ubus.Client, deviceID int64,
 					Reason:    "no configuration was written; desired managed state is not loaded in runtime",
 					HealthErr: healthErr,
 				}
-				r.logOutcome(ctx, deviceID, p, res, applyErr)
-				return res, applyErr
+				return r.finishApplyOutcome(ctx, deviceID, p, res, applyErr)
 			}
 		}
 		// Nothing to write, and possibly a great deal to remember.
@@ -367,8 +376,7 @@ func (r *Reconciler) Apply(ctx context.Context, c *ubus.Client, deviceID int64,
 		if err != nil {
 			res.Reason = fmt.Sprintf("device outcome was applied, but controller ownership recording failed: %v", err)
 		}
-		r.logOutcome(ctx, deviceID, p, res, err)
-		return res, err
+		return r.finishApplyOutcome(ctx, deviceID, p, res, err)
 	}
 
 	health = composeManagedRuntimeHealth(p, health)
@@ -379,8 +387,7 @@ func (r *Reconciler) Apply(ctx context.Context, c *ubus.Client, deviceID int64,
 			res.Reason = fmt.Sprintf("device outcome was applied, but controller ownership recording failed: %v", ownedErr)
 		}
 	}
-	r.logOutcome(ctx, deviceID, p, res, err)
-	return res, err
+	return r.finishApplyOutcome(ctx, deviceID, p, res, err)
 }
 
 // recordOwned makes the ownership record match what is on the device.
@@ -445,11 +452,36 @@ func (r *Reconciler) recordOwned(ctx context.Context, deviceID int64, p *DeviceP
 	return nil
 }
 
+// finishApplyOutcome makes the audit write part of the Apply result. The
+// router outcome remains intact when controller bookkeeping fails, but the
+// caller cannot mistake that run for ordinary success.
+func (r *Reconciler) finishApplyOutcome(ctx context.Context, deviceID int64,
+	p *DevicePlan, res applyengine.Result, applyErr error) (applyengine.Result, error) {
+	auditErr := r.logOutcome(ctx, deviceID, p, res, applyErr)
+	if auditErr == nil {
+		return res, applyErr
+	}
+	recordErr := fmt.Errorf("reconcile: record apply outcome audit: %w", auditErr)
+	failure := fmt.Sprintf("controller apply-outcome audit recording failed: %v", auditErr)
+	if res.Outcome != "" {
+		outcome := fmt.Sprintf("device outcome was %s", res.Outcome)
+		if res.Reason != "" {
+			outcome += ": " + res.Reason
+		}
+		res.Reason = outcome + "; " + failure
+	} else if res.Reason == "" {
+		res.Reason = failure
+	} else {
+		res.Reason += "; " + failure
+	}
+	return res, errors.Join(applyErr, recordErr)
+}
+
 // logOutcome writes an audit event for every apply, including the ones that
-// failed. An apply nobody can account for afterwards is worse than one that
-// failed loudly.
+// failed. Variable detail is bounded before it reaches the store's per-event
+// limit; clipping is explicit so the audit never presents a sample as complete.
 func (r *Reconciler) logOutcome(ctx context.Context, deviceID int64,
-	p *DevicePlan, res applyengine.Result, applyErr error) {
+	p *DevicePlan, res applyengine.Result, applyErr error) error {
 
 	sev := "info"
 	switch {
@@ -458,25 +490,71 @@ func (r *Reconciler) logOutcome(ctx context.Context, deviceID int64,
 	case res.Outcome == applyengine.Reverted:
 		sev = "warning"
 	}
+	omissions, omissionsTruncated := boundedApplyAuditOmissions(p.Report.Omissions)
+	reason, reasonTruncated := boundedApplyAuditText(res.Reason, applyAuditMaxTextBytes)
 	detail := map[string]any{
 		"outcome":   string(res.Outcome),
-		"reason":    res.Reason,
+		"reason":    reason,
 		"ops":       len(p.Plan.Ops),
 		"sections":  len(p.Doc.Sections),
-		"omissions": p.Report.Omissions,
+		"omissions": omissions,
 		"stranded":  res.Stranded,
 	}
+	if reasonTruncated {
+		detail["reason_truncated"] = true
+	}
+	if omissionsTruncated {
+		detail["omissions_total"] = len(p.Report.Omissions)
+		detail["omissions_truncated"] = true
+	}
 	if applyErr != nil {
-		detail["error"] = applyErr.Error()
+		message, truncated := boundedApplyAuditText(applyErr.Error(), applyAuditMaxTextBytes)
+		detail["error"] = message
+		if truncated {
+			detail["error_truncated"] = true
+		}
 	}
 	if res.HealthErr != nil {
-		detail["health_error"] = res.HealthErr.Error()
+		message, truncated := boundedApplyAuditText(res.HealthErr.Error(), applyAuditMaxTextBytes)
+		detail["health_error"] = message
+		if truncated {
+			detail["health_error_truncated"] = true
+		}
 	}
 	id := deviceID
-	_ = r.Store.LogEvent(ctx, store.Event{
+	auditCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), applyAuditPersistTimeout)
+	defer cancel()
+	return r.Store.LogEvent(auditCtx, store.Event{
 		DeviceID: &id, Category: "audit", Severity: sev,
 		Event: "config.apply", Detail: detail,
 	})
+}
+
+func boundedApplyAuditOmissions(in []render.Omission) ([]render.Omission, bool) {
+	n := min(len(in), applyAuditMaxOmissions)
+	out := make([]render.Omission, n)
+	truncated := len(in) > n
+	for i := range n {
+		wlan, wlanTruncated := boundedApplyAuditText(in[i].WLAN, applyAuditMaxOmissionWLANBytes)
+		reason, reasonTruncated := boundedApplyAuditText(in[i].Reason, applyAuditMaxOmissionReasonBytes)
+		kind, kindTruncated := boundedApplyAuditText(string(in[i].Kind), applyAuditMaxOmissionKindBytes)
+		out[i] = render.Omission{WLAN: wlan, Reason: reason, Kind: render.OmissionKind(kind)}
+		truncated = truncated || wlanTruncated || reasonTruncated || kindTruncated
+	}
+	return out, truncated
+}
+
+func boundedApplyAuditText(value string, limit int) (string, bool) {
+	valid := strings.ToValidUTF8(value, "\uFFFD")
+	changed := valid != value
+	if len(valid) <= limit {
+		return valid, changed
+	}
+	cut := limit - len("…")
+	for cut > 0 && !utf8.RuneStart(valid[cut]) {
+		cut--
+	}
+	return valid[:cut] + "…", true
 }
 
 func (r *Reconciler) now() time.Time {

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -2,6 +2,7 @@ package reconcile
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -509,6 +510,103 @@ func TestEveryOutcomeIsAudited(t *testing.T) {
 	}
 	if !strings.Contains(string(fmt.Appendf(nil, "%s", e.Detail)), "reverted") {
 		t.Errorf("the detail should record the outcome: %v", e.Detail)
+	}
+}
+
+func TestApplyOutcomeAuditIsBoundedAndSurvivesCallerCancellation(t *testing.T) {
+	r, db := newReconciler(t)
+	dev := device(t, db)
+	huge := strings.Repeat("&", 70<<10)
+	omissions := make([]render.Omission, 64)
+	for i := range omissions {
+		omissions[i] = render.Omission{
+			WLAN: strings.Repeat("<", 1024), Reason: huge,
+			Kind: render.OmissionKind(strings.Repeat(">", 512)),
+		}
+	}
+	if blob, err := json.Marshal(omissions); err != nil {
+		t.Fatal(err)
+	} else if len(blob) <= 64<<10 {
+		t.Fatalf("fixture is only %d bytes; it does not exercise the event cap", len(blob))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	res := applyengine.Result{
+		Outcome: applyengine.Applied, Reason: huge, HealthErr: errors.New(huge),
+	}
+	if err := r.logOutcome(ctx, dev.ID,
+		&DevicePlan{Report: render.Report{Omissions: omissions}}, res, errors.New(huge)); err != nil {
+		t.Fatalf("bounded detached audit: %v", err)
+	}
+	events, err := db.DeviceEvents(context.Background(), dev.ID, "config.apply", 1)
+	if err != nil || len(events) != 1 {
+		t.Fatalf("audit events=%+v err=%v", events, err)
+	}
+	raw, ok := events[0].Detail.(json.RawMessage)
+	if !ok {
+		t.Fatalf("audit detail type = %T", events[0].Detail)
+	}
+	if len(raw) >= 64<<10 {
+		t.Fatalf("bounded audit detail is %d bytes", len(raw))
+	}
+	var detail struct {
+		Omissions            []render.Omission `json:"omissions"`
+		OmissionsTotal       int               `json:"omissions_total"`
+		OmissionsTruncated   bool              `json:"omissions_truncated"`
+		ReasonTruncated      bool              `json:"reason_truncated"`
+		ErrorTruncated       bool              `json:"error_truncated"`
+		HealthErrorTruncated bool              `json:"health_error_truncated"`
+	}
+	if err := json.Unmarshal(raw, &detail); err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Omissions) != applyAuditMaxOmissions ||
+		detail.OmissionsTotal != len(omissions) || !detail.OmissionsTruncated ||
+		!detail.ReasonTruncated || !detail.ErrorTruncated || !detail.HealthErrorTruncated {
+		t.Fatalf("bounded audit detail = %+v", detail)
+	}
+}
+
+func TestApplyFailsLoudlyWhenOutcomeAuditCannotBeRecorded(t *testing.T) {
+	ctx := context.Background()
+	c := dial(t)
+	r, db := newReconciler(t)
+	dev := device(t, db)
+	p, err := r.PlanDevice(ctx, c, siteWLAN(dev.ID, 112), model.Device{ID: dev.ID}, caps())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Empty() || p.Blocked() {
+		t.Fatalf("fixture plan empty=%v blocked=%v", p.Empty(), p.Blocked())
+	}
+	for range 16 {
+		p.Report.Omissions = append(p.Report.Omissions, render.Omission{
+			WLAN: "large-audit-fixture", Reason: strings.Repeat("&", 1024),
+		})
+	}
+	if _, err := db.SQL().ExecContext(ctx, `CREATE TRIGGER reject_apply_audit
+BEFORE INSERT ON events WHEN NEW.event = 'config.apply' BEGIN
+  SELECT RAISE(ABORT, 'synthetic apply audit failure');
+END`); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := r.Apply(ctx, c, dev.ID, p,
+		func(context.Context, *ubus.Client) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "synthetic apply audit failure") {
+		t.Fatalf("apply error = %v", err)
+	}
+	if res.Outcome != applyengine.Applied ||
+		!strings.Contains(res.Reason, "device outcome was applied") ||
+		!strings.Contains(res.Reason, "apply-outcome audit recording failed") {
+		t.Fatalf("apply result = %+v", res)
+	}
+	if owned, err := db.OwnedSections(ctx, dev.ID); err != nil || len(owned) == 0 {
+		t.Fatalf("confirmed router outcome was lost: owned=%+v err=%v", owned, err)
+	}
+	if events, err := db.DeviceEvents(ctx, dev.ID, "config.apply", 1); err != nil || len(events) != 0 {
+		t.Fatalf("rejected audit unexpectedly persisted: events=%+v err=%v", events, err)
 	}
 }
 

--- a/internal/store/event_compaction.go
+++ b/internal/store/event_compaction.go
@@ -1,0 +1,477 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var openWRTIPv6RANoDefaultRouteLog = regexp.MustCompile(
+	`^odhcpd(?:\[[0-9]+\])?: No default route present, (?:setting|overriding) ra_lifetime(?: to 0)?!$`,
+)
+
+// IsOpenWRTIPv6RANoDefaultRouteLog identifies the exact odhcpd warning that is
+// safe to condense. Severity and every near-match remain ordinary raw events.
+func IsOpenWRTIPv6RANoDefaultRouteLog(priority uint32, message string) bool {
+	return priority == 28 && openWRTIPv6RANoDefaultRouteLog.MatchString(message)
+}
+
+type ipv6RAConditionDetail struct {
+	fields        map[string]json.RawMessage
+	occurrences   int64
+	firstSourceID uint32
+	lastSourceID  uint32
+}
+
+type storedIPv6RACondition struct {
+	id             int64
+	fixedTextBytes int
+	detail         ipv6RAConditionDetail
+}
+
+func loadIPv6RACondition(ctx context.Context, tx *sql.Tx, deviceID int64,
+	sourceBoot string) (storedIPv6RACondition, bool, error) {
+	var out storedIPv6RACondition
+	var category, severity, event string
+	var detailBytes int
+	var detail []byte
+	err := tx.QueryRowContext(ctx, `
+SELECT id, category, severity, event,
+       length(CAST(detail_json AS BLOB)),
+       substr(CAST(detail_json AS BLOB), 1, 65537),
+       length(CAST(COALESCE(category,'') AS BLOB)) +
+       length(CAST(COALESCE(severity,'') AS BLOB)) +
+       length(CAST(COALESCE(event,'') AS BLOB)) +
+       length(CAST(COALESCE(source,'') AS BLOB)) +
+       length(CAST(COALESCE(source_id,'') AS BLOB)) +
+       length(CAST(COALESCE(source_boot,'') AS BLOB)) +
+       length(CAST(COALESCE(client_mac,'') AS BLOB)) +
+       length(CAST(COALESCE(action,'') AS BLOB)) +
+       length(CAST(COALESCE(direction,'') AS BLOB)) +
+       length(CAST(COALESCE(in_iface,'') AS BLOB)) +
+       length(CAST(COALESCE(out_iface,'') AS BLOB)) +
+       length(CAST(COALESCE(src_ip,'') AS BLOB)) +
+       length(CAST(COALESCE(dst_ip,'') AS BLOB)) +
+       length(CAST(COALESCE(zone_in,'') AS BLOB)) +
+       length(CAST(COALESCE(zone_out,'') AS BLOB))
+  FROM events
+ WHERE device_id=? AND source='openwrt-logd' AND source_boot=? AND source_id=?`,
+		deviceID, sourceBoot, EventOpenWRTIPv6RANoDefaultRouteSourceID).
+		Scan(&out.id, &category, &severity, &event, &detailBytes, &detail, &out.fixedTextBytes)
+	if errors.Is(err, sql.ErrNoRows) {
+		return storedIPv6RACondition{}, false, nil
+	}
+	if err != nil {
+		return storedIPv6RACondition{}, false, fmt.Errorf("store: read IPv6 RA condition: %w", err)
+	}
+	if category != "system" || severity != "warning" ||
+		event != EventOpenWRTIPv6RANoDefaultRoute {
+		return storedIPv6RACondition{}, false,
+			errors.New("store: IPv6 RA condition identity has unexpected event fields")
+	}
+	if detailBytes != len(detail) || detailBytes > maxEncodedEventBytes ||
+		out.fixedTextBytes > maxEncodedEventBytes-detailBytes {
+		return storedIPv6RACondition{}, false,
+			errors.New("store: IPv6 RA condition exceeds the encoded storage limit")
+	}
+	parsed, err := decodeIPv6RAConditionDetail(detail)
+	if err != nil {
+		return storedIPv6RACondition{}, false, err
+	}
+	out.detail = parsed
+	return out, true, nil
+}
+
+func decodeIPv6RAConditionDetail(raw []byte) (ipv6RAConditionDetail, error) {
+	var out ipv6RAConditionDetail
+	if len(raw) == 0 || len(raw) > maxEncodedEventBytes ||
+		json.Unmarshal(raw, &out.fields) != nil || out.fields == nil {
+		return out, errors.New("store: IPv6 RA condition has invalid detail JSON")
+	}
+	if err := decodeJSONField(out.fields, "occurrences", &out.occurrences); err != nil ||
+		out.occurrences < 1 {
+		return out, errors.New("store: IPv6 RA condition has an invalid occurrence count")
+	}
+	first, err := canonicalUint32JSONField(out.fields, "first_source_id")
+	if err != nil {
+		return out, err
+	}
+	last, err := canonicalUint32JSONField(out.fields, "last_source_id")
+	if err != nil {
+		return out, err
+	}
+	out.firstSourceID, out.lastSourceID = first, last
+	for _, key := range []string{"source_time_ms", "first_source_time_ms", "last_source_time_ms"} {
+		var value int64
+		if err := decodeJSONField(out.fields, key, &value); err != nil || value <= 0 {
+			return out, fmt.Errorf("store: IPv6 RA condition has an invalid %s", key)
+		}
+	}
+	var priority uint32
+	var message, condition, addressFamily string
+	var lifetime int64
+	if err := decodeJSONField(out.fields, "priority", &priority); err != nil ||
+		decodeJSONField(out.fields, "message", &message) != nil ||
+		!IsOpenWRTIPv6RANoDefaultRouteLog(priority, message) ||
+		decodeJSONField(out.fields, "condition", &condition) != nil ||
+		condition != "ipv6_ra_no_default_route" ||
+		decodeJSONField(out.fields, "address_family", &addressFamily) != nil ||
+		addressFamily != "ipv6" ||
+		decodeJSONField(out.fields, "router_advertisement_lifetime", &lifetime) != nil || lifetime != 0 {
+		return out, errors.New("store: IPv6 RA condition has invalid source evidence")
+	}
+	return out, nil
+}
+
+func decodeJSONField(fields map[string]json.RawMessage, key string, out any) error {
+	raw, ok := fields[key]
+	if !ok || json.Unmarshal(raw, out) != nil {
+		return fmt.Errorf("invalid %s", key)
+	}
+	return nil
+}
+
+func canonicalUint32JSONField(fields map[string]json.RawMessage, key string) (uint32, error) {
+	var text string
+	if err := decodeJSONField(fields, key, &text); err != nil {
+		return 0, fmt.Errorf("store: IPv6 RA condition has an invalid %s", key)
+	}
+	value, err := strconv.ParseUint(text, 10, 32)
+	if err != nil || strconv.FormatUint(value, 10) != text {
+		return 0, fmt.Errorf("store: IPv6 RA condition has an invalid %s", key)
+	}
+	return uint32(value), nil
+}
+
+func setJSONField(fields map[string]json.RawMessage, key string, value any) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	fields[key] = raw
+	return nil
+}
+
+func mergeIPv6RACondition(ctx context.Context, tx *sql.Tx, existing storedIPv6RACondition,
+	incoming Event, incomingDetail string, increment int64) (bool, error) {
+	if increment <= 0 {
+		return false, errors.New("store: IPv6 RA condition increment must be positive")
+	}
+	next, err := decodeIPv6RAConditionDetail([]byte(incomingDetail))
+	if err != nil {
+		return false, err
+	}
+	if next.occurrences != increment {
+		return false, errors.New("store: IPv6 RA condition increment does not match its evidence")
+	}
+	delta := next.lastSourceID - existing.detail.lastSourceID
+	if delta == 0 || delta >= 1<<31 {
+		return false, nil
+	}
+	if existing.detail.occurrences > math.MaxInt64-increment {
+		return false, errors.New("store: IPv6 RA condition occurrence count overflow")
+	}
+	fields := make(map[string]json.RawMessage, len(existing.detail.fields))
+	for key, value := range existing.detail.fields {
+		fields[key] = value
+	}
+	for _, key := range []string{"last_source_time_ms", "last_source_id", "source_time_ms", "message"} {
+		fields[key] = next.fields[key]
+	}
+	if err := setJSONField(fields, "occurrences", existing.detail.occurrences+increment); err != nil {
+		return false, err
+	}
+	detail, err := json.Marshal(fields)
+	if err != nil {
+		return false, fmt.Errorf("store: encode updated IPv6 RA condition: %w", err)
+	}
+	if len(detail) > maxEncodedEventBytes || existing.fixedTextBytes > maxEncodedEventBytes-len(detail) {
+		return false, errors.New("store: IPv6 RA condition exceeds the encoded storage limit")
+	}
+	res, err := tx.ExecContext(ctx, `UPDATE events
+SET ts=MAX(ts,?), ingested_at=MAX(COALESCE(ingested_at,0),?), detail_json=? WHERE id=?`,
+		incoming.TS, incoming.IngestedAt, string(detail), existing.id)
+	if err != nil {
+		return false, fmt.Errorf("store: update IPv6 RA condition: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("store: inspect IPv6 RA condition update: %w", err)
+	}
+	if n != 1 {
+		return false, errors.New("store: IPv6 RA condition changed during update")
+	}
+	return true, nil
+}
+
+// coalesceOpenWRTIPv6RAEvent handles both a forward event and a replay of one
+// already represented by the stable condition row. Malformed durable state is
+// an error, so the caller cannot advance its cursor past missing evidence.
+func coalesceOpenWRTIPv6RAEvent(ctx context.Context, tx *sql.Tx, event Event,
+	detail string) (bool, error) {
+	existing, found, err := loadIPv6RACondition(ctx, tx, *event.DeviceID, event.SourceBoot)
+	if err != nil || !found {
+		return false, err
+	}
+	_, err = mergeIPv6RACondition(ctx, tx, existing, event, detail, 1)
+	return true, err
+}
+
+type legacyIPv6RACompactionLimits struct {
+	events int
+	groups int
+	bytes  int64
+}
+
+var defaultLegacyIPv6RACompactionLimits = legacyIPv6RACompactionLimits{
+	events: 100_000,
+	groups: 4096,
+	bytes:  16 << 20,
+}
+
+type legacyIPv6RAKey struct {
+	deviceID   int64
+	sourceBoot string
+}
+
+type legacyIPv6RAEntry struct {
+	rowID        int64
+	sourceID     uint32
+	sourceIDText string
+	sourceTimeMS int64
+	message      string
+	ts           int64
+	ingestedAt   int64
+}
+
+type legacyIPv6RAGroup struct {
+	key     legacyIPv6RAKey
+	entries []legacyIPv6RAEntry
+}
+
+// CompactOpenWRTIPv6RANoDefaultRouteEvents converts exact legacy raw rows into
+// the same bounded condition record used by current ingest. It runs once per
+// daemon startup, in one transaction, before any API can observe the database.
+func (db *DB) CompactOpenWRTIPv6RANoDefaultRouteEvents(ctx context.Context) (int64, error) {
+	return db.compactOpenWRTIPv6RANoDefaultRouteEvents(ctx,
+		defaultLegacyIPv6RACompactionLimits)
+}
+
+func (db *DB) compactOpenWRTIPv6RANoDefaultRouteEvents(ctx context.Context,
+	limits legacyIPv6RACompactionLimits) (int64, error) {
+	if limits.events <= 0 || limits.groups <= 0 || limits.bytes <= 0 {
+		return 0, errors.New("store: IPv6 RA compaction limits must be positive")
+	}
+	tx, err := db.sql.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("store: begin IPv6 RA event compaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	rows, err := tx.QueryContext(ctx, legacyIPv6RAEventsSQL)
+	if err != nil {
+		return 0, fmt.Errorf("store: query legacy IPv6 RA events: %w", err)
+	}
+	groups := map[legacyIPv6RAKey]*legacyIPv6RAGroup{}
+	ids := make([]int64, 0)
+	var inputBytes int64
+	for rows.Next() {
+		var entry legacyIPv6RAEntry
+		var deviceID int64
+		var sourceBoot string
+		if err := rows.Scan(&entry.rowID, &deviceID, &sourceBoot, &entry.sourceIDText,
+			&entry.ts, &entry.ingestedAt, &entry.message, &entry.sourceTimeMS); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("store: scan legacy IPv6 RA event: %w", err)
+		}
+		value, err := strconv.ParseUint(entry.sourceIDText, 10, 32)
+		if err != nil || strconv.FormatUint(value, 10) != entry.sourceIDText ||
+			!IsOpenWRTIPv6RANoDefaultRouteLog(28, entry.message) {
+			continue
+		}
+		entry.sourceID = uint32(value)
+		if len(ids) == limits.events {
+			rows.Close()
+			return 0, fmt.Errorf("store: IPv6 RA compaction exceeds %d events", limits.events)
+		}
+		rowBytes := int64(len(sourceBoot) + len(entry.sourceIDText) + len(entry.message))
+		if rowBytes > limits.bytes-inputBytes {
+			rows.Close()
+			return 0, fmt.Errorf("store: IPv6 RA compaction exceeds %d input bytes", limits.bytes)
+		}
+		inputBytes += rowBytes
+		key := legacyIPv6RAKey{deviceID: deviceID, sourceBoot: sourceBoot}
+		group := groups[key]
+		if group == nil {
+			if len(groups) == limits.groups {
+				rows.Close()
+				return 0, fmt.Errorf("store: IPv6 RA compaction exceeds %d producer groups", limits.groups)
+			}
+			group = &legacyIPv6RAGroup{key: key}
+			groups[key] = group
+		}
+		group.entries = append(group.entries, entry)
+		ids = append(ids, entry.rowID)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return 0, fmt.Errorf("store: read legacy IPv6 RA events: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, fmt.Errorf("store: close legacy IPv6 RA events: %w", err)
+	}
+	if len(ids) == 0 {
+		if err := tx.Commit(); err != nil {
+			return 0, fmt.Errorf("store: commit IPv6 RA event compaction: %w", err)
+		}
+		return 0, nil
+	}
+
+	for _, group := range groups {
+		if err := compactLegacyIPv6RAGroup(ctx, tx, group); err != nil {
+			return 0, err
+		}
+	}
+	if err := deleteLegacyIPv6RAEvents(ctx, tx, ids); err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("store: commit IPv6 RA event compaction: %w", err)
+	}
+	return int64(len(ids)), nil
+}
+
+const legacyIPv6RAEventsSQL = `
+SELECT id, device_id, source_boot, source_id, ts,
+       COALESCE(ingested_at, ts * 1000),
+       substr(json_extract(CASE WHEN json_valid(detail_json) THEN detail_json ELSE '{}' END,
+                           '$.message'), 1, 4097),
+       CAST(json_extract(CASE WHEN json_valid(detail_json) THEN detail_json ELSE '{}' END,
+                             '$.source_time_ms') AS INTEGER)
+  FROM events
+ WHERE source='openwrt-logd' AND event='openwrt.log' AND severity='warning'
+   AND category='system' AND device_id IS NOT NULL
+   AND source_boot IS NOT NULL AND length(source_boot) BETWEEN 1 AND 256
+   AND source_id IS NOT NULL AND length(source_id) BETWEEN 1 AND 10
+   AND json_type(CASE WHEN json_valid(detail_json) THEN detail_json ELSE '{}' END,
+                 '$.priority')='integer'
+   AND json_extract(CASE WHEN json_valid(detail_json) THEN detail_json ELSE '{}' END,
+                    '$.priority')=28
+   AND json_type(CASE WHEN json_valid(detail_json) THEN detail_json ELSE '{}' END,
+                 '$.message')='text'
+   AND length(json_extract(CASE WHEN json_valid(detail_json) THEN detail_json ELSE '{}' END,
+                           '$.message')) <= 4096
+   AND json_type(CASE WHEN json_valid(detail_json) THEN detail_json ELSE '{}' END,
+                 '$.source_time_ms')='integer'
+   AND json_extract(CASE WHEN json_valid(detail_json) THEN detail_json ELSE '{}' END,
+                    '$.source_time_ms') > 0
+ ORDER BY id`
+
+func compactLegacyIPv6RAGroup(ctx context.Context, tx *sql.Tx,
+	group *legacyIPv6RAGroup) error {
+	existing, found, err := loadIPv6RACondition(ctx, tx, group.key.deviceID,
+		group.key.sourceBoot)
+	if err != nil {
+		return err
+	}
+	hasLast := found
+	lastID := existing.detail.lastSourceID
+	var first, last legacyIPv6RAEntry
+	var accepted int64
+	var maxTS, maxIngestedAt int64
+	for _, entry := range group.entries {
+		if hasLast {
+			delta := entry.sourceID - lastID
+			if delta == 0 || delta >= 1<<31 {
+				continue
+			}
+		}
+		if accepted == 0 {
+			first, maxTS, maxIngestedAt = entry, entry.ts, entry.ingestedAt
+		}
+		last = entry
+		accepted++
+		maxTS = max(maxTS, entry.ts)
+		maxIngestedAt = max(maxIngestedAt, entry.ingestedAt)
+		lastID, hasLast = entry.sourceID, true
+	}
+	if accepted == 0 {
+		return nil
+	}
+	deviceID := group.key.deviceID
+	event := Event{
+		TS: maxTS, DeviceID: &deviceID, Category: "system", Severity: "warning",
+		Event: EventOpenWRTIPv6RANoDefaultRoute, Source: "openwrt-logd",
+		SourceID: EventOpenWRTIPv6RANoDefaultRouteSourceID, SourceBoot: group.key.sourceBoot,
+		IngestedAt: maxIngestedAt,
+		Detail: map[string]any{
+			"message": last.message, "facility": uint32(3), "priority": uint32(28),
+			"source_time_ms": last.sourceTimeMS,
+			"condition":      "ipv6_ra_no_default_route", "occurrences": accepted,
+			"first_source_time_ms": first.sourceTimeMS,
+			"last_source_time_ms":  last.sourceTimeMS,
+			"first_source_id":      first.sourceIDText, "last_source_id": last.sourceIDText,
+			"address_family": "ipv6", "router_advertisement_lifetime": 0,
+		},
+	}
+	event, detail, err := normalizeEvent(event)
+	if err != nil {
+		return fmt.Errorf("store: encode compacted IPv6 RA event: %w", err)
+	}
+	if _, err := decodeIPv6RAConditionDetail([]byte(detail)); err != nil {
+		return fmt.Errorf("store: validate compacted IPv6 RA event: %w", err)
+	}
+	if found {
+		updated, err := mergeIPv6RACondition(ctx, tx, existing, event, detail, accepted)
+		if err != nil {
+			return err
+		}
+		if !updated {
+			return errors.New("store: compacted IPv6 RA evidence was not forward")
+		}
+		return nil
+	}
+	res, err := tx.ExecContext(ctx, appendEventSQL, eventInsertArgs(event, detail)...)
+	if err != nil {
+		return fmt.Errorf("store: insert compacted IPv6 RA event: %w", err)
+	}
+	inserted, err := eventInsertResult(res)
+	if err != nil {
+		return err
+	}
+	if !inserted {
+		return errors.New("store: compacted IPv6 RA event identity already exists")
+	}
+	return nil
+}
+
+func deleteLegacyIPv6RAEvents(ctx context.Context, tx *sql.Tx, ids []int64) error {
+	const batchSize = 256
+	for start := 0; start < len(ids); start += batchSize {
+		end := min(start+batchSize, len(ids))
+		args := make([]any, end-start)
+		for i, id := range ids[start:end] {
+			args[i] = id
+		}
+		query := `DELETE FROM events WHERE source='openwrt-logd' AND event='openwrt.log' AND id IN (` +
+			strings.TrimSuffix(strings.Repeat("?,", len(args)), ",") + `)`
+		res, err := tx.ExecContext(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("store: delete legacy IPv6 RA events: %w", err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("store: inspect legacy IPv6 RA deletion: %w", err)
+		}
+		if n != int64(len(args)) {
+			return errors.New("store: legacy IPv6 RA event set changed during compaction")
+		}
+	}
+	return nil
+}

--- a/internal/store/observability_test.go
+++ b/internal/store/observability_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -249,6 +250,82 @@ func downgradeFixtureToV15(t *testing.T, db *DB) {
 		if _, err := db.SQL().ExecContext(ctx, stmt); err != nil {
 			t.Fatalf("prepare v15 fixture (%s): %v", stmt, err)
 		}
+	}
+}
+
+func TestAppendEventBoundsAggregateEncodedStorage(t *testing.T) {
+	db := open(t)
+	ctx := context.Background()
+	event := Event{Category: "system", Severity: "info", Source: "controller"}
+	_, detail, err := normalizeEvent(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remaining := maxEncodedEventBytes - len(detail)
+	for _, value := range []string{event.Category, event.Severity, event.Source} {
+		remaining -= len(value)
+	}
+	event.Event = strings.Repeat("x", remaining)
+	if inserted, err := db.AppendEvent(ctx, event); err != nil || !inserted {
+		t.Fatalf("boundary event inserted=%v err=%v", inserted, err)
+	}
+
+	over := event
+	over.Event += "x"
+	if inserted, err := db.AppendEvent(ctx, over); inserted || err == nil ||
+		err.Error() != "store: event exceeds 65536-byte encoded storage limit" {
+		t.Fatalf("oversized event inserted=%v err=%v", inserted, err)
+	}
+	encodedDetail := Event{Category: "system", Severity: "info", Event: "encoded",
+		Detail: strings.Repeat("&", maxEncodedEventBytes/6)}
+	if _, err := db.AppendEvent(ctx, encodedDetail); err == nil ||
+		err.Error() != "store: event exceeds 65536-byte encoded storage limit" {
+		t.Fatalf("escaped oversized detail err=%v", err)
+	}
+	var count int
+	if err := db.SQL().QueryRowContext(ctx, `SELECT COUNT(*) FROM events`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("stored events=%d, want only the exact-boundary row", count)
+	}
+}
+
+func TestAppendEventsAndCursorRejectsOversizedBatchAtomically(t *testing.T) {
+	db := open(t)
+	ctx := context.Background()
+	device := addObservationDevice(t, db)
+	cursor := IngestCursor{DeviceID: device.ID, Source: "logd",
+		BootID: "boot:pid:0", Cursor: "0:1000", UpdatedAt: 1000}
+	if inserted, err := db.AppendEventsAndCursor(ctx, nil, cursor); err != nil || inserted != 0 {
+		t.Fatalf("seed cursor inserted=%d err=%v", inserted, err)
+	}
+	next := cursor
+	next.Cursor, next.UpdatedAt = "2:2000", 2000
+	events := []Event{
+		{TS: 1, DeviceID: &device.ID, Category: "system", Severity: "info",
+			Event: "valid", Source: "logd", SourceBoot: cursor.BootID, SourceID: "1"},
+		{TS: 2, DeviceID: &device.ID, Category: "system", Severity: "info",
+			Event: strings.Repeat("x", maxEncodedEventBytes), Source: "logd",
+			SourceBoot: cursor.BootID, SourceID: "2"},
+	}
+	if inserted, err := db.AppendEventsAndCursor(ctx, events, next); inserted != 0 || err == nil ||
+		!strings.Contains(err.Error(), "store: ingest event 1: store: event exceeds 65536-byte encoded storage limit") {
+		t.Fatalf("oversized batch inserted=%d err=%v", inserted, err)
+	}
+	got, err := db.LoadIngestCursor(ctx, device.ID, cursor.Source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Cursor != cursor.Cursor {
+		t.Fatalf("cursor advanced to %q, want %q", got.Cursor, cursor.Cursor)
+	}
+	var count int
+	if err := db.SQL().QueryRowContext(ctx, `SELECT COUNT(*) FROM events`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("oversized batch stored %d rows", count)
 	}
 }
 
@@ -552,6 +629,486 @@ func TestAppendEventsAndCursorIsAtomicBoundedAndReplaySafe(t *testing.T) {
 	}
 	if _, err := db.AppendEventsAndCursor(ctx, make([]Event, 513), next); err == nil {
 		t.Fatal("batch larger than 512 was accepted")
+	}
+}
+
+func TestAppendEventsAndCursorCoalescesKnownIPv6RAWarningPerProducerEpoch(t *testing.T) {
+	db := open(t)
+	ctx := context.Background()
+	device := addObservationDevice(t, db)
+	boot := "boot:81:0"
+	cursor := IngestCursor{DeviceID: device.ID, Source: "openwrt-logd",
+		BootID: boot, Cursor: "11:110000", UpdatedAt: 111_000}
+	condition := func(id, sourceTime uint64) Event {
+		return Event{
+			TS: int64(sourceTime / 1000), DeviceID: &device.ID,
+			Category: "system", Severity: "warning",
+			Event:  EventOpenWRTIPv6RANoDefaultRoute,
+			Source: "openwrt-logd", SourceBoot: boot, SourceID: EventOpenWRTIPv6RANoDefaultRouteSourceID,
+			IngestedAt: int64(sourceTime + 1_000),
+			Detail: map[string]any{
+				"message":  "odhcpd[81]: No default route present, setting ra_lifetime to 0!",
+				"priority": uint32(28), "occurrences": 1,
+				"source_time_ms": sourceTime,
+				"condition":      "ipv6_ra_no_default_route", "address_family": "ipv6",
+				"router_advertisement_lifetime": 0,
+				"first_source_time_ms":          sourceTime, "last_source_time_ms": sourceTime,
+				"first_source_id": fmt.Sprint(id), "last_source_id": fmt.Sprint(id),
+			},
+		}
+	}
+	inserted, err := db.AppendEventsAndCursor(ctx,
+		[]Event{condition(10, 100_000), condition(11, 110_000)}, cursor)
+	if err != nil || inserted != 1 {
+		t.Fatalf("condition batch inserted=%d err=%v", inserted, err)
+	}
+	events, err := db.QueryEventsKeyset(ctx, EventQuery{Scope: "general", Limit: 10})
+	if err != nil || len(events) != 1 {
+		t.Fatalf("events=%+v err=%v", events, err)
+	}
+	got := events[0]
+	if got.Event != EventOpenWRTIPv6RANoDefaultRoute ||
+		got.SourceID != EventOpenWRTIPv6RANoDefaultRouteSourceID || got.TS != 110 {
+		t.Fatalf("condition row=%+v", got)
+	}
+	var detail map[string]any
+	if err := json.Unmarshal(got.Detail.(json.RawMessage), &detail); err != nil {
+		t.Fatal(err)
+	}
+	if detail["occurrences"] != float64(2) || detail["first_source_id"] != "10" ||
+		detail["last_source_id"] != "11" || detail["first_source_time_ms"] != float64(100_000) ||
+		detail["last_source_time_ms"] != float64(110_000) {
+		t.Fatalf("condition detail=%+v", detail)
+	}
+	if inserted, err = db.AppendEventsAndCursor(ctx,
+		[]Event{condition(10, 100_000), condition(11, 110_000)}, cursor); err != nil || inserted != 0 {
+		t.Fatalf("condition replay inserted=%d err=%v", inserted, err)
+	}
+	if err := db.SQL().QueryRowContext(ctx,
+		`SELECT json_extract(detail_json,'$.occurrences') FROM events WHERE event=?`,
+		EventOpenWRTIPv6RANoDefaultRoute).Scan(&inserted); err != nil || inserted != 2 {
+		t.Fatalf("condition replay occurrences=%d err=%v", inserted, err)
+	}
+
+	nextBoot := cursor
+	nextBoot.BootID, nextBoot.Cursor, nextBoot.UpdatedAt = "boot:82:0", "1:120000", 121_000
+	third := condition(1, 120_000)
+	third.SourceBoot = nextBoot.BootID
+	if inserted, err = db.AppendEventsAndCursor(ctx, []Event{third}, nextBoot); err != nil || inserted != 1 {
+		t.Fatalf("new epoch inserted=%d err=%v", inserted, err)
+	}
+	if err := db.SQL().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM events WHERE event=?`, EventOpenWRTIPv6RANoDefaultRoute).Scan(&inserted); err != nil || inserted != 2 {
+		t.Fatalf("condition rows=%d err=%v", inserted, err)
+	}
+}
+
+func TestAppendEventsAndCursorIPv6RAWrapReplayIsIdempotent(t *testing.T) {
+	db := open(t)
+	ctx := context.Background()
+	device := addObservationDevice(t, db)
+	boot := "boot:81:1"
+	cursor := IngestCursor{DeviceID: device.ID, Source: "openwrt-logd",
+		BootID: boot, Cursor: "1:103000", UpdatedAt: 104_000}
+	condition := func(id uint64, sourceTime int64) Event {
+		return Event{
+			TS: sourceTime / 1000, IngestedAt: sourceTime + 1_000, DeviceID: &device.ID,
+			Category: "system", Severity: "warning",
+			Event: EventOpenWRTIPv6RANoDefaultRoute, Source: "openwrt-logd",
+			SourceBoot: boot, SourceID: EventOpenWRTIPv6RANoDefaultRouteSourceID,
+			Detail: map[string]any{
+				"message":  "odhcpd[81]: No default route present, setting ra_lifetime to 0!",
+				"priority": uint32(28), "occurrences": 1,
+				"source_time_ms": sourceTime,
+				"condition":      "ipv6_ra_no_default_route", "address_family": "ipv6",
+				"router_advertisement_lifetime": 0,
+				"first_source_time_ms":          sourceTime, "last_source_time_ms": sourceTime,
+				"first_source_id": fmt.Sprint(id), "last_source_id": fmt.Sprint(id),
+			},
+		}
+	}
+	page := []Event{
+		condition(uint64(^uint32(0)), 101_000),
+		condition(0, 102_000),
+		condition(1, 103_000),
+	}
+	if inserted, err := db.AppendEventsAndCursor(ctx, page, cursor); err != nil || inserted != 1 {
+		t.Fatalf("first wrap page inserted=%d err=%v", inserted, err)
+	}
+	if inserted, err := db.AppendEventsAndCursor(ctx, page, cursor); err != nil || inserted != 0 {
+		t.Fatalf("replayed wrap page inserted=%d err=%v", inserted, err)
+	}
+	var occurrences int64
+	var lastID string
+	if err := db.SQL().QueryRowContext(ctx, `
+SELECT json_extract(detail_json,'$.occurrences'), json_extract(detail_json,'$.last_source_id')
+  FROM events WHERE event=? AND source_boot=?`,
+		EventOpenWRTIPv6RANoDefaultRoute, boot).Scan(&occurrences, &lastID); err != nil {
+		t.Fatal(err)
+	}
+	if occurrences != 3 || lastID != "1" {
+		t.Fatalf("wrap replay occurrences=%d last_source_id=%q", occurrences, lastID)
+	}
+	got, err := db.LoadIngestCursor(ctx, device.ID, "openwrt-logd")
+	if err != nil || got.Cursor != cursor.Cursor || got.BootID != cursor.BootID {
+		t.Fatalf("wrap replay cursor=%+v err=%v", got, err)
+	}
+}
+
+func TestCompactLegacyIPv6RAWarningsPreservesEvidenceAndDistinctAlerts(t *testing.T) {
+	db := open(t)
+	ctx := context.Background()
+	device := addObservationDevice(t, db)
+	boot := "boot:81:0"
+	message := "odhcpd[81]: No default route present, setting ra_lifetime to 0!"
+	raw := func(id uint64, text string) Event {
+		return Event{
+			TS: int64(100 + id), IngestedAt: int64(100_000 + id), DeviceID: &device.ID,
+			Category: "system", Severity: "warning", Event: "openwrt.log",
+			Source: "openwrt-logd", SourceBoot: boot, SourceID: fmt.Sprint(id),
+			Detail: map[string]any{
+				"message": text, "facility": uint32(3), "priority": uint32(28),
+				"source_time_ms": int64(100_000 + id),
+			},
+		}
+	}
+	events := make([]Event, 0, 10)
+	for id := uint64(1); id <= 9; id++ {
+		events = append(events, raw(id, message))
+	}
+	events = append(events, raw(10, "odhcpd[81]: unable to send router advertisement"))
+	cursor := IngestCursor{DeviceID: device.ID, Source: "openwrt-logd", BootID: boot,
+		Cursor: "10:100010", UpdatedAt: 101_000}
+	if inserted, err := db.AppendEventsAndCursor(ctx, events, cursor); err != nil || inserted != 10 {
+		t.Fatalf("seed legacy events inserted=%d err=%v", inserted, err)
+	}
+	if err := db.LogEvent(ctx, Event{TS: 50, Category: "system", Severity: "error",
+		Event: "distinct.controller.alert"}); err != nil {
+		t.Fatal(err)
+	}
+
+	compacted, err := db.CompactOpenWRTIPv6RANoDefaultRouteEvents(ctx)
+	if err != nil || compacted != 9 {
+		t.Fatalf("compacted=%d err=%v", compacted, err)
+	}
+	alerts, err := db.QueryRecentGeneralAlerts(ctx, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(alerts) != 3 {
+		t.Fatalf("alerts=%+v, want condition, near-match and distinct alert", alerts)
+	}
+	var condition Event
+	for _, event := range alerts {
+		if event.Event == EventOpenWRTIPv6RANoDefaultRoute {
+			condition = event
+		}
+	}
+	if condition.ID == 0 || condition.SourceID != EventOpenWRTIPv6RANoDefaultRouteSourceID {
+		t.Fatalf("condition=%+v", condition)
+	}
+	var detail map[string]any
+	if err := json.Unmarshal(condition.Detail.(json.RawMessage), &detail); err != nil {
+		t.Fatal(err)
+	}
+	if detail["occurrences"] != float64(9) || detail["first_source_id"] != "1" ||
+		detail["last_source_id"] != "9" || detail["message"] != message {
+		t.Fatalf("condition detail=%+v", detail)
+	}
+	var rawRows int
+	if err := db.SQL().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM events WHERE source='openwrt-logd' AND event='openwrt.log'`).Scan(&rawRows); err != nil || rawRows != 1 {
+		t.Fatalf("raw rows=%d err=%v, want untouched near-match", rawRows, err)
+	}
+	if compacted, err = db.CompactOpenWRTIPv6RANoDefaultRouteEvents(ctx); err != nil || compacted != 0 {
+		t.Fatalf("idempotent compacted=%d err=%v", compacted, err)
+	}
+
+	next := cursor
+	next.Cursor, next.UpdatedAt = "11:100011", 102_000
+	if inserted, err := db.AppendEventsAndCursor(ctx, []Event{raw(11, message)}, next); err != nil || inserted != 1 {
+		t.Fatalf("later legacy event inserted=%d err=%v", inserted, err)
+	}
+	if compacted, err = db.CompactOpenWRTIPv6RANoDefaultRouteEvents(ctx); err != nil || compacted != 1 {
+		t.Fatalf("merged compacted=%d err=%v", compacted, err)
+	}
+	if err := db.SQL().QueryRowContext(ctx, `SELECT json_extract(detail_json,'$.occurrences')
+FROM events WHERE event=?`, EventOpenWRTIPv6RANoDefaultRoute).Scan(&compacted); err != nil || compacted != 10 {
+		t.Fatalf("merged occurrences=%d err=%v", compacted, err)
+	}
+}
+
+func TestIPv6RAConditionCorruptionOrGrowthCannotAdvanceCursor(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*testing.T, *DB)
+	}{
+		{
+			name: "missing evidence",
+			mutate: func(t *testing.T, db *DB) {
+				if _, err := db.SQL().Exec(`UPDATE events SET detail_json='{}' WHERE event=?`,
+					EventOpenWRTIPv6RANoDefaultRoute); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "noncanonical source id",
+			mutate: func(t *testing.T, db *DB) {
+				if _, err := db.SQL().Exec(`UPDATE events SET detail_json=json_set(
+detail_json,'$.last_source_id','01') WHERE event=?`, EventOpenWRTIPv6RANoDefaultRoute); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "occurrence overflow",
+			mutate: func(t *testing.T, db *DB) {
+				if _, err := db.SQL().Exec(`UPDATE events SET detail_json=json_set(
+detail_json,'$.occurrences',?) WHERE event=?`, int64(math.MaxInt64),
+					EventOpenWRTIPv6RANoDefaultRoute); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := open(t)
+			ctx := context.Background()
+			device := addObservationDevice(t, db)
+			boot := "boot:81:0"
+			firstCursor := IngestCursor{DeviceID: device.ID, Source: "openwrt-logd",
+				BootID: boot, Cursor: "1:100000", UpdatedAt: 101_000}
+			first := testIPv6RAConditionEvent(device.ID, boot, 1, 100_000)
+			if inserted, err := db.AppendEventsAndCursor(ctx, []Event{first}, firstCursor); err != nil || inserted != 1 {
+				t.Fatalf("first inserted=%d err=%v", inserted, err)
+			}
+			tc.mutate(t, db)
+			var before string
+			if err := db.SQL().QueryRow(`SELECT detail_json FROM events WHERE event=?`,
+				EventOpenWRTIPv6RANoDefaultRoute).Scan(&before); err != nil {
+				t.Fatal(err)
+			}
+
+			nextCursor := firstCursor
+			nextCursor.Cursor, nextCursor.UpdatedAt = "2:110000", 111_000
+			if _, err := db.AppendEventsAndCursor(ctx,
+				[]Event{testIPv6RAConditionEvent(device.ID, boot, 2, 110_000)}, nextCursor); err == nil {
+				t.Fatal("corrupt condition advanced without an error")
+			}
+			got, err := db.LoadIngestCursor(ctx, device.ID, "openwrt-logd")
+			if err != nil || got.Cursor != firstCursor.Cursor {
+				t.Fatalf("cursor=%+v err=%v", got, err)
+			}
+			var after string
+			if err := db.SQL().QueryRow(`SELECT detail_json FROM events WHERE event=?`,
+				EventOpenWRTIPv6RANoDefaultRoute).Scan(&after); err != nil || after != before {
+				t.Fatalf("condition changed=%v err=%v", after != before, err)
+			}
+		})
+	}
+}
+
+func TestIPv6RAConditionCannotGrowPastEncodedLimit(t *testing.T) {
+	db := open(t)
+	ctx := context.Background()
+	device := addObservationDevice(t, db)
+	boot := "boot:81:0"
+	event := testIPv6RAConditionEvent(device.ID, boot, 1, 100_000)
+	detail := event.Detail.(map[string]any)
+	detail["padding"] = ""
+	normalized, encoded, err := normalizeEvent(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixed := 0
+	for _, value := range []string{
+		normalized.Category, normalized.Severity, normalized.Event, normalized.Source,
+		normalized.SourceID, normalized.SourceBoot, normalized.ClientMAC, normalized.Action,
+		normalized.Direction, normalized.InIface, normalized.OutIface, normalized.SrcIP,
+		normalized.DstIP, normalized.ZoneIn, normalized.ZoneOut,
+	} {
+		fixed += len(value)
+	}
+	padding := maxEncodedEventBytes - fixed - len(encoded)
+	if padding <= 0 {
+		t.Fatalf("invalid padding target=%d", padding)
+	}
+	detail["padding"] = strings.Repeat("x", padding)
+	if _, encoded, err = normalizeEvent(event); err != nil || fixed+len(encoded) != maxEncodedEventBytes {
+		t.Fatalf("boundary detail bytes=%d fixed=%d err=%v", len(encoded), fixed, err)
+	}
+	cursor := IngestCursor{DeviceID: device.ID, Source: "openwrt-logd",
+		BootID: boot, Cursor: "1:100000", UpdatedAt: 101_000}
+	if inserted, err := db.AppendEventsAndCursor(ctx, []Event{event}, cursor); err != nil || inserted != 1 {
+		t.Fatalf("boundary inserted=%d err=%v", inserted, err)
+	}
+	if _, err := db.SQL().Exec(`UPDATE events SET detail_json=json_set(
+detail_json,'$.occurrences',9) WHERE event=?`, EventOpenWRTIPv6RANoDefaultRoute); err != nil {
+		t.Fatal(err)
+	}
+	next := cursor
+	next.Cursor, next.UpdatedAt = "2:110000", 111_000
+	if _, err := db.AppendEventsAndCursor(ctx,
+		[]Event{testIPv6RAConditionEvent(device.ID, boot, 2, 110_000)}, next); err == nil ||
+		!strings.Contains(err.Error(), "encoded storage limit") {
+		t.Fatalf("growth error=%v", err)
+	}
+	got, err := db.LoadIngestCursor(ctx, device.ID, "openwrt-logd")
+	if err != nil || got.Cursor != cursor.Cursor {
+		t.Fatalf("cursor=%+v err=%v", got, err)
+	}
+}
+
+func TestIPv6RALegacyCompactionLimitsArePreflightOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		limits legacyIPv6RACompactionLimits
+		want   string
+	}{
+		{name: "events", limits: legacyIPv6RACompactionLimits{events: 2, groups: 10, bytes: 1 << 20}, want: "exceeds 2 events"},
+		{name: "groups", limits: legacyIPv6RACompactionLimits{events: 10, groups: 2, bytes: 1 << 20}, want: "exceeds 2 producer groups"},
+		{name: "bytes", limits: legacyIPv6RACompactionLimits{events: 10, groups: 10, bytes: 10}, want: "exceeds 10 input bytes"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := open(t)
+			ctx := context.Background()
+			device := addObservationDevice(t, db)
+			for i := 1; i <= 3; i++ {
+				event := testLegacyIPv6RAEvent(device.ID, fmt.Sprintf("boot:%d:0", i), 1,
+					int64(100_000+i))
+				if _, err := db.AppendEvent(ctx, event); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := db.compactOpenWRTIPv6RANoDefaultRouteEvents(ctx, tc.limits); err == nil ||
+				!strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("limit error=%v", err)
+			}
+			var raw, conditions int
+			if err := db.SQL().QueryRow(`SELECT
+SUM(CASE WHEN event='openwrt.log' THEN 1 ELSE 0 END),
+SUM(CASE WHEN event=? THEN 1 ELSE 0 END) FROM events`,
+				EventOpenWRTIPv6RANoDefaultRoute).Scan(&raw, &conditions); err != nil || raw != 3 || conditions != 0 {
+				t.Fatalf("preflight mutated raw=%d conditions=%d err=%v", raw, conditions, err)
+			}
+		})
+	}
+}
+
+func TestIPv6RALegacyCompactionLeavesInvalidSourceTimesRaw(t *testing.T) {
+	db := open(t)
+	ctx := context.Background()
+	device := addObservationDevice(t, db)
+	boot := "boot:81:invalid-time"
+	for i, sourceTime := range []int64{0, -1} {
+		if _, err := db.AppendEvent(ctx,
+			testLegacyIPv6RAEvent(device.ID, boot, uint64(i+1), sourceTime)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if compacted, err := db.CompactOpenWRTIPv6RANoDefaultRouteEvents(ctx); err != nil || compacted != 0 {
+		t.Fatalf("compacted=%d err=%v", compacted, err)
+	}
+	var raw, conditions int
+	if err := db.SQL().QueryRow(`SELECT
+SUM(CASE WHEN event='openwrt.log' THEN 1 ELSE 0 END),
+SUM(CASE WHEN event=? THEN 1 ELSE 0 END) FROM events`,
+		EventOpenWRTIPv6RANoDefaultRoute).Scan(&raw, &conditions); err != nil || raw != 2 || conditions != 0 {
+		t.Fatalf("raw=%d conditions=%d err=%v", raw, conditions, err)
+	}
+
+	cursor := IngestCursor{DeviceID: device.ID, Source: "openwrt-logd", BootID: boot,
+		Cursor: "3:100000", UpdatedAt: 101_000}
+	if inserted, err := db.AppendEventsAndCursor(ctx,
+		[]Event{testIPv6RAConditionEvent(device.ID, boot, 3, 100_000)}, cursor); err != nil || inserted != 1 {
+		t.Fatalf("valid condition inserted=%d err=%v", inserted, err)
+	}
+	next := cursor
+	next.Cursor, next.UpdatedAt = "4:110000", 111_000
+	if inserted, err := db.AppendEventsAndCursor(ctx,
+		[]Event{testIPv6RAConditionEvent(device.ID, boot, 4, 110_000)}, next); err != nil || inserted != 0 {
+		t.Fatalf("valid condition update inserted=%d err=%v", inserted, err)
+	}
+	var occurrences int64
+	if err := db.SQL().QueryRow(`SELECT json_extract(detail_json,'$.occurrences')
+FROM events WHERE event=?`, EventOpenWRTIPv6RANoDefaultRoute).Scan(&occurrences); err != nil || occurrences != 2 {
+		t.Fatalf("occurrences=%d err=%v", occurrences, err)
+	}
+}
+
+func TestIPv6RALegacyCompactionSkipsReplayAndAcceptsWrapSuffix(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		existingID uint64
+		rawIDs     []uint64
+		wantCount  int64
+		wantLast   string
+	}{
+		{name: "replay then forward", existingID: 1,
+			rawIDs: []uint64{math.MaxUint32, 0, 1, 2}, wantCount: 2, wantLast: "2"},
+		{name: "forward wrap", existingID: math.MaxUint32,
+			rawIDs: []uint64{0, 1}, wantCount: 3, wantLast: "1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := open(t)
+			ctx := context.Background()
+			device := addObservationDevice(t, db)
+			boot := "boot:81:1"
+			cursor := IngestCursor{DeviceID: device.ID, Source: "openwrt-logd", BootID: boot,
+				Cursor: fmt.Sprintf("%d:100000", tc.existingID), UpdatedAt: 101_000}
+			if inserted, err := db.AppendEventsAndCursor(ctx,
+				[]Event{testIPv6RAConditionEvent(device.ID, boot, tc.existingID, 100_000)}, cursor); err != nil || inserted != 1 {
+				t.Fatalf("summary inserted=%d err=%v", inserted, err)
+			}
+			for i, id := range tc.rawIDs {
+				if _, err := db.AppendEvent(ctx, testLegacyIPv6RAEvent(device.ID, boot, id,
+					int64(110_000+i))); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if compacted, err := db.CompactOpenWRTIPv6RANoDefaultRouteEvents(ctx); err != nil ||
+				compacted != int64(len(tc.rawIDs)) {
+				t.Fatalf("compacted=%d err=%v", compacted, err)
+			}
+			var count int64
+			var last string
+			if err := db.SQL().QueryRow(`SELECT json_extract(detail_json,'$.occurrences'),
+json_extract(detail_json,'$.last_source_id') FROM events WHERE event=?`,
+				EventOpenWRTIPv6RANoDefaultRoute).Scan(&count, &last); err != nil ||
+				count != tc.wantCount || last != tc.wantLast {
+				t.Fatalf("condition count=%d last=%q err=%v", count, last, err)
+			}
+		})
+	}
+}
+
+func testIPv6RAConditionEvent(deviceID int64, boot string, id uint64, sourceTime int64) Event {
+	return Event{
+		TS: sourceTime / 1000, IngestedAt: sourceTime + 1_000, DeviceID: &deviceID,
+		Category: "system", Severity: "warning",
+		Event: EventOpenWRTIPv6RANoDefaultRoute, Source: "openwrt-logd",
+		SourceBoot: boot, SourceID: EventOpenWRTIPv6RANoDefaultRouteSourceID,
+		Detail: map[string]any{
+			"message":  "odhcpd[81]: No default route present, setting ra_lifetime to 0!",
+			"facility": uint32(3), "priority": uint32(28), "source_time_ms": sourceTime,
+			"condition": "ipv6_ra_no_default_route", "occurrences": 1,
+			"first_source_time_ms": sourceTime, "last_source_time_ms": sourceTime,
+			"first_source_id": fmt.Sprint(id), "last_source_id": fmt.Sprint(id),
+			"address_family": "ipv6", "router_advertisement_lifetime": 0,
+		},
+	}
+}
+
+func testLegacyIPv6RAEvent(deviceID int64, boot string, id uint64, sourceTime int64) Event {
+	return Event{
+		TS: sourceTime / 1000, IngestedAt: sourceTime + 1_000, DeviceID: &deviceID,
+		Category: "system", Severity: "warning", Event: "openwrt.log",
+		Source: "openwrt-logd", SourceBoot: boot, SourceID: fmt.Sprint(id),
+		Detail: map[string]any{
+			"message":  "odhcpd[81]: No default route present, setting ra_lifetime to 0!",
+			"facility": uint32(3), "priority": uint32(28), "source_time_ms": sourceTime,
+		},
 	}
 }
 

--- a/internal/store/rollup.go
+++ b/internal/store/rollup.go
@@ -213,6 +213,25 @@ type PruneResult struct {
 	RadioScans int64
 }
 
+// PruneEvents enforces event retention in its own transaction. Daemon startup
+// and periodic maintenance use it independently of rollup folding so a broken
+// telemetry ladder cannot leave the event table growing without a bound.
+func (db *DB) PruneEvents(ctx context.Context, now time.Time, r Retention) (int64, error) {
+	tx, err := db.sql.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("store: begin event prune: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+	pruned, err := pruneEventsOn(ctx, tx, now, r)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("store: commit event prune: %w", err)
+	}
+	return pruned, nil
+}
+
 // Prune enforces retention. It runs after FoldHourly, never before: dropping a
 // 5-minute row that has not been folded yet loses the data outright rather than
 // downsampling it.
@@ -244,77 +263,10 @@ func (db *DB) Prune(ctx context.Context, now time.Time, r Retention) (PruneResul
 		}
 		out.Hourly, _ = res.RowsAffected()
 	}
-	if r.OpenWRTLogs > 0 {
-		res, err := tx.ExecContext(ctx,
-			`DELETE FROM events WHERE source='openwrt-logd' AND COALESCE(ingested_at, ts * 1000) < ?`,
-			now.Add(-r.OpenWRTLogs).UnixMilli())
-		if err != nil {
-			return out, fmt.Errorf("store: prune OpenWrt logd events: %w", err)
-		}
-		n, _ := res.RowsAffected()
-		out.Events += n
-	}
-	if r.MaxOpenWRTEventsPerDevice > 0 {
-		if _, err := tx.ExecContext(ctx, `
-UPDATE ingest_cursors
-   SET continuity_gap_at=MAX(continuity_gap_at, ?)
- WHERE source='openwrt-logd' AND device_id IN (
-   SELECT device_id FROM (
-     SELECT device_id,
-            ROW_NUMBER() OVER (PARTITION BY device_id ORDER BY id DESC) AS n
-       FROM events
-      WHERE source='openwrt-logd' AND device_id IS NOT NULL
-   ) WHERE n > ?
-)`, now.UnixMilli(), r.MaxOpenWRTEventsPerDevice); err != nil {
-			return out, fmt.Errorf("store: mark per-device OpenWrt logd truncation: %w", err)
-		}
-		res, err := tx.ExecContext(ctx, `
-DELETE FROM events WHERE id IN (
-  SELECT id FROM (
-    SELECT id, ROW_NUMBER() OVER (PARTITION BY device_id ORDER BY id DESC) AS n
-      FROM events WHERE source='openwrt-logd'
-  ) WHERE n > ?
-)`, r.MaxOpenWRTEventsPerDevice)
-		if err != nil {
-			return out, fmt.Errorf("store: prune per-device OpenWrt logd events: %w", err)
-		}
-		n, _ := res.RowsAffected()
-		out.Events += n
-	}
-	if r.MaxOpenWRTEvents > 0 {
-		if _, err := tx.ExecContext(ctx, `
-UPDATE ingest_cursors
-   SET continuity_gap_at=MAX(continuity_gap_at, ?)
- WHERE source='openwrt-logd' AND device_id IN (
-   SELECT DISTINCT device_id FROM events
-    WHERE source='openwrt-logd' AND device_id IS NOT NULL AND id NOT IN (
-      SELECT id FROM events WHERE source='openwrt-logd' ORDER BY id DESC LIMIT ?
-    )
-)`, now.UnixMilli(), r.MaxOpenWRTEvents); err != nil {
-			return out, fmt.Errorf("store: mark global OpenWrt logd truncation: %w", err)
-		}
-		res, err := tx.ExecContext(ctx, `
-DELETE FROM events WHERE source='openwrt-logd' AND id NOT IN (
-  SELECT id FROM events WHERE source='openwrt-logd' ORDER BY id DESC LIMIT ?
-)`, r.MaxOpenWRTEvents)
-		if err != nil {
-			return out, fmt.Errorf("store: prune global OpenWrt logd events: %w", err)
-		}
-		n, _ := res.RowsAffected()
-		out.Events += n
-	}
-	if r.MaxEvents > 0 {
-		// Controller/audit history remains row-count based. OpenWrt logd rows use
-		// their independent time window above, so a noisy router cannot evict
-		// controller outcomes or lose recent logs to this cap.
-		res, err := tx.ExecContext(ctx, `
-DELETE FROM events WHERE source <> 'openwrt-logd' AND id NOT IN (
-  SELECT id FROM events WHERE source <> 'openwrt-logd' ORDER BY id DESC LIMIT ?)`, r.MaxEvents)
-		if err != nil {
-			return out, fmt.Errorf("store: prune events: %w", err)
-		}
-		n, _ := res.RowsAffected()
-		out.Events += n
+	var eventErr error
+	out.Events, eventErr = pruneEventsOn(ctx, tx, now, r)
+	if eventErr != nil {
+		return out, eventErr
 	}
 	if r.TopologyHistory > 0 {
 		// Active edges are the current graph and have no expiry. Only intervals
@@ -373,6 +325,91 @@ DELETE FROM series WHERE id NOT IN (SELECT series_id FROM rollup_5m)
 		return out, fmt.Errorf("store: commit prune: %w", err)
 	}
 	return out, nil
+}
+
+func pruneEventsOn(ctx context.Context, exec *sql.Tx, now time.Time, r Retention) (int64, error) {
+	var pruned int64
+	if r.OpenWRTLogs > 0 {
+		res, err := exec.ExecContext(ctx,
+			`DELETE FROM events WHERE source='openwrt-logd' AND COALESCE(ingested_at, ts * 1000) < ?`,
+			now.Add(-r.OpenWRTLogs).UnixMilli())
+		if err != nil {
+			return 0, fmt.Errorf("store: prune OpenWrt logd events: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		pruned += n
+	}
+	if r.MaxOpenWRTEventsPerDevice > 0 {
+		if _, err := exec.ExecContext(ctx, `
+UPDATE ingest_cursors
+   SET continuity_gap_at=MAX(continuity_gap_at, ?)
+ WHERE source='openwrt-logd' AND device_id IN (
+   SELECT device_id FROM (
+     SELECT device_id,
+            ROW_NUMBER() OVER (
+              PARTITION BY device_id
+              ORDER BY COALESCE(ingested_at, ts * 1000) DESC, id DESC
+            ) AS n
+       FROM events
+      WHERE source='openwrt-logd' AND device_id IS NOT NULL
+   ) WHERE n > ?
+)`, now.UnixMilli(), r.MaxOpenWRTEventsPerDevice); err != nil {
+			return 0, fmt.Errorf("store: mark per-device OpenWrt logd truncation: %w", err)
+		}
+		res, err := exec.ExecContext(ctx, `
+DELETE FROM events WHERE id IN (
+  SELECT id FROM (
+    SELECT id, ROW_NUMBER() OVER (
+      PARTITION BY device_id
+      ORDER BY COALESCE(ingested_at, ts * 1000) DESC, id DESC
+    ) AS n
+      FROM events WHERE source='openwrt-logd'
+  ) WHERE n > ?
+)`, r.MaxOpenWRTEventsPerDevice)
+		if err != nil {
+			return 0, fmt.Errorf("store: prune per-device OpenWrt logd events: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		pruned += n
+	}
+	if r.MaxOpenWRTEvents > 0 {
+		if _, err := exec.ExecContext(ctx, `
+UPDATE ingest_cursors
+   SET continuity_gap_at=MAX(continuity_gap_at, ?)
+ WHERE source='openwrt-logd' AND device_id IN (
+   SELECT DISTINCT device_id FROM events
+    WHERE source='openwrt-logd' AND device_id IS NOT NULL AND id NOT IN (
+      SELECT id FROM events WHERE source='openwrt-logd'
+       ORDER BY COALESCE(ingested_at, ts * 1000) DESC, id DESC LIMIT ?
+    )
+)`, now.UnixMilli(), r.MaxOpenWRTEvents); err != nil {
+			return 0, fmt.Errorf("store: mark global OpenWrt logd truncation: %w", err)
+		}
+		res, err := exec.ExecContext(ctx, `
+DELETE FROM events WHERE source='openwrt-logd' AND id NOT IN (
+  SELECT id FROM events WHERE source='openwrt-logd'
+   ORDER BY COALESCE(ingested_at, ts * 1000) DESC, id DESC LIMIT ?
+)`, r.MaxOpenWRTEvents)
+		if err != nil {
+			return 0, fmt.Errorf("store: prune global OpenWrt logd events: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		pruned += n
+	}
+	if r.MaxEvents > 0 {
+		// Controller/audit history remains row-count based. OpenWrt logd rows use
+		// their independent time window above, so a noisy router cannot evict
+		// controller outcomes or lose recent logs to this cap.
+		res, err := exec.ExecContext(ctx, `
+DELETE FROM events WHERE source <> 'openwrt-logd' AND id NOT IN (
+  SELECT id FROM events WHERE source <> 'openwrt-logd' ORDER BY id DESC LIMIT ?)`, r.MaxEvents)
+		if err != nil {
+			return 0, fmt.Errorf("store: prune events: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		pruned += n
+	}
+	return pruned, nil
 }
 
 // SweepOrphans deletes rollups whose series row is gone, and any series row

--- a/internal/store/rollup_test.go
+++ b/internal/store/rollup_test.go
@@ -351,6 +351,43 @@ func TestPruneCapsEventsByRowCount(t *testing.T) {
 	}
 }
 
+func TestPruneEventsCommitsIndependentlyAndRollsBackOnFailure(t *testing.T) {
+	ctx := context.Background()
+	db := open(t)
+	for i := range 3 {
+		if err := db.LogEvent(ctx, Event{TS: int64(100 + i), Category: "system",
+			Severity: "info", Event: fmt.Sprintf("event-%d", i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := db.SQL().ExecContext(ctx, `CREATE TRIGGER reject_event_prune
+BEFORE DELETE ON events BEGIN SELECT RAISE(ABORT,'blocked'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.PruneEvents(ctx, time.Now(), Retention{MaxEvents: 1}); err == nil ||
+		!strings.Contains(err.Error(), "store: prune events:") ||
+		!strings.Contains(err.Error(), "blocked") {
+		t.Fatalf("failed event prune err=%v", err)
+	}
+	var count int
+	if err := db.SQL().QueryRowContext(ctx, `SELECT COUNT(*) FROM events`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 3 {
+		t.Fatalf("failed event prune left %d rows, want 3", count)
+	}
+	if _, err := db.SQL().ExecContext(ctx, `DROP TRIGGER reject_event_prune`); err != nil {
+		t.Fatal(err)
+	}
+	pruned, err := db.PruneEvents(ctx, time.Now(), Retention{MaxEvents: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pruned != 2 {
+		t.Fatalf("pruned=%d, want 2", pruned)
+	}
+}
+
 func TestPruneKeepsOpenWRTLogWindowIndependentOfEventCap(t *testing.T) {
 	ctx := context.Background()
 	db := open(t)
@@ -498,6 +535,115 @@ func TestPruneBoundsFreshOpenWRTLogsWithoutEvictingControllerHistory(t *testing.
 	}
 	if logs != 3 || !controller {
 		t.Fatalf("remaining logs=%d controller=%v events=%+v", logs, controller, events)
+	}
+}
+
+func TestPrunePerDeviceOpenWRTCapKeepsRefreshedSummary(t *testing.T) {
+	ctx := context.Background()
+	db := open(t)
+	seedDevices(t, db, 1, 2)
+	for _, deviceID := range []int64{1, 2} {
+		if err := db.SaveIngestCursor(ctx, IngestCursor{DeviceID: deviceID,
+			Source: "openwrt-logd", BootID: fmt.Sprintf("boot-%d", deviceID),
+			Cursor: "3", UpdatedAt: 3_000}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	add := func(deviceID int64, event, sourceID string, ingestedAt int64) {
+		t.Helper()
+		if err := db.LogEvent(ctx, Event{TS: ingestedAt / 1000, DeviceID: &deviceID,
+			Category: "system", Severity: "warning", Event: event,
+			Source: "openwrt-logd", SourceBoot: fmt.Sprintf("boot-%d", deviceID),
+			SourceID: sourceID, IngestedAt: ingestedAt}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	add(1, EventOpenWRTIPv6RANoDefaultRoute, EventOpenWRTIPv6RANoDefaultRouteSourceID, 1_000)
+	add(1, "per-device-victim", "2", 2_000)
+	add(1, "per-device-newest", "3", 3_000)
+	add(2, "per-device-untouched", "1", 1_000)
+	if _, err := db.SQL().ExecContext(ctx, `UPDATE events SET ts=4, ingested_at=4000 WHERE event=?`,
+		EventOpenWRTIPv6RANoDefaultRoute); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.UnixMilli(10_000)
+	pruned, err := db.PruneEvents(ctx, now, Retention{MaxOpenWRTEventsPerDevice: 2})
+	if err != nil || pruned != 1 {
+		t.Fatalf("pruned=%d err=%v, want one stale device row", pruned, err)
+	}
+	events, err := db.RecentEvents(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kept := map[string]bool{}
+	for _, event := range events {
+		kept[event.Event] = true
+	}
+	if !kept[EventOpenWRTIPv6RANoDefaultRoute] || !kept["per-device-newest"] ||
+		!kept["per-device-untouched"] || kept["per-device-victim"] {
+		t.Fatalf("per-device cap kept=%v", kept)
+	}
+	for deviceID, wantGap := range map[int64]int64{1: now.UnixMilli(), 2: 0} {
+		cursor, err := db.LoadIngestCursor(ctx, deviceID, "openwrt-logd")
+		if err != nil || cursor.ContinuityGapAt != wantGap {
+			t.Fatalf("device %d gap=%d err=%v, want %d", deviceID,
+				cursor.ContinuityGapAt, err, wantGap)
+		}
+	}
+}
+
+func TestPruneGlobalOpenWRTCapMarksTheDeletedVictimDevice(t *testing.T) {
+	ctx := context.Background()
+	db := open(t)
+	seedDevices(t, db, 1, 2, 3)
+	for _, deviceID := range []int64{1, 2, 3} {
+		if err := db.SaveIngestCursor(ctx, IngestCursor{DeviceID: deviceID,
+			Source: "openwrt-logd", BootID: fmt.Sprintf("boot-%d", deviceID),
+			Cursor: "1", UpdatedAt: 3_000}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	add := func(deviceID int64, event, sourceID string, ingestedAt int64) {
+		t.Helper()
+		if err := db.LogEvent(ctx, Event{TS: ingestedAt / 1000, DeviceID: &deviceID,
+			Category: "system", Severity: "warning", Event: event,
+			Source: "openwrt-logd", SourceBoot: fmt.Sprintf("boot-%d", deviceID),
+			SourceID: sourceID, IngestedAt: ingestedAt}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	add(1, EventOpenWRTIPv6RANoDefaultRoute, EventOpenWRTIPv6RANoDefaultRouteSourceID, 1_000)
+	add(2, "global-victim", "1", 2_000)
+	add(3, "global-newest", "1", 3_000)
+	if _, err := db.SQL().ExecContext(ctx, `UPDATE events SET ts=4, ingested_at=4000 WHERE event=?`,
+		EventOpenWRTIPv6RANoDefaultRoute); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.UnixMilli(10_000)
+	pruned, err := db.PruneEvents(ctx, now, Retention{MaxOpenWRTEvents: 2})
+	if err != nil || pruned != 1 {
+		t.Fatalf("pruned=%d err=%v, want one global victim", pruned, err)
+	}
+	events, err := db.RecentEvents(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kept := map[string]bool{}
+	for _, event := range events {
+		kept[event.Event] = true
+	}
+	if !kept[EventOpenWRTIPv6RANoDefaultRoute] || !kept["global-newest"] ||
+		kept["global-victim"] {
+		t.Fatalf("global cap kept=%v", kept)
+	}
+	for deviceID, wantGap := range map[int64]int64{1: 0, 2: now.UnixMilli(), 3: 0} {
+		cursor, err := db.LoadIngestCursor(ctx, deviceID, "openwrt-logd")
+		if err != nil || cursor.ContinuityGapAt != wantGap {
+			t.Fatalf("device %d gap=%d err=%v, want %d", deviceID,
+				cursor.ContinuityGapAt, err, wantGap)
+		}
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1295,6 +1295,9 @@ func (db *DB) ForgetOwned(ctx context.Context, deviceID int64) error {
 	return err
 }
 
+// maxEncodedEventBytes covers every text column, including encoded detail JSON.
+const maxEncodedEventBytes = 64 << 10
+
 // Event is an audit or telemetry event.
 type Event struct {
 	ID         int64
@@ -1321,6 +1324,15 @@ type Event struct {
 	ZoneOut    string
 	PolicyID   *int64
 }
+
+// EventOpenWRTIPv6RANoDefaultRoute is the durable condition emitted when
+// odhcpd advertises a zero router lifetime because it cannot find a usable
+// IPv6 default route. The source warning remains a warning; only identical
+// repeats from one router-log epoch are condensed.
+const (
+	EventOpenWRTIPv6RANoDefaultRoute         = "openwrt.ipv6_ra_no_default_route"
+	EventOpenWRTIPv6RANoDefaultRouteSourceID = "condition:ipv6-ra-no-default-route"
+)
 
 // LogEvent appends to the event log. Every apply outcome lands here, including
 // the Unknown one — especially that one.
@@ -1394,7 +1406,29 @@ func normalizeEvent(e Event) (Event, string, error) {
 		}
 		detail = string(blob)
 	}
+	if !eventFitsEncodedLimit(e, detail) {
+		return e, "", fmt.Errorf("store: event exceeds %d-byte encoded storage limit",
+			maxEncodedEventBytes)
+	}
 	return e, detail, nil
+}
+
+func eventFitsEncodedLimit(e Event, detail string) bool {
+	if len(detail) > maxEncodedEventBytes {
+		return false
+	}
+	remaining := maxEncodedEventBytes - len(detail)
+	for _, value := range []string{
+		e.Category, e.Severity, e.Event, e.Source, e.SourceID, e.SourceBoot,
+		e.ClientMAC, e.Action, e.Direction, e.InIface, e.OutIface,
+		e.SrcIP, e.DstIP, e.ZoneIn, e.ZoneOut,
+	} {
+		if len(value) > remaining {
+			return false
+		}
+		remaining -= len(value)
+	}
+	return true
 }
 
 func eventInsertArgs(e Event, detail string) []any {
@@ -1455,6 +1489,25 @@ func (db *DB) AppendEventsAndCursor(ctx context.Context, events []Event,
 	}
 	defer stmt.Close()
 	for i, event := range prepared {
+		condition := event.event.Source == "openwrt-logd" && event.event.Severity == "warning" &&
+			event.event.Event == EventOpenWRTIPv6RANoDefaultRoute &&
+			event.event.SourceID == EventOpenWRTIPv6RANoDefaultRouteSourceID
+		if condition {
+			detail, err := decodeIPv6RAConditionDetail([]byte(event.detail))
+			if err != nil || detail.occurrences != 1 {
+				if err == nil {
+					err = errors.New("store: new IPv6 RA condition must represent one occurrence")
+				}
+				return 0, fmt.Errorf("store: ingest event %d: %w", i, err)
+			}
+			updated, err := coalesceOpenWRTIPv6RAEvent(ctx, tx, event.event, event.detail)
+			if err != nil {
+				return 0, fmt.Errorf("store: ingest event %d: %w", i, err)
+			}
+			if updated {
+				continue
+			}
+		}
 		res, err := stmt.ExecContext(ctx, eventInsertArgs(event.event, event.detail)...)
 		if err != nil {
 			return 0, fmt.Errorf("store: ingest event %d: %w", i, err)
@@ -1462,6 +1515,9 @@ func (db *DB) AppendEventsAndCursor(ctx context.Context, events []Event,
 		added, err := eventInsertResult(res)
 		if err != nil {
 			return 0, err
+		}
+		if condition && !added {
+			return 0, fmt.Errorf("store: ingest event %d: IPv6 RA condition identity conflicted", i)
 		}
 		if added {
 			inserted++

--- a/internal/telemetry/maintain.go
+++ b/internal/telemetry/maintain.go
@@ -87,15 +87,25 @@ func (m *Maintainer) tick(ctx context.Context, final bool) {
 		return
 	}
 
+	eventRows, err := m.Store.PruneEvents(ctx, now, m.Retention)
+	if err != nil {
+		m.Log.Error("could not prune events", "err", err)
+	}
 	if err := m.Store.FoldHourly(ctx, now); err != nil {
 		m.Log.Error("could not fold hourly rollups", "err", err)
 		return // pruning now would delete 5-minute rows that never got folded
 	}
-	res, err := m.Store.Prune(ctx, now, m.Retention)
+	retention := m.Retention
+	retention.OpenWRTLogs = 0
+	retention.MaxOpenWRTEvents = 0
+	retention.MaxOpenWRTEventsPerDevice = 0
+	retention.MaxEvents = 0
+	res, err := m.Store.Prune(ctx, now, retention)
 	if err != nil {
 		m.Log.Error("could not prune telemetry", "err", err)
 		return
 	}
+	res.Events = eventRows
 	// Clients age out on their own schedule. Randomised MACs mean one phone can
 	// produce a new "client" per SSID per reconnect, so the table grows without
 	// this even on a small network.

--- a/internal/telemetry/maintain_test.go
+++ b/internal/telemetry/maintain_test.go
@@ -95,3 +95,58 @@ func TestFinalFlushPersistsCompletedBucketsWithoutWritingCurrentPartial(t *testi
 		t.Fatalf("completed buckets=%+v, want process A then process B", got.Points)
 	}
 }
+
+func TestEventPruneRunsWhenHourlyFoldFails(t *testing.T) {
+	ctx := context.Background()
+	db, _ := openMaintainerDB(t)
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	if err := db.LogEvent(ctx, store.Event{TS: now.Add(-2 * time.Hour).Unix(),
+		IngestedAt: now.Add(-2 * time.Hour).UnixMilli(), Category: "system",
+		Severity: "warning", Event: "expired", Source: "openwrt-logd"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.SQL().ExecContext(ctx, `DROP TABLE rollup_5m`); err != nil {
+		t.Fatal(err)
+	}
+	m := NewMaintainer(db, New(Options{}), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	m.Retention = store.Retention{OpenWRTLogs: time.Hour}
+	m.Now = func() time.Time { return now }
+	m.Tick(ctx)
+	var count int
+	if err := db.SQL().QueryRowContext(ctx, `SELECT COUNT(*) FROM events`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("fold failure left %d expired events", count)
+	}
+}
+
+func TestEventPruneFailureDoesNotBlockOtherMaintenance(t *testing.T) {
+	ctx := context.Background()
+	db, _ := openMaintainerDB(t)
+	for range 2 {
+		if err := db.LogEvent(ctx, store.Event{Category: "system", Severity: "info",
+			Event: "bounded"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := db.SQL().ExecContext(ctx, `CREATE TRIGGER reject_event_prune
+BEFORE DELETE ON events BEGIN SELECT RAISE(ABORT,'blocked'); END`); err != nil {
+		t.Fatal(err)
+	}
+	m := NewMaintainer(db, New(Options{}), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	m.Retention = store.Retention{MaxEvents: 1}
+	runAfterTick := false
+	m.AfterTick = func() { runAfterTick = true }
+	m.Tick(ctx)
+	if !runAfterTick {
+		t.Fatal("event prune failure stopped independent maintenance")
+	}
+	var count int
+	if err := db.SQL().QueryRowContext(ctx, `SELECT COUNT(*) FROM events`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("failed event prune changed rows=%d, want 2", count)
+	}
+}

--- a/ui/e2e/desktop.spec.ts
+++ b/ui/e2e/desktop.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test, type Locator, type Page } from '@playwright/test'
 
 const dashboard = {
   devices: { total: 2, online: 2, offline: 0, pending: 0, unknown: 0 },
@@ -71,6 +71,104 @@ const speedTests = {
   },
 }
 
+const clientPage = {
+  clients: [{
+    mac: '02:00:00:00:00:01',
+    name: 'Fixture phone',
+    ipv4: '192.168.1.20',
+    first_seen: 1_787_999_000,
+    last_seen: 1_788_000_000,
+    blocked: false,
+    connection: 'wireless',
+    online: true,
+    signal: -55,
+    device_id: 1,
+    scope: 'local',
+  }],
+  total: 1,
+  limit: 500,
+  offset: 0,
+  facets: {
+    presence: [{ value: 'online', count: 1 }],
+    connection: [{ value: 'wireless', count: 1 }],
+    scope: [{ value: 'local', count: 1 }],
+  },
+  note: 'Current fixture evidence is available',
+  scope_note: '',
+}
+
+const site = {
+  name: 'Fixture site',
+  uuid: 'f8a258d7-3bf1-4099-a534-ce1f0a6cdd7c',
+  wlans: [],
+  meshes: [],
+  uplinks: [],
+  groups: [],
+  networks: [{ id: 1, name: 'lan', vlan: 1, cidr: '192.168.1.1/24', zone: 'lan', enabled: true }],
+  zones: [{ name: 'lan', forward_to: ['wan'], explicit: true }],
+  policies: [],
+  policy_capabilities: [
+    { kind: 'firewall', available: true },
+    { kind: 'route', available: true },
+    { kind: 'fixed_ip', available: true },
+  ],
+  problems: [],
+  overrides: [],
+  overridable: [],
+  override_note: '',
+}
+
+const radios = {
+  generated_at: 1_788_000_000_000,
+  gaps: [],
+  devices: [{
+    device_id: 7,
+    name: 'Fixture AP',
+    status: { last_poll_ok: true, consecutive_failures: 0, stale: false },
+    radios: [{
+      radio_key: 'radio0',
+      up: true,
+      band: '5g',
+      configured_channel: 'auto',
+      htmode: 'VHT80',
+      current_mhz: 5180,
+      current_channel: 36,
+      inventory_observed_at: 1_788_000_000_000,
+      channels_observed_at: 1_788_000_000_000,
+      stale: false,
+      interfaces: [{ name: 'phy0-ap0', mode: 'ap' }],
+      channels_known: true,
+      channels: [
+        { band: '5g', channel: 36, mhz: 5180, state: 'in-use', availability: 'enabled', in_use: true, restricted: false, dfs: null, excluded: null, flags: [] },
+        { band: '5g', channel: 44, mhz: 5220, state: 'enabled', availability: 'enabled', in_use: false, restricted: false, dfs: null, excluded: null, flags: [] },
+        { band: '5g', channel: 52, mhz: 5260, state: 'restricted', availability: 'restricted', in_use: false, restricted: true, dfs: null, excluded: null, flags: ['NO-IR'] },
+        { band: '5g', channel: 60, mhz: 5300, state: 'unknown', availability: 'unknown', in_use: false, restricted: false, dfs: null, excluded: null, flags: [] },
+      ],
+      scan_capability: 'absent',
+      latest_observations: [],
+    }],
+  }],
+}
+
+const accounts = {
+  accounts: [{
+    id: 1,
+    username: 'operator',
+    role: 'owner',
+    role_label: 'Owner',
+    enabled: true,
+    created_at: 1_787_000_000,
+    last_login_at: 1_788_000_000,
+    active_session_count: 1,
+  }],
+  roles: [
+    { value: 'owner', label: 'Owner', description: 'Full controller and account administration.' },
+    { value: 'admin', label: 'Administrator', description: 'Full network administration.' },
+    { value: 'operator', label: 'Operator', description: 'Operate the network.' },
+    { value: 'viewer', label: 'Read only', description: 'View controller state.' },
+  ],
+}
+
 async function installControllerFixture(page: Page, topologyResponse: unknown = topology) {
   const unexpectedRequests: string[] = []
   await page.addInitScript(() => {
@@ -123,15 +221,7 @@ async function installControllerFixture(page: Page, topologyResponse: unknown = 
       },
       '/api/v1/dashboard': dashboard,
       '/api/v1/devices': { devices: [] },
-      '/api/v1/clients': {
-        clients: [],
-        total: 0,
-        limit: 500,
-        offset: 0,
-        facets: { presence: [], connection: [], scope: [] },
-        note: 'No current RF evidence is available',
-        scope_note: '',
-      },
+      '/api/v1/clients': clientPage,
       '/api/v1/events': {
         events: [],
         total: 0,
@@ -143,8 +233,15 @@ async function installControllerFixture(page: Page, topologyResponse: unknown = 
       },
       '/api/v1/speedtests': speedTests,
       '/api/v1/topology': topologyResponse,
+      '/api/v1/site': site,
+      '/api/v1/accounts': accounts,
+      '/api/v1/radios': radios,
+      '/api/v1/roaming/neighbours': { ran: false },
+      '/api/v1/site/mesh-health': { links: [], note: 'No configured mesh links.' },
     }
-    const body = responses[path]
+    const body = path.startsWith('/api/v1/stats/')
+      ? { device_id: 7, kind: path.split('/').at(-1), key: 'radio0', resolution: '5m', points: [] }
+      : responses[path]
     if (route.request().method() !== 'GET' || body === undefined) {
       unexpectedRequests.push(`${route.request().method()} ${path}`)
       await route.fulfill({ status: 500, json: { error: `unmocked fixture route: ${path}` } })
@@ -166,6 +263,35 @@ async function readOverflow(page: Page) {
       document: document.documentElement.scrollWidth - document.documentElement.clientWidth,
       main: main ? main.scrollWidth - main.clientWidth : Number.POSITIVE_INFINITY,
     }
+  })
+}
+
+async function expectWithinMain(page: Page, locator: Locator) {
+  await locator.scrollIntoViewIfNeeded()
+  const [main, element] = await Promise.all([
+    page.locator('#main-content').boundingBox(),
+    locator.boundingBox(),
+  ])
+  expect(main).not.toBeNull()
+  expect(element).not.toBeNull()
+  expect(element!.x).toBeGreaterThanOrEqual(main!.x - 1)
+  expect(element!.x + element!.width).toBeLessThanOrEqual(main!.x + main!.width + 1)
+}
+
+async function contrastRatio(locator: Locator) {
+  return locator.evaluate((element) => {
+    const rgb = (value: string) => (value.match(/[\d.]+/g) ?? []).slice(0, 3).map(Number)
+    const luminance = (value: string) => {
+      const [red, green, blue] = rgb(value).map((channel) => {
+        const normalized = channel / 255
+        return normalized <= .04045 ? normalized / 12.92 : ((normalized + .055) / 1.055) ** 2.4
+      })
+      return .2126 * red + .7152 * green + .0722 * blue
+    }
+    const style = getComputedStyle(element)
+    const foreground = luminance(style.color)
+    const background = luminance(style.backgroundColor)
+    return (Math.max(foreground, background) + .05) / (Math.min(foreground, background) + .05)
   })
 }
 
@@ -275,6 +401,115 @@ for (const viewport of [{ width: 1280, height: 720 }, { width: 1440, height: 900
     overflow = await readOverflow(page)
     expect(overflow.document).toBeLessThanOrEqual(1)
     expect(overflow.main).toBeLessThanOrEqual(1)
+    expect(unexpectedRequests).toEqual([])
+  })
+}
+
+test('390x844 responsive routes keep controls and state in view', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  const unexpectedRequests = await installControllerFixture(page)
+
+  await page.goto('/logs')
+  await expect(page.getByRole('heading', { level: 1, name: 'Logs' })).toBeVisible()
+  expect(await page.locator('.logs-page').evaluate((element) =>
+    getComputedStyle(element).gridTemplateColumns.split(/\s+/).length)).toBe(1)
+  await expectWithinMain(page, page.getByRole('group', { name: 'Event view' }))
+  await expectWithinMain(page, page.locator('.logs-page .pager').getByRole('button', { name: 'Next' }))
+
+  await page.goto('/settings')
+  await expect(page.getByRole('heading', { level: 1, name: 'Settings' })).toBeVisible()
+  await page.getByRole('tab', { name: 'Accounts' }).click()
+  for (const field of ['Username', 'Password', 'Repeat password']) {
+    await expectWithinMain(page, page.getByLabel(field, { exact: true }).first())
+  }
+  await expectWithinMain(page, page.getByRole('combobox', { name: /^Role/ }))
+
+  await page.goto('/radios')
+  await expect(page.getByRole('heading', { level: 1, name: 'Radios & Channel Plan' })).toBeVisible()
+  expect(await page.locator('.radio-stat-grid').evaluate((element) =>
+    getComputedStyle(element).gridTemplateColumns.split(/\s+/).length)).toBe(1)
+  expect(await page.locator('.radio-plan-row').evaluate((element) =>
+    getComputedStyle(element).gridTemplateColumns.split(/\s+/).length)).toBe(1)
+  await expectWithinMain(page, page.getByLabel('Filter by access point'))
+  await expectWithinMain(page, page.getByLabel('Filter by band'))
+  await expectWithinMain(page, page.getByLabel('Channel Plan legend'))
+
+  await page.goto('/topology')
+  await expect(page.getByRole('heading', { level: 1, name: 'Topology' })).toBeVisible()
+  expect(await page.locator('.topology-stat-grid').evaluate((element) =>
+    getComputedStyle(element).gridTemplateColumns.split(/\s+/).length)).toBe(1)
+  await expectWithinMain(page, page.getByText('Evidence coverage').locator('..'))
+  await expectWithinMain(page, page.getByLabel('Topology confidence legend'))
+
+  await page.goto('/policy')
+  const policyTabs = page.getByRole('tablist', { name: 'Policy Engine views' })
+  await expect(policyTabs).toBeVisible()
+  await expectWithinMain(page, policyTabs)
+  await page.getByRole('tab', { name: 'Objects' }).click()
+  expect(await page.locator('.policy-object-picker').evaluate((element) =>
+    getComputedStyle(element).gridTemplateColumns.split(/\s+/).length)).toBe(1)
+  await page.getByRole('checkbox', { name: /^Route\b/ }).check()
+  expect(await page.locator('.policy-route-fields').evaluate((element) =>
+    getComputedStyle(element).gridTemplateColumns.split(/\s+/).length)).toBe(1)
+
+  await page.goto('/clients')
+  await expect(page.getByRole('heading', { level: 1, name: 'Client Devices' })).toBeVisible()
+  await expectWithinMain(page, page.locator('.pager').getByRole('button', { name: 'Next' }))
+
+  const overflow = await readOverflow(page)
+  expect(overflow.document).toBeLessThanOrEqual(1)
+  expect(overflow.main).toBeLessThanOrEqual(1)
+  expect(unexpectedRequests).toEqual([])
+})
+
+test('320px narrow dashboard, Logs pager, and Channel Plan do not clip', async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 568 })
+  const unexpectedRequests = await installControllerFixture(page)
+
+  await page.goto('/')
+  await expect(page.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeVisible()
+  let overflow = await readOverflow(page)
+  expect(overflow.document).toBeLessThanOrEqual(1)
+  expect(overflow.main).toBeLessThanOrEqual(1)
+
+  await page.goto('/logs')
+  const logsPager = page.locator('.logs-page .pager')
+  await expect(logsPager).toBeVisible()
+  await expectWithinMain(page, logsPager.getByRole('button', { name: 'Previous' }))
+  await expectWithinMain(page, logsPager.getByRole('button', { name: 'Next' }))
+
+  await page.goto('/radios')
+  const channel = page.locator('.radio-channel[data-state="in-use"]')
+  await expect(channel).toBeVisible()
+  await expectWithinMain(page, channel)
+  expect(await page.locator('.radio-plan-row').evaluate((element) =>
+    getComputedStyle(element).gridTemplateColumns.split(/\s+/).length)).toBe(1)
+  overflow = await readOverflow(page)
+  expect(overflow.document).toBeLessThanOrEqual(1)
+  expect(overflow.main).toBeLessThanOrEqual(1)
+  expect(unexpectedRequests).toEqual([])
+})
+
+for (const theme of ['dark', 'light'] as const) {
+  test(`${theme} selected controls and channel numerals meet text contrast`, async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    const unexpectedRequests = await installControllerFixture(page)
+
+    await page.goto('/logs')
+    if (theme === 'light') await page.getByRole('button', { name: /switch to light theme/i }).click()
+    await expect(page.locator('html')).toHaveAttribute('data-theme', theme)
+    expect(await contrastRatio(page.getByRole('button', { name: 'General' }))).toBeGreaterThanOrEqual(4.5)
+
+    await page.goto('/policy')
+    const objects = page.getByRole('tab', { name: 'Objects' })
+    await objects.click()
+    expect(await contrastRatio(objects)).toBeGreaterThanOrEqual(4.5)
+
+    await page.goto('/radios')
+    await expect(page.locator('.radio-channel')).toHaveCount(4)
+    for (const state of ['in-use', 'enabled', 'restricted', 'unknown']) {
+      expect(await contrastRatio(page.locator(`.radio-channel[data-state="${state}"]`))).toBeGreaterThanOrEqual(4.5)
+    }
     expect(unexpectedRequests).toEqual([])
   })
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -310,7 +310,7 @@ export function App() {
                 setSigningOut(false)
               }
             }}
-            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--accent)', fontSize: 12 }}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--accent-text)', fontSize: 12 }}
           >
             {signingOut ? 'Signing out…' : 'Sign out'}
           </button>

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -82,6 +82,7 @@ export function Card({
           style={{
             display: 'flex',
             alignItems: 'center',
+            flexWrap: 'wrap',
             justifyContent: 'space-between',
             gap: 12,
             padding: '10px 14px',
@@ -90,7 +91,7 @@ export function Card({
             fontWeight: 600,
           }}
         >
-          <span>{title}</span>
+          <span style={{ minWidth: 0, overflowWrap: 'anywhere' }}>{title}</span>
           {actions}
         </header>
       )}
@@ -1323,21 +1324,11 @@ export function Pager({
   const from = total === 0 ? 0 : offset + 1
   const to = Math.min(offset + limit, total)
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        padding: '6px 12px',
-        borderTop: '1px solid var(--border)',
-        fontSize: 11,
-        color: 'var(--text-secondary)',
-      }}
-    >
+    <div className="pager">
       <span className="num">
         {from.toLocaleString()}–{to.toLocaleString()} of {total.toLocaleString()}
       </span>
-      <div style={{ flex: 1 }} />
+      <div className="pager-spacer" />
       <label style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
         Rows
         <select

--- a/ui/src/lib/eventCondition.ts
+++ b/ui/src/lib/eventCondition.ts
@@ -1,0 +1,19 @@
+import type { EventRow } from './api'
+
+export const IPV6_RA_NO_DEFAULT_ROUTE = 'openwrt.ipv6_ra_no_default_route'
+
+export function ipv6RACondition(event: EventRow): { occurrences: number } | null {
+  if (event.Event !== IPV6_RA_NO_DEFAULT_ROUTE) return null
+  const detail = event.Detail
+  if (!detail || typeof detail !== 'object' || Array.isArray(detail)) return { occurrences: 1 }
+  const value = (detail as Record<string, unknown>).occurrences
+  return {
+    occurrences: Number.isSafeInteger(value) && Number(value) > 0 ? Number(value) : 1,
+  }
+}
+
+export function eventLabel(event: EventRow): string {
+  return ipv6RACondition(event)
+    ? 'IPv6 router advertisements have no usable default route'
+    : event.Event
+}

--- a/ui/src/lib/tokens.css
+++ b/ui/src/lib/tokens.css
@@ -184,7 +184,7 @@ body {
 }
 
 a {
-  color: var(--accent);
+  color: var(--accent-text);
 }
 
 :focus-visible {
@@ -377,6 +377,14 @@ a {
   gap: 12px;
 }
 
+.settings-heading > * {
+  min-width: 0;
+}
+
+.settings-heading span {
+  overflow-wrap: anywhere;
+}
+
 .settings-heading h1 {
   margin: 0;
   font-size: 22px;
@@ -396,12 +404,15 @@ a {
   gap: 3px;
   padding: 3px;
   width: fit-content;
+  max-width: 100%;
+  overflow-x: auto;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--surface-1);
 }
 
 .settings-tabs button {
+  flex: 0 0 auto;
   min-height: 32px;
   padding: 0 13px;
   border: 0;
@@ -420,6 +431,213 @@ a {
 
 .settings-panel {
   min-width: 0;
+}
+
+.logs-page {
+  display: grid;
+  grid-template-columns: 190px minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+  min-width: 0;
+}
+
+.logs-page-header {
+  grid-column: 1 / -1;
+}
+
+.logs-page-content {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.radio-stat-grid,
+.topology-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.card-inline-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  min-width: 0;
+  max-width: 100%;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.radio-plan-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.radio-plan-filters label {
+  min-width: 0;
+  max-width: 100%;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.radio-plan-filters select {
+  max-width: 100%;
+}
+
+.radio-plan-row {
+  display: grid;
+  grid-template-columns: 160px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.radio-state-mark {
+  display: inline-grid;
+  width: 13px;
+  height: 13px;
+  flex: 0 0 13px;
+  place-items: center;
+  border: 1px solid var(--border-strong);
+  border-radius: 3px;
+  background: var(--surface-2);
+  color: var(--text-primary);
+  font-size: 9px;
+  font-style: normal;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.radio-state-mark[data-state='in-use'] {
+  border-color: var(--accent);
+  border-radius: 50%;
+  color: var(--accent-text);
+}
+
+.radio-state-mark[data-state='in-use']::after {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentcolor;
+  content: '';
+}
+
+.radio-state-mark[data-state='enabled'] {
+  border-color: var(--good);
+}
+
+.radio-state-mark[data-state='restricted'] {
+  border-color: var(--warning);
+}
+
+.radio-state-mark[data-state='restricted']::after {
+  content: '!';
+}
+
+.radio-state-mark[data-state='unknown'] {
+  border-style: dashed;
+  color: var(--text-secondary);
+}
+
+.radio-state-mark[data-state='unknown']::after {
+  content: '?';
+}
+
+.radio-channel {
+  position: relative;
+  display: inline-grid;
+  width: 34px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--surface-2);
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.radio-channel[data-state='in-use'] {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-text);
+}
+
+.radio-channel[data-state='enabled'] {
+  border-color: var(--good);
+}
+
+.radio-channel[data-state='restricted'] {
+  border-color: var(--warning);
+}
+
+.radio-channel[data-state='unknown'] {
+  border-style: dashed;
+  color: var(--text-secondary);
+}
+
+.radio-channel > .radio-state-mark {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  width: 8px;
+  height: 8px;
+  border: 0;
+  background: transparent;
+  font-size: 7px;
+}
+
+.radio-channel > .radio-state-mark[data-state='in-use']::after {
+  width: 4px;
+  height: 4px;
+}
+
+.pager {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 6px 12px;
+  border-top: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.pager-spacer {
+  flex: 1;
+}
+
+.policy-object-picker,
+.policy-route-fields,
+.policy-client-picker {
+  display: grid;
+  gap: 8px;
+  align-items: end;
+  min-width: 0;
+}
+
+.policy-object-picker {
+  grid-template-columns: minmax(130px, .55fr) minmax(220px, 1.45fr) auto;
+}
+
+.policy-route-fields {
+  grid-template-columns: 1fr 1fr 120px;
+  margin-top: 10px;
+}
+
+.policy-client-picker {
+  grid-template-columns: minmax(240px, 1fr) auto;
+}
+
+.policy-tabs {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.policy-tabs > button {
+  flex: 0 0 auto;
 }
 
 .account-page {
@@ -795,6 +1013,88 @@ a {
   }
 }
 
+@media (max-width: 720px) {
+  .logs-page {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .logs-page-header {
+    grid-column: auto;
+  }
+
+  .settings-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .settings-tabs {
+    width: 100%;
+  }
+
+  .settings-tabs button {
+    min-height: 44px;
+  }
+
+  .account-facts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .account-form,
+  .account-create-form,
+  .account-reauth,
+  .restore-upload-form,
+  .diagnostics-flags {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .account-reauth {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .restore-preview-counts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .account-list-row,
+  .diagnostics-active-heading,
+  .diagnostics-history-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .account-row-actions,
+  .diagnostics-disabled-action {
+    justify-content: flex-start;
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .radio-stat-grid,
+  .topology-stat-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .radio-plan-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .policy-object-picker,
+  .policy-route-fields,
+  .policy-client-picker {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .pager-spacer {
+    display: none;
+  }
+
+  .pager > .num {
+    flex: 1 0 100%;
+    text-align: left;
+  }
+}
+
 .dashboard-page {
   display: grid;
   gap: 14px;
@@ -1018,13 +1318,25 @@ a {
   overflow: visible;
 }
 
-.dashboard-trend path {
+.dashboard-trend-series {
   fill: none;
   stroke: var(--series-1);
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke-width: 2;
   vector-effect: non-scaling-stroke;
+}
+
+.dashboard-trend-point {
+  fill: var(--series-1);
+  stroke: var(--surface-1);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.dashboard-trend-gap {
+  fill: var(--text-muted);
+  fill-opacity: 0.08;
 }
 
 .dashboard-wan-footnote {
@@ -1169,6 +1481,26 @@ a {
 }
 
 @media (max-width: 720px) {
+  .dashboard-page-heading,
+  .dashboard-section-heading,
+  .dashboard-wan-context,
+  .speedtest-active-heading,
+  .speedtest-history-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .dashboard-page-heading > *,
+  .dashboard-section-heading > *,
+  .dashboard-wan-context > * {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .dashboard-wan-reachability {
+    justify-items: start;
+  }
+
   .dashboard-wan-metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/ui/src/screens/Adopt.tsx
+++ b/ui/src/screens/Adopt.tsx
@@ -439,12 +439,12 @@ export function Adopt({ onAdopted }: { onAdopted: () => void }) {
                       <span style={{ fontSize: 12, fontWeight: 600 }}>
                         {item.label}
                         {isRecommended && (
-                          <span style={{ color: 'var(--accent)', fontWeight: 500 }}>
+                          <span style={{ color: 'var(--accent-text)', fontWeight: 500 }}>
                             {' '}· recommended
                           </span>
                         )}
                         {!isRecommended && !isUnknown && isAvailable && (
-                          <span style={{ color: 'var(--accent)', fontWeight: 500 }}>
+                          <span style={{ color: 'var(--accent-text)', fontWeight: 500 }}>
                             {' '}· available
                           </span>
                         )}

--- a/ui/src/screens/ClientObservability.tsx
+++ b/ui/src/screens/ClientObservability.tsx
@@ -565,7 +565,7 @@ function viewButtonStyle(active: boolean) {
   return {
     minHeight: 26, padding: '2px 9px', borderRadius: 5, cursor: 'pointer', fontSize: 11,
     border: `1px solid ${active ? 'var(--accent)' : 'var(--border-strong)'}`,
-    color: active ? 'var(--accent)' : 'var(--text-secondary)',
+    color: active ? 'var(--accent-text)' : 'var(--text-secondary)',
     background: active ? 'var(--accent-soft)' : 'var(--surface-2)',
   } as const
 }

--- a/ui/src/screens/Dashboard.trend.test.tsx
+++ b/ui/src/screens/Dashboard.trend.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Trend, WANMetric } from './Dashboard'
+
+describe('dashboard WAN trend', () => {
+  it('marks missing time without connecting across it and keeps isolated samples visible', () => {
+    const { container } = render(<Trend label="Download traffic" points={[
+      { ts: 0, value: 10 },
+      { ts: 1, value: null },
+      { ts: 2, value: 20 },
+      { ts: 3, value: 30 },
+      { ts: 4, value: null },
+      { ts: 5, value: 40 },
+    ]} />)
+
+    expect(screen.getByRole('img').getAttribute('aria-label')).toContain('4 available and 2 unavailable')
+    expect(container.querySelectorAll('.dashboard-trend-gap')).toHaveLength(2)
+    expect(container.querySelectorAll('.dashboard-trend-series')).toHaveLength(1)
+    expect(container.querySelectorAll('.dashboard-trend-point')).toHaveLength(2)
+  })
+
+  it('centres a flat series instead of making it look clipped at the bottom', () => {
+    const { container } = render(<Trend label="ICMP loss" points={[
+      { ts: 0, value: 0 },
+      { ts: 1, value: 0 },
+      { ts: 2, value: 0 },
+    ]} />)
+
+    expect(container.querySelector('.dashboard-trend-series')?.getAttribute('d'))
+      .toBe('M 0.0 19.0 L 90.0 19.0 L 180.0 19.0')
+  })
+
+  it('explains partial coverage beside the freshness note', () => {
+    render(<WANMetric label="Download traffic" format={(value) => `${value} bps`} metric={{
+      kind: 'download_bps',
+      unit: 'bps',
+      meaning: 'WAN download traffic',
+      status: 'fresh',
+      value: 30,
+      as_of: Date.now(),
+      points: [{ ts: 0, value: 10 }, { ts: 1, value: null }, { ts: 2, value: 30 }],
+    }} />)
+
+    expect(screen.getByText(/Updated .* · 1 missing/)).toBeTruthy()
+    expect(screen.getByRole('img').getAttribute('aria-label')).toContain('2 available and 1 unavailable')
+  })
+})

--- a/ui/src/screens/Dashboard.tsx
+++ b/ui/src/screens/Dashboard.tsx
@@ -8,6 +8,7 @@ import type {
   SpeedTestJob,
   TopologySnapshot,
 } from '../lib/api'
+import { eventLabel, ipv6RACondition } from '../lib/eventCondition'
 import { Banner, Button, Card, Notice, Stat, Status, Unknown } from '../components/ui'
 import { ago } from '../components/Chart'
 
@@ -48,43 +49,68 @@ function speedTestProvenance(value: string | null | undefined) {
     : value || 'Controller host/container'
 }
 
-function Trend({ label, points }: { label: string; points: DashboardMetricPoint[] }) {
+export function Trend({ label, points }: { label: string; points: DashboardMetricPoint[] }) {
   const observed = points.flatMap((point) => point.value == null ? [] : [point.value])
-  if (observed.length < 2) return null
+  if (observed.length === 0) return null
 
   const width = 180
   const height = 38
   const low = Math.min(...observed)
   const high = Math.max(...observed)
-  const span = high - low || 1
-  const segments: string[] = []
-  let current = ''
+  const span = high - low
+  const x = (index: number) => points.length === 1 ? width / 2 : (index / (points.length - 1)) * width
+  const y = (value: number) => span === 0
+    ? height / 2
+    : height - 2 - ((value - low) / span) * (height - 4)
+  const segments: Array<{ path: string; count: number; x: number; y: number }> = []
+  const gaps: Array<{ from: number; to: number }> = []
+  let current = { path: '', count: 0, x: 0, y: 0 }
+  let gapStart = -1
   points.forEach((point, index) => {
     if (point.value == null) {
-      if (current) segments.push(current)
-      current = ''
+      if (current.count) segments.push(current)
+      current = { path: '', count: 0, x: 0, y: 0 }
+      if (gapStart < 0) gapStart = index
       return
     }
-    const x = points.length === 1 ? 0 : (index / (points.length - 1)) * width
-    const y = height - 2 - ((point.value - low) / span) * (height - 4)
-    current += `${current ? ' L' : 'M'} ${x.toFixed(1)} ${y.toFixed(1)}`
+    if (gapStart >= 0) {
+      gaps.push({ from: gapStart, to: index - 1 })
+      gapStart = -1
+    }
+    const px = x(index)
+    const py = y(point.value)
+    current.path += `${current.path ? ' L' : 'M'} ${px.toFixed(1)} ${py.toFixed(1)}`
+    current.count++
+    current.x = px
+    current.y = py
   })
-  if (current) segments.push(current)
+  if (current.count) segments.push(current)
+  if (gapStart >= 0) gaps.push({ from: gapStart, to: points.length - 1 })
+
+  const gapX = (index: number) => Math.max(0, Math.min(width, x(index)))
+  const missing = points.length - observed.length
 
   return (
     <svg
       className="dashboard-trend"
       viewBox={`0 0 ${width} ${height}`}
       role="img"
-      aria-label={`${label} six-hour trend: ${observed.length} of ${points.length} five-minute buckets observed`}
+      aria-label={`${label} six-hour trend: ${observed.length} available and ${missing} unavailable five-minute samples${missing ? '; shaded bands mark unavailable samples' : ''}`}
       preserveAspectRatio="none"
     >
-      {segments.map((path, index) => <path key={index} d={path} />)}
+      {gaps.map(({ from, to }) => {
+        const left = gapX(from - 0.5)
+        const right = gapX(to + 0.5)
+        return <rect key={`${from}-${to}`} className="dashboard-trend-gap" x={left} width={right - left} height={height} />
+      })}
+      {segments.map((segment, index) => segment.count === 1
+        ? <circle key={index} className="dashboard-trend-point" cx={segment.x} cy={segment.y} r="2" />
+        : <path key={index} className="dashboard-trend-series" d={segment.path} />)}
     </svg>
   )
 }
 
-function WANMetric({
+export function WANMetric({
   label,
   metric,
   format,
@@ -94,6 +120,13 @@ function WANMetric({
   format: (value: number, unit?: string) => string
 }) {
   const available = metric?.value != null && metric.status !== 'unavailable'
+  const missing = metric?.points.filter((point) => point.value == null).length ?? 0
+  const note = [
+    metric?.status === 'fresh' && metric.as_of ? `Updated ${agoMilliseconds(metric.as_of)}` : '',
+    metric?.status === 'last_observed' && metric.as_of ? `Last observed ${agoMilliseconds(metric.as_of)}` : '',
+    !metric || metric.status === 'unavailable' ? 'Current value unavailable' : '',
+    missing ? `${missing} missing` : '',
+  ].filter(Boolean).join(' · ')
   return (
     <div className="dashboard-metric">
       <div className="dashboard-metric-label">{label}</div>
@@ -103,11 +136,7 @@ function WANMetric({
           : <Unknown why={metric?.meaning || 'the controller has no matching WAN telemetry'} />}
       </div>
       {metric && <Trend label={label} points={metric.points} />}
-      <div className="dashboard-metric-note">
-        {metric?.status === 'fresh' && metric.as_of ? `Updated ${agoMilliseconds(metric.as_of)}` : null}
-        {metric?.status === 'last_observed' && metric.as_of ? `Last observed ${agoMilliseconds(metric.as_of)}` : null}
-        {!metric || metric.status === 'unavailable' ? 'Current value unavailable' : null}
-      </div>
+      <div className="dashboard-metric-note">{note}</div>
     </div>
   )
 }
@@ -409,7 +438,8 @@ function InternetHealth({ data }: { data: DashboardData }) {
 
       <div className="dashboard-wan-footnote">
         Fixed-target ICMP to {wan?.target ?? 'an unavailable target'} measures reachability, not gateway uptime.
-        {' '}Traffic requires an exact default-route interface series key; gaps remain gaps.
+        {' '}Traffic charts appear only when telemetry matches the active default-route interface. Shaded spans are unavailable samples;
+        {' '}trend lines never bridge them.
         {wan?.as_of ? ` Evidence ${wan.freshness === 'fresh' ? 'updated' : 'last observed'} ${agoMilliseconds(wan.as_of)}.` : ''}
       </div>
     </Card>
@@ -758,25 +788,34 @@ export function Dashboard({
                   The feed is partial; open Logs for the complete record.
                 </Banner>
               )}
-              {alerts.slice(0, 8).map((e) => (
-                <div key={e.ID} style={{ display: 'flex', gap: 10, fontSize: 12 }}>
-                  <span
-                    style={{
-                      color:
-                        e.Severity === 'error'
-                          ? 'var(--critical)'
-                          : e.Severity === 'warning'
-                            ? 'var(--warning)'
-                            : 'var(--text-secondary)',
-                      minWidth: 58,
-                    }}
-                  >
-                    {e.Severity}
-                  </span>
-                  <span style={{ flex: 1 }}>{e.Event}</span>
-                  <span style={{ color: 'var(--text-muted)' }}>{ago(e.TS)}</span>
-                </div>
-              ))}
+              {alerts.slice(0, 8).map((e) => {
+                const condition = ipv6RACondition(e)
+                return (
+                  <div key={e.ID} style={{ display: 'flex', gap: 10, fontSize: 12 }}>
+                    <span
+                      style={{
+                        color:
+                          e.Severity === 'error'
+                            ? 'var(--critical)'
+                            : e.Severity === 'warning'
+                              ? 'var(--warning)'
+                              : 'var(--text-secondary)',
+                        minWidth: 58,
+                      }}
+                    >
+                      {e.Severity}
+                    </span>
+                    <span style={{ flex: 1 }}>
+                      {eventLabel(e)}
+                      {condition && (
+                        <> · {condition.occurrences.toLocaleString()} occurrence
+                          {condition.occurrences === 1 ? '' : 's'}</>
+                      )}
+                    </span>
+                    <span style={{ color: 'var(--text-muted)' }}>{ago(e.TS)}</span>
+                  </div>
+                )
+              })}
             </div>
           )}
         </Card>

--- a/ui/src/screens/Devices.tsx
+++ b/ui/src/screens/Devices.tsx
@@ -97,7 +97,7 @@ export function Devices({
       key: 'tier',
       header: 'Poll',
       render: (d) => (
-        <span style={{ color: d.tier === 'focused' ? 'var(--accent)' : undefined }}>
+        <span style={{ color: d.tier === 'focused' ? 'var(--accent-text)' : undefined }}>
           {d.quiesced ? 'paused (applying)' : (d.tier ?? d.poll_state)}
         </span>
       ),
@@ -1770,7 +1770,7 @@ function TakeoverBriefBlock({ deviceID, b, onNoted }: { deviceID: number; b: Bro
           border: 'none',
           padding: 0,
           marginTop: 2,
-          color: 'var(--accent)',
+          color: 'var(--accent-text)',
           cursor: 'pointer',
           font: 'inherit',
         }}

--- a/ui/src/screens/Logs.tsx
+++ b/ui/src/screens/Logs.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api } from '../lib/api'
 import type { Device, EventCursor, EventPage, EventRow } from '../lib/api'
+import { eventLabel, ipv6RACondition } from '../lib/eventCondition'
 import { Banner, Button, Card, DataGrid, FilterRail, Notice, PageHeader, useColumnPrefs } from '../components/ui'
 import type { Column } from '../components/ui'
 
@@ -142,6 +143,14 @@ export function Logs() {
     gaps: ['router log coverage was not reported by this controller response'],
   }
   const rows = page?.events ?? []
+  const ipv6RAConditions = rows.flatMap((event) => {
+    const condition = ipv6RACondition(event)
+    return condition ? [condition] : []
+  })
+  const ipv6RAOccurrences = ipv6RAConditions.reduce(
+    (total, condition) => total + condition.occurrences,
+    0,
+  )
   const clockSkew = scope === 'general'
     ? rows.find((event) => event.Source === 'openwrt-logd' && event.IngestedAt > 0 &&
         Math.abs(event.TS * 1000 - event.IngestedAt) >= 5 * 60_000)
@@ -191,7 +200,19 @@ export function Logs() {
       render: (e) => e.Category,
       sortBy: (e) => e.Category,
     },
-    { key: 'event', header: 'Event', render: (e) => e.Event, sortBy: (e) => e.Event },
+    {
+      key: 'event', header: 'Event',
+      render: (e) => {
+        const condition = ipv6RACondition(e)
+        return condition ? (
+          <span>
+            {eventLabel(e)} · {condition.occurrences.toLocaleString()} occurrence
+            {condition.occurrences === 1 ? '' : 's'}
+          </span>
+        ) : e.Event
+      },
+      sortBy: (e) => eventLabel(e),
+    },
     {
       key: 'device',
       header: 'Device',
@@ -225,7 +246,7 @@ export function Logs() {
       width: 76,
       required: true,
       render: (e) => (
-        <Button aria-label={`View event ${e.ID}: ${e.Event}`} onClick={(event) => {
+        <Button aria-label={`View event ${e.ID}: ${eventLabel(e)}`} onClick={(event) => {
           detailTrigger.current = event.currentTarget
           void openDetail(e)
         }}>View</Button>
@@ -234,15 +255,8 @@ export function Logs() {
   ]
 
   return (
-    <div
-      style={{
-        display: 'grid',
-        gridTemplateColumns: '190px 1fr',
-        gap: 14,
-        alignItems: 'start',
-      }}
-    >
-      <div style={{ gridColumn: '1 / -1' }}>
+    <div className="logs-page">
+      <div className="logs-page-header">
         <PageHeader
           title="Logs"
           purpose="Controller, router, and audit events with explicit source and time coverage."
@@ -265,7 +279,7 @@ export function Logs() {
           },
         ]}
       />
-      <div style={{ display: 'grid', gap: 12 }}>
+      <div className="logs-page-content">
         <Card
           title={`Events (${page == null ? '…' : page.total.toLocaleString()})`}
           actions={(
@@ -282,7 +296,7 @@ export function Logs() {
                     borderRadius: 6,
                     border: '1px solid var(--border-strong)',
                     color: scope === value ? '#fff' : 'var(--text-primary)',
-                    background: scope === value ? 'var(--accent)' : 'var(--surface-2)',
+                    background: scope === value ? 'var(--control-accent)' : 'var(--surface-2)',
                     cursor: 'pointer',
                   }}
                 >
@@ -346,6 +360,23 @@ export function Logs() {
               />
             </div>
           )}
+          {scope === 'general' && ipv6RAConditions.length > 0 && (
+            <div style={{ padding: '12px 12px 0' }}>
+              <Notice
+                tone="warning"
+                component="IPv6 router advertisements"
+                summary={(
+                  <div role="status">
+                    OpenWrt reported no usable IPv6 default route while sending router
+                    advertisements. This concerns IPv6 and does not indicate an IPv4 outage.
+                  </div>
+                )}
+                details={`${ipv6RAOccurrences.toLocaleString()} reported occurrence${ipv6RAOccurrences === 1 ? '' : 's'} ${ipv6RAOccurrences === 1 ? 'is' : 'are'} condensed into ${ipv6RAConditions.length} condition record${ipv6RAConditions.length === 1 ? '' : 's'} on this page. The original warning priority, message, first and latest source timestamps remain in event detail.`}
+                closedLabel="More information about this IPv6 warning"
+                openLabel="Hide IPv6 warning information"
+              />
+            </div>
+          )}
           <DataGrid
             tableLabel={`${scope === 'audit' ? 'Audit' : 'General'} events`}
             totalRows={page?.total}
@@ -370,17 +401,11 @@ export function Logs() {
             }
           />
           {page && (
-            <div
-              style={{
-                display: 'flex', alignItems: 'center', gap: 10, padding: '6px 12px',
-                borderTop: '1px solid var(--border)', fontSize: 11,
-                color: 'var(--text-secondary)',
-              }}
-            >
+            <div className="pager">
               <span className="num">
                 Page {history.length + 1} · {rows.length.toLocaleString()} rows · {page.total.toLocaleString()} matching
               </span>
-              <div style={{ flex: 1 }} />
+              <div className="pager-spacer" />
               <label style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
                 Rows
                 <select
@@ -529,7 +554,7 @@ function EventDetail({
       >
         <header style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12 }}>
           <h2 id="event-detail-title" style={{ margin: 0, fontSize: 15, flex: 1 }}>
-            {event ? `${event.Event} · event ${event.ID}` : 'Event detail'}
+            {event ? `${eventLabel(event)} · event ${event.ID}` : 'Event detail'}
           </h2>
           <Button onClick={onClose}>Close</Button>
         </header>

--- a/ui/src/screens/PolicyEngine.tsx
+++ b/ui/src/screens/PolicyEngine.tsx
@@ -373,7 +373,7 @@ function PolicyTabs({ value, onChange }: { value: Tab; onChange: (tab: Tab) => v
   }
 
   return (
-    <div role="tablist" aria-label="Policy Engine views" style={{
+    <div className="policy-tabs" role="tablist" aria-label="Policy Engine views" style={{
       display: 'flex', gap: 2, padding: 3, width: 'fit-content',
       background: 'var(--surface-1)', border: '1px solid var(--border)', borderRadius: 8,
     }}>
@@ -393,7 +393,7 @@ function PolicyTabs({ value, onChange }: { value: Tab; onChange: (tab: Tab) => v
           style={{
             minHeight: 30, padding: '0 13px', border: 0, borderRadius: 6,
             cursor: 'pointer', fontSize: 12, fontWeight: 600,
-            color: value === tab.id ? 'var(--accent)' : 'var(--text-secondary)',
+            color: value === tab.id ? 'var(--accent-text)' : 'var(--text-secondary)',
             background: value === tab.id ? 'var(--accent-soft)' : 'transparent',
           }}
         >
@@ -1080,7 +1080,7 @@ function ObjectsPanel({
         <div style={{ display: 'grid', gap: 14 }}>
           <div>
             <div style={stepTitleStyle}>1 · Choose objects</div>
-            <div style={{ display: 'grid', gridTemplateColumns: 'minmax(130px, .55fr) minmax(220px, 1.45fr) auto', gap: 8, alignItems: 'end' }}>
+            <div className="policy-object-picker">
               <SelectField label="Object type" value={objectKind} disabled={compiling} onChange={(value) => setObjectKind(value as PolicyObjectTarget['kind'])}>
                 <option value="device">Client device</option>
                 <option value="group">Client group</option>
@@ -1170,7 +1170,7 @@ function ObjectsPanel({
               </div>
             )}
             {outcomes.includes('route') && (
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 120px', gap: 8, marginTop: 10 }}>
+              <div className="policy-route-fields">
                 <Field label="Route target" placeholder="10.40.0.0/16" disabled={compiling} value={routeTarget} onChange={(event) => setRouteTarget(event.target.value)} />
                 <Field label="Next-hop IPv4" placeholder="192.168.20.2" disabled={compiling} value={routeGateway} onChange={(event) => setRouteGateway(event.target.value)} />
                 <Field label="Metric" type="number" min={0} max={65535} disabled={compiling} value={routeMetric} onChange={(event) => setRouteMetric(numberValue(event.target.value))} />
@@ -1218,7 +1218,7 @@ function ObjectsPanel({
                     <strong style={{ fontSize: 13 }}>{policy.name}</strong>
                     <div style={hintStyle}>{kindLabel(policy.kind)} · {originLabel(policy.origin)} · {policy.enabled ? 'enabled' : 'disabled'}</div>
                   </div>
-                  <Pill colour="var(--accent)">Draft</Pill>
+                  <Pill colour="var(--accent-text)">Draft</Pill>
                 </div>
                 {policy.kind === 'firewall_rule' && policy.firewall && (
                   <div style={{ color: 'var(--text-secondary)', fontSize: 12 }}>
@@ -1258,7 +1258,7 @@ function ObjectsPanel({
           It affects new routed flows; existing conntrack sessions may continue until expiry.
         </div>
         {clients && clients.length > 0 && (
-          <div style={{ display: 'grid', gridTemplateColumns: 'minmax(240px, 1fr) auto', gap: 8, alignItems: 'end' }}>
+          <div className="policy-client-picker">
             <SelectField
               label={clientsCoverage ? 'Client (partial client inventory)' : 'Client'}
               value={clientChoice}
@@ -1781,7 +1781,7 @@ const tableActionStyle = {
   border: '1px solid var(--border-strong)',
   borderRadius: 5,
   background: 'var(--surface-2)',
-  color: 'var(--accent)',
+  color: 'var(--accent-text)',
   cursor: 'pointer',
   fontSize: 11,
   fontWeight: 600,

--- a/ui/src/screens/Radios.test.tsx
+++ b/ui/src/screens/Radios.test.tsx
@@ -40,6 +40,7 @@ const response: RadiosResponse = {
         { band: '5g', channel: 36, mhz: 5180, state: 'in-use', availability: 'enabled', in_use: true, restricted: false, dfs: null, excluded: null, flags: [] },
         { band: '5g', channel: 44, mhz: 5220, state: 'enabled', availability: 'enabled', in_use: false, restricted: false, dfs: null, excluded: null, flags: [] },
         { band: '5g', channel: 52, mhz: 5260, state: 'restricted', availability: 'restricted', in_use: false, restricted: true, dfs: null, excluded: null, flags: ['NO-IR'] },
+        { band: '5g', channel: 60, mhz: 5300, state: 'unknown', availability: 'unknown', in_use: false, restricted: false, dfs: null, excluded: null, flags: [] },
       ],
       scan_capability: 'present',
       latest_observations: [],
@@ -69,7 +70,7 @@ describe('Radios', () => {
     expect((await screen.findAllByText('Gateway AP')).length).toBeGreaterThan(0)
     expect(screen.getAllByText('radio0').length).toBeGreaterThan(0)
     const classification = screen.getByRole('group', { name: 'Warning: Channel classification' })
-    expect(within(classification).getByText(/DFS and channel exclusions are unknown here/i)).toBeTruthy()
+    expect(within(classification).getByText(/cannot prove which restricted channels require DFS/i)).toBeTruthy()
     const classificationToggle = within(classification).getByText('More information about channel classification')
     const classificationDetails = classificationToggle.closest('details')
     expect(classificationDetails?.open).toBe(false)
@@ -77,7 +78,13 @@ describe('Radios', () => {
     expect(classificationDetails?.open).toBe(true)
     expect(within(classification).getByText(/freqlist\.restricted/)).toBeTruthy()
     const plan = screen.getByRole('list', { name: /Channel plan for 1 radios/ })
-    expect(within(plan).getByLabelText('Channel 52, restricted, DFS unknown, exclusion unknown')).toBeTruthy()
+    for (const [channel, state] of [['36', 'in-use'], ['52', 'restricted'], ['60', 'unknown']] as const) {
+      const tile = plan.querySelector(`.radio-channel[data-state="${state}"]`)!
+      expect(tile.getAttribute('aria-label')).toContain(`Channel ${channel},`)
+      expect(tile.querySelector(`.radio-state-mark[data-state="${state}"]`)).toBeTruthy()
+    }
+    const legend = screen.getByLabelText('Channel Plan legend')
+    expect(legend.querySelectorAll('.radio-state-mark')).toHaveLength(4)
 
     const table = screen.getByRole('table', { name: 'Per-radio observability' })
     await waitFor(() => expect(within(table).getByText('23.4%')).toBeTruthy())

--- a/ui/src/screens/Radios.tsx
+++ b/ui/src/screens/Radios.tsx
@@ -25,13 +25,6 @@ const metricFreshnessSeconds = 15 * 60
 const metricQueryBoundaryAllowanceSeconds = 5 * 60
 const metricRefreshMilliseconds = 5 * 60 * 1000
 
-const stateColours: Record<RadioChannel['state'], string> = {
-  'in-use': 'var(--accent)',
-  enabled: 'var(--good)',
-  restricted: 'var(--warning)',
-  unknown: 'var(--text-muted)',
-}
-
 const radioID = (deviceID: number, key: string) => `${deviceID}/${key}`
 
 export function Radios() {
@@ -231,7 +224,7 @@ export function Radios() {
       )}
       <Notice
         component="Channel classification"
-        summary="DFS and channel exclusions are unknown here; restricted channels remain labelled Restricted."
+        summary="The controller cannot prove which restricted channels require DFS, so it labels them Restricted rather than guessing."
         closedLabel="More information about channel classification"
         openLabel="Hide channel classification information"
         details={(
@@ -242,31 +235,31 @@ export function Radios() {
         )}
       />
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,minmax(0,1fr))', gap: 10 }}>
+      <div className="radio-stat-grid">
         <Card><Stat label="Radios" value={data == null ? '—' : rows.length} /></Card>
         <Card><Stat label="Known channel plans" value={data == null ? '—' : `${knownPlans}/${rows.length}`} tone={data != null && knownPlans === rows.length ? 'good' : 'warning'} /></Card>
-        <Card><Stat label="Reported channels" value={data == null ? '—' : channels} sub="Restricted is not relabelled as DFS" /></Card>
+        <Card><Stat label="Reported channels" value={data == null ? '—' : channels} sub="DFS status is not inferred." /></Card>
       </div>
 
       <Card title="Channel Plan" actions={(
-        <div aria-label="Channel Plan legend" style={{ display: 'flex', gap: 10, fontSize: 11, color: 'var(--text-secondary)' }}>
+        <div aria-label="Channel Plan legend" className="card-inline-legend">
           {(['in-use', 'enabled', 'restricted', 'unknown'] as const).map((state) => (
             <span key={state} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
-              <i aria-hidden style={{ width: 9, height: 9, borderRadius: 2, background: stateColours[state] }} />
+              <i aria-hidden className="radio-state-mark" data-state={state} />
               {state === 'in-use' ? 'In use' : state[0].toUpperCase() + state.slice(1)}
             </span>
           ))}
         </div>
       )}>
-        <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
-          <label style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+        <div className="radio-plan-filters">
+          <label>
             Access point{' '}
             <select aria-label="Filter by access point" value={deviceFilter} onChange={(e) => setDeviceFilter(e.target.value)}>
               <option value="all">All</option>
               {data?.devices.map((device) => <option key={device.device_id} value={device.device_id}>{device.name}</option>)}
             </select>
           </label>
-          <label style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+          <label>
             Band{' '}
             <select aria-label="Filter by band" value={bandFilter} onChange={(e) => setBandFilter(e.target.value)}>
               <option value="all">All</option><option value="2g">2.4 GHz</option><option value="5g">5 GHz</option><option value="6g">6 GHz</option>
@@ -276,7 +269,7 @@ export function Radios() {
         {rows.length > 0 ? (
           <div role="list" aria-label={`Channel plan for ${rows.length} radios`} style={{ display: 'grid', gap: 10 }}>
             {rows.map((row) => (
-              <div role="listitem" key={radioID(row.deviceID, row.radio.radio_key)} style={{ display: 'grid', gridTemplateColumns: '160px 1fr', gap: 10, alignItems: 'center' }}>
+              <div role="listitem" className="radio-plan-row" key={radioID(row.deviceID, row.radio.radio_key)}>
                 <div style={{ fontSize: 12 }}>
                   <strong>{row.deviceName}</strong><br />
                   <span style={{ color: 'var(--text-secondary)' }}>{row.radio.radio_key} · {bandName(row.radio.band)}</span>
@@ -289,12 +282,15 @@ export function Radios() {
                     {row.radio.channels.map((channel) => (
                       <span
                         role="listitem"
+                        className="radio-channel"
+                        data-state={channel.state}
                         key={`${channel.channel}/${channel.mhz}`}
                         title={channelLabel(channel, true)}
                         aria-label={channelLabel(channel, false)}
-                        style={{ width: 34, height: 28, display: 'inline-grid', placeItems: 'center', borderRadius: 4,
-                          background: stateColours[channel.state], color: channel.state === 'enabled' ? '#07140d' : '#fff', fontSize: 11, fontWeight: 600 }}
-                      >{channel.channel}</span>
+                      >
+                        {channel.channel}
+                        <i aria-hidden className="radio-state-mark" data-state={channel.state} />
+                      </span>
                     ))}
                   </div>
                 ) : <span style={{ color: 'var(--text-muted)', fontSize: 12 }}>Channel list unavailable</span>}

--- a/ui/src/screens/Settings.tsx
+++ b/ui/src/screens/Settings.tsx
@@ -889,7 +889,7 @@ function WLANRow({
         borderTop: '1px solid var(--border)',
       }}
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontSize: 13, fontWeight: 600 }}>
             {w.ssid}
@@ -929,7 +929,7 @@ function WLANRow({
                 Delete <strong>{w.ssid}</strong> from desired state? No router changes until
                 you Preview and Apply.
               </span>
-              <div style={{ display: 'flex', gap: 8 }}>
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
                 <Button
                   disabled={deleting}
                   onClick={async () => {
@@ -1227,7 +1227,7 @@ function WLANEditor({
           />
         </div>
 
-        <div style={{ display: 'flex', gap: 8 }}>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
           <Button kind="primary" disabled={saving || !draft.ssid} onClick={save}>
             {saving ? 'Saving…' : 'Save'}
           </Button>
@@ -1304,13 +1304,14 @@ function Groups({
     <Card
       title="AP groups"
       actions={
-        <div style={{ display: 'flex', gap: 6 }}>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', maxWidth: '100%' }}>
           <input
             aria-label="New AP group name"
             value={name}
             placeholder="new group"
             onChange={(e) => setName(e.target.value)}
             style={{
+              maxWidth: '100%',
               height: 26,
               padding: '0 8px',
               borderRadius: 4,
@@ -1996,7 +1997,7 @@ function NetworkEditor({
           </Card>
         )}
 
-        <div style={{ display: 'flex', gap: 8 }}>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
           <Button disabled={
             !dirty || busy || !draft.name.trim() || !!addressWarning || !!dhcpWarning
           } onClick={save}>
@@ -2555,8 +2556,8 @@ function MeshRow({
         borderTop: '1px solid var(--border)',
       }}
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-        <div style={{ flex: 1 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontSize: 13, fontWeight: 600 }}>
             {m.mesh_id}
             {!m.enabled && (
@@ -2598,7 +2599,7 @@ function MeshRow({
                 Delete <strong>{m.mesh_id}</strong> from desired state? No router changes
                 until you Preview and Apply.
               </span>
-              <div style={{ display: 'flex', gap: 8 }}>
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
                 <Button
                   disabled={deleting}
                   onClick={async () => {
@@ -2749,7 +2750,7 @@ function MeshEditor({
           A mesh point is an extra interface, not a different kind of device.
         </div>
 
-        <div style={{ display: 'flex', gap: 8 }}>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
           <Button kind="primary" onClick={save} disabled={saving || !(draft.mesh_id ?? '').trim()}>
             {saving ? 'Saving…' : 'Save'}
           </Button>
@@ -2941,6 +2942,7 @@ function NeighbourDeviceRow({ d }: { d: NeighbourDevice }) {
           key={b.iface}
           style={{
             display: 'flex',
+            flexWrap: 'wrap',
             gap: 8,
             marginTop: 3,
             color: b.failed ? 'var(--critical)' : 'var(--text-secondary)',
@@ -3045,7 +3047,7 @@ function MeshLinkRow({ l }: { l: MeshLink }) {
         fontSize: 12,
       }}
     >
-      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
         <span style={{ fontWeight: 600 }}>
           {l.name}{' '}
           <span style={{ fontWeight: 400, color: 'var(--text-muted)' }}>
@@ -3181,6 +3183,7 @@ function Uplinks({
                 padding: '6px 8px',
                 fontSize: 12,
                 display: 'flex',
+                flexWrap: 'wrap',
                 justifyContent: 'space-between',
                 alignItems: 'center',
                 gap: 8,

--- a/ui/src/screens/Topology.tsx
+++ b/ui/src/screens/Topology.tsx
@@ -594,7 +594,7 @@ export function Topology({ onReviewCapabilities }: { onReviewCapabilities?: () =
         </Banner>
       )}
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 10 }}>
+      <div className="topology-stat-grid">
         <Card><Stat label="Nodes" value={data?.nodes.length ?? '—'} /></Card>
         <Card><Stat label={mode === 'current' ? 'Active links' : 'Link intervals'} value={data?.edges.length ?? '—'} /></Card>
         <Card>
@@ -612,7 +612,7 @@ export function Topology({ onReviewCapabilities }: { onReviewCapabilities?: () =
           ? 'Current infrastructure'
           : `Infrastructure at ${historyAt ? when(historyAt) : 'selected time'}`}
         actions={(
-          <div aria-label="Topology confidence legend" style={{ display: 'flex', gap: 10, fontSize: 11, color: 'var(--text-secondary)' }}>
+          <div aria-label="Topology confidence legend" className="card-inline-legend">
             <ConfidenceLegendItem confidence="measured" />
             <ConfidenceLegendItem confidence="inferred" />
             <ConfidenceLegendItem confidence="ambiguous" />

--- a/ui/src/screens/screens.test.tsx
+++ b/ui/src/screens/screens.test.tsx
@@ -4402,6 +4402,41 @@ describe('Logs', () => {
     expect(screen.queryByText(/will not rewrite/)).toBeNull()
   })
 
+  it('explains and condenses the known IPv6 router-advertisement condition', async () => {
+	api.devices.mockResolvedValue({ devices: [] })
+	api.events.mockResolvedValue({
+	  events: [ev({
+		Event: 'openwrt.ipv6_ra_no_default_route',
+		Severity: 'warning',
+		Source: 'openwrt-logd',
+		Detail: {
+		  message: 'odhcpd[81]: No default route present, setting ra_lifetime to 0!',
+		  priority: 28,
+		  occurrences: 37,
+		},
+	  })],
+	  total: 1,
+	  limit: 100,
+	  scope: 'general',
+	  next_before: null,
+	  facets: { category: [], severity: [] },
+	  coverage: { complete: true, expected_devices: 1, observed_devices: 1, gaps: [] },
+	})
+
+	render(<Logs />)
+
+	expect(await screen.findByText(/IPv6 router advertisements have no usable default route · 37 occurrences/)).toBeTruthy()
+	const notice = screen.getByRole('group', { name: 'Warning: IPv6 router advertisements' })
+	expect(within(notice).getByRole('status').textContent ?? '').toMatch(
+	  /does not indicate an IPv4 outage/i,
+	)
+	const toggle = within(notice).getByText('More information about this IPv6 warning')
+	const details = toggle.closest('details') as HTMLDetailsElement
+	expect(details.open).toBe(false)
+	fireEvent.click(toggle)
+	expect(within(notice).getByText(/37 reported occurrences.*1 condition record/i)).toBeTruthy()
+  })
+
   it('never renders an out-of-order response under newer filters', async () => {
     vi.useFakeTimers()
     api.devices.mockResolvedValue({ devices: [] })
@@ -4813,6 +4848,23 @@ describe('Dashboard', () => {
     expect(screen.queryByText('routine.activity')).toBeNull()
     expect(screen.queryByText('invalid.alert')).toBeNull()
     expect(screen.getByText(/1 alert row had an unrecognized severity/)).toBeTruthy()
+  })
+
+  it('renders the coalesced IPv6 condition without hiding its warning severity', async () => {
+    const { Dashboard } = await import('./Dashboard')
+    render(<Dashboard data={{
+      ...data,
+      recent_alert_events: [{
+        ID: 44,
+        TS: Date.now() / 1000,
+        Severity: 'warning',
+        Event: 'openwrt.ipv6_ra_no_default_route',
+        Detail: { occurrences: 220 },
+      }],
+    } as never} />)
+
+    const row = screen.getByText(/IPv6 router advertisements have no usable default route/).parentElement
+    expect(row?.textContent).toMatch(/warning.*220 occurrences/i)
   })
 
   it('distinguishes a confirmed-empty alert feed from unavailable evidence', async () => {


### PR DESCRIPTION
## Summary

- condense repeated IPv6 RA warnings into one evidence-preserving condition and harden event/audit storage bounds
- make dashboard trend gaps truthful and improve dashboard warning wording
- repair responsive layout, contrast, and non-colour state cues across Logs, Settings, Policy, Radios, Topology, Clients, and shared controls
- add unit and browser regressions for narrow layouts, both themes, keyboard disclosure, and contrast

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./internal/store ./internal/daemon ./internal/reconcile ./internal/telemetry -count=1`
- `npm --prefix ui test` (378 tests)
- `CI=1 npm --prefix ui run test:browser` (11 tests)
- `npm --prefix ui run build`
- `./tools/budget_check.sh` (188 KB / 1536 KB)
- `npm --prefix ui audit --audit-level=high`
- tree and history secret scans
- live schema-19 health, integrity, event-compaction, and embedded-asset smoke checks