### PR TITLE
fix(dashboard): repair WAN health charts and polling

### DIFF
--- a/docs/UI-SPEC.md
+++ b/docs/UI-SPEC.md
@@ -49,10 +49,13 @@ its public artifacts.
 All durable Phase-4 data is REST; the WebSocket supplies only `device.stats`
 focus/current updates.
 
-**v0.1.0 UI source and historical live checkpoint:** schema-19 source renders the polished WAN
-health and controller-speed-test cards. WAN charts use server-selected six-hour
-fixed-target ICMP and exact-interface throughput evidence with null gaps and
-freshness. The speed-test review shows controller-host vantage point, Cloudflare
+**Current schema-19 UI and historical live checkpoint:** the post-`v0.1.0` source
+renders equal-height WAN-health and controller-speed-test cards. Internet health
+shows the observed gateway, default-route interface and fixed-target probe as
+separate evidence, then plots server-selected six-hour throughput, latency and
+loss as zero-based five-minute activity columns. Missing buckets remain missing
+and appear only in a thin coverage rail; a table toggle exposes every aligned sample.
+The speed-test review shows controller-host vantage point, Cloudflare
 endpoint, single-stream method, 15 MiB estimate, 30-second limit, privacy and
 saturation before consent; Start binds a fresh acknowledgement to the reviewed
 `plan_id`, then shows progress/cancel and bounded history as paired

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -1362,16 +1362,21 @@ func (p *poller) succeed(snap Snapshot) {
 	}
 
 	// Evidence-based backoff, DEVICE-BUDGET §4.5. Widen on the device's own
-	// symptoms — its load average, or how long it took to answer us — and
+	// symptoms — its load average, or how long its non-paced work took — and
 	// recover one step at a time so a device sitting near the threshold does not
 	// flip rates every interval.
+	busyDuration := snap.Duration
+	if snap.busyDurationKnown {
+		busyDuration = snap.busyDuration
+	}
 	switch {
-	case snap.Load[0] >= p.c.opts.LoadLimit, snap.Duration >= p.c.opts.SlowPoll:
+	case snap.Load[0] >= p.c.opts.LoadLimit, busyDuration >= p.c.opts.SlowPoll:
 		if p.widen < maxWiden {
 			p.widen++
 			p.c.log.Info("widening poll interval; the device reports it is busy",
 				"device", snap.MAC, "load1", snap.Load[0],
-				"poll_ms", snap.Duration.Milliseconds(), "step", p.widen)
+				"poll_ms", snap.Duration.Milliseconds(),
+				"busy_ms", busyDuration.Milliseconds(), "step", p.widen)
 		}
 	case p.widen > 0:
 		p.widen--

--- a/internal/collector/poll.go
+++ b/internal/collector/poll.go
@@ -27,6 +27,10 @@ const loadScale = 65536.0
 type call struct {
 	inv    ubus.Invocation
 	decode func(json.RawMessage, *Snapshot) error
+	// adaptiveWait is deterministic elapsed time deliberately spent inside the
+	// call. It remains part of Snapshot.Duration for diagnostics, but is not
+	// evidence that the router itself needs a slower polling interval.
+	adaptiveWait time.Duration
 	// radioInventory marks the optional getWirelessDevices source. Its outcome
 	// is tracked independently from system.info: a healthy device poll does not
 	// make a denied radio refresh current.
@@ -44,6 +48,17 @@ type call struct {
 	// optional marks a call whose failure degrades the snapshot rather than
 	// meaning the device is unreachable.
 	optional bool
+}
+
+// setBusyDuration removes only waits whose result decoded successfully from the
+// duration used by adaptive backoff. The total Snapshot.Duration is unchanged.
+func (snap *Snapshot) setBusyDuration(completedWait time.Duration) {
+	busy := snap.Duration - completedWait
+	if busy < 0 {
+		busy = 0
+	}
+	snap.busyDuration = busy
+	snap.busyDurationKnown = true
 }
 
 func degradationCause(err error, status ubus.Status) DegradationCause {
@@ -142,6 +157,7 @@ func (p *poller) poll(ctx context.Context, c *ubus.Client, target Target, tier T
 			len(results), len(calls))
 		return snap
 	}
+	var completedWait time.Duration
 
 	for i, res := range results {
 		spec := calls[i]
@@ -185,12 +201,14 @@ func (p *poller) poll(ctx context.Context, c *ubus.Client, target Target, tier T
 				return snap
 			}
 		} else {
+			completedWait += spec.adaptiveWait
 			snap.topologyAnswered(spec.topologySource)
 			if spec.assocIface != "" {
 				snap.AssocAnswered[spec.assocIface] = true
 			}
 		}
 	}
+	snap.setBusyDuration(completedWait)
 	// Decided by the ANSWERS, not by the intent.
 	//
 	// Having a current interface list is necessary and not sufficient. The

--- a/internal/collector/snapshot.go
+++ b/internal/collector/snapshot.go
@@ -41,6 +41,11 @@ type Snapshot struct {
 	At       time.Time
 	Duration time.Duration
 
+	// busyDuration excludes deliberate call pacing only for adaptive backoff.
+	// Duration above remains the complete externally visible diagnostic.
+	busyDuration      time.Duration
+	busyDurationKnown bool
+
 	// Err is set when the poll as a whole failed — unreachable, not logged in,
 	// transport error. Every other field is then meaningless.
 	Err error

--- a/internal/collector/wanprobe.go
+++ b/internal/collector/wanprobe.go
@@ -75,6 +75,9 @@ func wanProbeCall() call {
 			},
 		}},
 		decode: decodeWANProbe, optional: true,
+		// BusyBox ping spaces three sends one second apart. That fixed two-second
+		// cadence measures the WAN, not router pressure.
+		adaptiveWait: time.Duration(wanProbePackets-1) * time.Second,
 	}
 }
 

--- a/internal/collector/wanprobe_poll_test.go
+++ b/internal/collector/wanprobe_poll_test.go
@@ -48,8 +48,10 @@ func TestWANProbeUsesExactGatewayOnlyLowCadenceCall(t *testing.T) {
 				continue
 			}
 			got++
-			if !spec.optional || !reflect.DeepEqual(args["params"], wantParams) {
-				t.Fatalf("WAN call optional=%v args=%#v", spec.optional, spec.inv.Args)
+			if !spec.optional || spec.adaptiveWait != 2*time.Second ||
+				!reflect.DeepEqual(args["params"], wantParams) {
+				t.Fatalf("WAN call optional=%v adaptive wait=%v args=%#v",
+					spec.optional, spec.adaptiveWait, spec.inv.Args)
 			}
 		}
 		if got != want {
@@ -75,6 +77,58 @@ func TestWANProbeUsesExactGatewayOnlyLowCadenceCall(t *testing.T) {
 	p.mu.Unlock()
 	now = now.Add(wanProbeInterval)
 	assert(p.buildCalls(Baseline, []string{"phy0-ap0"}, map[string]string{"phy0-ap0": "ap"}), 0)
+}
+
+func TestGatewayProbePacingIsExcludedFromAdaptiveWidening(t *testing.T) {
+	c := New(newRecorder(), Options{
+		Baseline: time.Second, MaxInterval: time.Hour,
+		SlowPoll: DefaultSlowPoll, LoadLimit: DefaultLoadLimit, Log: quiet(),
+	})
+	p := newPoller(c, Target{DeviceID: 1, MAC: "aa", Gateway: true})
+	probeWait := wanProbeCall().adaptiveWait
+
+	snapshot := func(total, completedWait time.Duration) Snapshot {
+		t.Helper()
+		snap := Snapshot{Duration: total}
+		snap.setBusyDuration(completedWait)
+		return snap
+	}
+
+	clamped := snapshot(time.Second, probeWait)
+	if !clamped.busyDurationKnown || clamped.busyDuration != 0 {
+		t.Fatalf("busy duration below fixed pacing = %v known=%v, want 0 true",
+			clamped.busyDuration, clamped.busyDurationKnown)
+	}
+
+	ordinary := snapshot(2*time.Second+200*time.Millisecond, probeWait)
+	p.succeed(ordinary)
+	if ordinary.Duration != 2200*time.Millisecond {
+		t.Fatalf("diagnostic duration changed to %v", ordinary.Duration)
+	}
+	if ordinary.busyDuration != 200*time.Millisecond || p.widen != 0 {
+		t.Fatalf("ping plus normal core work: busy=%v widen=%d, want 200ms and 0",
+			ordinary.busyDuration, p.widen)
+	}
+
+	slow := snapshot(2*time.Second+1600*time.Millisecond, probeWait)
+	p.succeed(slow)
+	if slow.busyDuration != 1600*time.Millisecond || p.widen != 1 {
+		t.Fatalf("ping plus unexplained overhead: busy=%v widen=%d, want 1.6s and 1",
+			slow.busyDuration, p.widen)
+	}
+
+	// An RPC response is not enough: only a valid decoded ping result proves
+	// that the request spent the expected two seconds pacing packets.
+	p.widen = 0
+	invalid := snapshot(2*time.Second+200*time.Millisecond, 0)
+	if err := wanProbeCall().decode([]byte(`{"code":2,"stdout":"","stderr":"bad option"}`), &invalid); err == nil {
+		t.Fatal("invalid ping unexpectedly decoded")
+	}
+	p.succeed(invalid)
+	if invalid.busyDuration != 2200*time.Millisecond || p.widen != 1 {
+		t.Fatalf("invalid ping: busy=%v widen=%d, want full 2.2s and 1",
+			invalid.busyDuration, p.widen)
+	}
 }
 
 func TestAPOnlyTargetNeverSchedulesWANProbe(t *testing.T) {

--- a/ui/e2e/desktop.spec.ts
+++ b/ui/e2e/desktop.spec.ts
@@ -1,5 +1,29 @@
 import { expect, test, type Locator, type Page } from '@playwright/test'
 
+const dashboardObservedAt = Date.now() - 240_000
+const dashboardTimes = Array.from(
+  { length: 72 },
+  (_, index) => dashboardObservedAt - (71 - index) * 300_000,
+)
+
+function wanMetric(
+  kind: string,
+  unit: string,
+  value: number | null,
+  samples: Array<number | null>,
+  status: 'fresh' | 'last_observed' | 'unavailable' = 'fresh',
+) {
+  return {
+    kind,
+    unit,
+    meaning: `${kind} from the selected default-route interface`,
+    status,
+    value,
+    as_of: value == null ? null : dashboardObservedAt,
+    points: samples.map((sample, index) => ({ ts: dashboardTimes[index], value: sample })),
+  }
+}
+
 const dashboard = {
   devices: { total: 2, online: 2, offline: 0, pending: 0, unknown: 0 },
   wireless_clients: 1,
@@ -19,6 +43,32 @@ const dashboard = {
     Severity: 'warning',
     Event: 'fixture.warning',
   }],
+  wan: {
+    target: '1.1.1.1',
+    probe: 'icmp',
+    freshness: 'fresh',
+    as_of: dashboardObservedAt,
+    gateway: { device_id: 1, name: 'Gateway', route_interface: 'wan', series_key: 'wan' },
+    resolution: '5m',
+    bucket_ms: 300_000,
+    from: dashboardTimes[0],
+    to: dashboardTimes.at(-1),
+    metrics: {
+      download_bps: wanMetric('site_wan_download_bps', 'B/s', 13_125,
+        dashboardTimes.map((_, index) => index % 17 === 0
+          ? null
+          : index % 23 === 0 ? 0 : 12_000 + (index % 9) * 450)),
+      upload_bps: wanMetric('site_wan_upload_bps', 'B/s', 66.75,
+        dashboardTimes.map((_, index) => index % 19 === 7
+          ? null
+          : index % 29 === 0 ? 0 : 62 + (index % 8) * 1.25)),
+      latency_ms: wanMetric('site_wan_latency_ms', 'ms', 22,
+        dashboardTimes.map((_, index) => index % 31 === 4 ? null : 21 + (index % 8) * .2)),
+      loss_pct: wanMetric('site_wan_loss_pct', 'percent', 0,
+        dashboardTimes.map((_, index) => index % 31 === 5 ? null : index === 20 ? 1.2 : 0)),
+      reachable: wanMetric('site_wan_reachable', 'boolean', 1, []),
+    },
+  },
 }
 
 const topology = {
@@ -326,6 +376,25 @@ for (const viewport of [{ width: 1280, height: 720 }, { width: 1440, height: 900
       await expect(page.getByText('fixture.warning')).toBeVisible()
       await expect(page.getByText('Complete coverage')).toBeVisible()
 
+      const health = page.getByRole('region', { name: 'Internet health details' })
+      const healthCharts = health.locator('.dashboard-wan-metrics')
+      await expect(healthCharts.getByRole('img')).toHaveCount(4)
+      await expect(page.getByLabel(/Throughput history for 2 completed tests/)).toBeVisible()
+      expect(await healthCharts.evaluate((element) =>
+        getComputedStyle(element).gridTemplateColumns.split(/\s+/).length)).toBe(2)
+      const operationCards = page.locator('.dashboard-operations-grid > section')
+      await expect(operationCards).toHaveCount(2)
+      const cardHeights = await operationCards.evaluateAll((cards) =>
+        cards.map((card) => card.getBoundingClientRect().height))
+      expect(Math.abs(cardHeights[0] - cardHeights[1])).toBeLessThanOrEqual(1)
+
+      const healthView = health.getByRole('group', { name: 'Internet health history view' })
+      await healthView.getByRole('button', { name: 'Table' }).click()
+      const healthTable = health.getByRole('region', { name: 'Internet health history table' })
+      await expect(healthTable.getByRole('row')).toHaveCount(73)
+      await expectWithinMain(page, healthTable)
+      await healthView.getByRole('button', { name: 'Chart' }).click()
+
       const overflow = await readOverflow(page)
       expect(overflow.document).toBeLessThanOrEqual(1)
       expect(overflow.main).toBeLessThanOrEqual(1)
@@ -485,6 +554,13 @@ test('320px narrow dashboard, Logs pager, and Channel Plan do not clip', async (
 
   await page.goto('/')
   await expect(page.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeVisible()
+  const health = page.getByRole('region', { name: 'Internet health details' })
+  await expect(health.getByRole('img')).toHaveCount(4)
+  await expectWithinMain(page, health)
+  const healthView = health.getByRole('group', { name: 'Internet health history view' })
+  await healthView.getByRole('button', { name: 'Table' }).click()
+  await expectWithinMain(page, health.getByRole('region', { name: 'Internet health history table' }))
+  await healthView.getByRole('button', { name: 'Chart' }).click()
   const speedChart = page.getByLabel(/Throughput history for 2 completed tests/)
   await expect(speedChart).toBeVisible()
   await expectWithinMain(page, speedChart)
@@ -502,9 +578,10 @@ test('320px narrow dashboard, Logs pager, and Channel Plan do not clip', async (
   const lastTooltip = page.getByRole('tooltip').filter({ hasText: 'Upload 412.4 Mbps' })
   await expect(lastTooltip).toBeVisible()
   await expectWithinMain(page, lastTooltip)
-  await page.getByRole('button', { name: 'Table' }).click()
+  const speedView = page.getByRole('group', { name: 'Speed test history view' })
+  await speedView.getByRole('button', { name: 'Table' }).click()
   await expectWithinMain(page, page.getByRole('region', { name: 'Speed test result table' }))
-  await page.getByRole('button', { name: 'Chart' }).click()
+  await speedView.getByRole('button', { name: 'Chart' }).click()
   let overflow = await readOverflow(page)
   expect(overflow.document).toBeLessThanOrEqual(1)
   expect(overflow.main).toBeLessThanOrEqual(1)
@@ -547,6 +624,14 @@ for (const theme of ['dark', 'light'] as const) {
     for (const state of ['in-use', 'enabled', 'restricted', 'unknown']) {
       expect(await contrastRatio(page.locator(`.radio-channel[data-state="${state}"]`))).toBeGreaterThanOrEqual(4.5)
     }
+
+    await page.goto('/')
+    const health = page.getByRole('region', { name: 'Internet health details' })
+    await expect(health.getByRole('img')).toHaveCount(4)
+    await expectWithinMain(page, health)
+    const overflow = await readOverflow(page)
+    expect(overflow.document).toBeLessThanOrEqual(1)
+    expect(overflow.main).toBeLessThanOrEqual(1)
     expect(unexpectedRequests).toEqual([])
   })
 }

--- a/ui/src/lib/tokens.css
+++ b/ui/src/lib/tokens.css
@@ -1103,7 +1103,6 @@ a {
 
 .dashboard-page-heading,
 .dashboard-section-heading,
-.dashboard-wan-context,
 .speedtest-active-heading {
   display: flex;
   align-items: center;
@@ -1144,7 +1143,25 @@ a {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;
+}
+
+.dashboard-operations-grid {
+  align-items: stretch;
+}
+
+.dashboard-detail-grid {
   align-items: start;
+}
+
+.dashboard-operations-grid > section {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.dashboard-operations-grid > section > div:last-child {
+  flex: 1;
+  min-height: 0;
 }
 
 .dashboard-topology-card {
@@ -1273,28 +1290,169 @@ a {
   color: var(--critical);
 }
 
-.dashboard-wan-context {
-  padding-bottom: 10px;
-  border-bottom: 1px solid var(--border);
+.dashboard-internet-health {
+  display: flex;
+  height: 100%;
+  min-width: 0;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.dashboard-wan-reachability {
+.dashboard-wan-path {
   display: grid;
-  justify-items: end;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, .72fr) auto minmax(0, 1.2fr);
+  align-items: stretch;
+  gap: 7px;
+  min-width: 0;
+}
+
+.dashboard-wan-path-node {
+  position: relative;
+  display: grid;
+  align-content: center;
+  gap: 3px;
+  min-width: 0;
+  padding: 9px 10px 9px 12px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-0);
+}
+
+.dashboard-wan-path-node::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--series-1);
+  content: '';
+}
+
+.dashboard-wan-path-node:last-child::before {
+  background: var(--text-muted);
+}
+
+.dashboard-wan-path-node[data-state='up']::before {
+  background: var(--good);
+}
+
+.dashboard-wan-path-node[data-state='missing']::before {
+  background: var(--critical);
+}
+
+.dashboard-wan-path-node > span {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-wan-path-node > strong {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-wan-path-link {
+  align-self: center;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.dashboard-wan-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 11px;
+  border-top: 1px solid var(--border);
+}
+
+.dashboard-wan-toolbar-actions,
+.dashboard-wan-coverage-key {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.dashboard-wan-toolbar-actions {
+  justify-content: flex-end;
+  gap: 8px 12px;
+}
+
+.dashboard-wan-coverage-key {
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 9px;
+}
+
+.dashboard-wan-coverage-key span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.dashboard-wan-coverage-key span::before {
+  width: 10px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--accent-text);
+  content: '';
+}
+
+.dashboard-wan-coverage-key span[data-state='unavailable']::before {
+  border: 1px solid var(--border-strong);
+  background: var(--surface-2);
 }
 
 .dashboard-wan-metrics {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1px;
-  margin: 0 -14px;
-  background: var(--border);
+  flex: 1;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(142px, 1fr));
+  gap: 8px;
+  min-height: 0;
 }
 
 .dashboard-metric {
+  --dashboard-trend-color: var(--series-1);
   min-width: 0;
-  padding: 12px 14px 8px;
-  background: var(--surface-1);
+  padding: 10px 11px 8px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--dashboard-trend-color) 7%, var(--surface-0)), var(--surface-0) 48%);
+}
+
+.dashboard-metric[data-tone='upload'] {
+  --dashboard-trend-color: var(--series-2);
+}
+
+.dashboard-metric[data-tone='latency'] {
+  --dashboard-trend-color: var(--series-7);
+}
+
+.dashboard-metric[data-tone='loss'] {
+  --dashboard-trend-color: var(--series-3);
+}
+
+.dashboard-metric-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.dashboard-metric-heading > span {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dashboard-metric-label {
@@ -1303,43 +1461,126 @@ a {
 }
 
 .dashboard-metric-value {
-  min-height: 26px;
-  font-size: 18px;
+  min-height: 29px;
+  color: var(--text-primary);
+  font-size: 20px;
   font-weight: 600;
   text-align: left;
+}
+
+.dashboard-trend-figure {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  grid-template-rows: minmax(76px, 1fr) auto;
+  gap: 2px 6px;
+  min-height: 0;
+  margin: 0;
+}
+
+.dashboard-trend-scale {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  min-width: 0;
+  flex-direction: column;
+  padding: 8px 0 12px;
+  color: var(--text-muted);
+  font-size: 9px;
+  text-align: right;
+  white-space: nowrap;
 }
 
 .dashboard-trend {
   display: block;
   width: 100%;
-  height: 38px;
-  margin-top: 3px;
-  overflow: visible;
+  height: 100%;
+  min-height: 76px;
+  overflow: hidden;
 }
 
-.dashboard-trend-series {
-  fill: none;
-  stroke: var(--series-1);
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-width: 2;
-  vector-effect: non-scaling-stroke;
-}
-
-.dashboard-trend-point {
-  fill: var(--series-1);
-  stroke: var(--surface-1);
+.dashboard-trend-guide,
+.dashboard-trend-baseline {
+  stroke: var(--border);
   stroke-width: 1;
   vector-effect: non-scaling-stroke;
 }
 
+.dashboard-trend-baseline {
+  stroke: var(--border-strong);
+}
+
+.dashboard-trend-bar,
+.dashboard-trend-coverage {
+  fill: var(--dashboard-trend-color);
+}
+
+.dashboard-trend-bar {
+  opacity: .82;
+}
+
+.dashboard-trend-bar[data-zero='true'] {
+  opacity: 1;
+}
+
+.dashboard-trend-coverage {
+  opacity: .72;
+}
+
 .dashboard-trend-gap {
-  fill: var(--text-muted);
-  fill-opacity: 0.08;
+  fill: var(--surface-2);
+  stroke: var(--border-strong);
+  stroke-width: .5;
+  vector-effect: non-scaling-stroke;
+}
+
+.dashboard-trend-caption {
+  display: grid;
+  grid-column: 2;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 9px;
+}
+
+.dashboard-trend-caption > span:nth-child(2) {
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.dashboard-trend-caption > span:last-child {
+  text-align: right;
+}
+
+.dashboard-trend-empty {
+  display: grid;
+  min-height: 84px;
+  place-items: center;
+  padding: 10px;
+  border: 1px dashed var(--border);
+  border-radius: 5px;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-align: center;
+}
+
+.dashboard-wan-table-wrap {
+  min-height: 0;
+  max-height: 334px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.dashboard-wan-table thead {
+  position: sticky;
+  z-index: 1;
+  top: 0;
+  background: var(--surface-1);
 }
 
 .dashboard-wan-footnote {
-  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid var(--border);
 }
 
 .speedtest-active,
@@ -1704,7 +1945,7 @@ a {
 @media (max-width: 720px) {
   .dashboard-page-heading,
   .dashboard-section-heading,
-  .dashboard-wan-context,
+  .dashboard-wan-toolbar,
   .speedtest-active-heading,
   .speedtest-history-toolbar,
   .speedtest-chart-run > header {
@@ -1714,17 +1955,24 @@ a {
 
   .dashboard-page-heading > *,
   .dashboard-section-heading > *,
-  .dashboard-wan-context > * {
+  .dashboard-wan-toolbar > * {
     min-width: 0;
     max-width: 100%;
   }
 
-  .dashboard-wan-reachability {
-    justify-items: start;
+  .dashboard-wan-path {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .dashboard-wan-path-link {
+    justify-self: center;
+    line-height: 8px;
+    transform: rotate(90deg);
   }
 
   .dashboard-wan-metrics {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: none;
   }
 
   .dashboard-topology-stats {

--- a/ui/src/screens/Dashboard.trend.test.tsx
+++ b/ui/src/screens/Dashboard.trend.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import { Trend, WANMetric } from './Dashboard'
+import { Trend, WANMetric, wanTrendCeiling } from './Dashboard'
 
 describe('dashboard WAN trend', () => {
-  it('marks missing time without connecting across it and keeps isolated samples visible', () => {
+  it('renders only observed samples as bars and consolidates missing runs', () => {
     const { container } = render(<Trend label="Download traffic" points={[
       { ts: 0, value: 10 },
       { ts: 1, value: null },
@@ -15,22 +15,49 @@ describe('dashboard WAN trend', () => {
 
     expect(screen.getByRole('img').getAttribute('aria-label')).toContain('4 available and 2 unavailable')
     expect(container.querySelectorAll('.dashboard-trend-gap')).toHaveLength(2)
-    expect(container.querySelectorAll('.dashboard-trend-series')).toHaveLength(1)
-    expect(container.querySelectorAll('.dashboard-trend-point')).toHaveLength(2)
+    expect(container.querySelectorAll('.dashboard-trend-bar')).toHaveLength(4)
+    expect(container.querySelectorAll('.dashboard-trend-coverage')).toHaveLength(1)
+    expect(container.querySelector('.dashboard-trend-series')).toBeNull()
   })
 
-  it('centres a flat series instead of making it look clipped at the bottom', () => {
+  it('keeps a real zero visible and rejects invalid loss samples', () => {
     const { container } = render(<Trend label="ICMP loss" points={[
       { ts: 0, value: 0 },
-      { ts: 1, value: 0 },
-      { ts: 2, value: 0 },
-    ]} />)
+      { ts: 1, value: null },
+      { ts: 2, value: -1 },
+      { ts: 3, value: 101 },
+      { ts: 4, value: Number.NaN },
+    ]} kind="site_wan_loss_pct" unit="percent" tone="loss" format={(value) => `${value.toFixed(1)}%`} />)
 
-    expect(container.querySelector('.dashboard-trend-series')?.getAttribute('d'))
-      .toBe('M 0.0 19.0 L 90.0 19.0 L 180.0 19.0')
+    const trend = screen.getByRole('img')
+    expect(trend.getAttribute('aria-label')).toContain('1 available and 4 unavailable')
+    expect(trend.getAttribute('aria-label')).toContain('zero-based scale to 100.0%')
+    const zero = container.querySelector('.dashboard-trend-bar[data-zero="true"]')
+    expect(zero?.getAttribute('height')).toBe('2')
+    expect(container.querySelectorAll('.dashboard-trend-bar')).toHaveLength(1)
+    expect(container.querySelectorAll('.dashboard-trend-gap')).toHaveLength(1)
   })
 
-  it('explains partial coverage beside the freshness note', () => {
+  it('uses finite zero-based ceilings for empty and flat metric ranges', () => {
+    expect(wanTrendCeiling('download_bps', [])).toBe(1)
+    expect(wanTrendCeiling('download_bps', [0])).toBe(1)
+    expect(wanTrendCeiling('site_wan_latency_ms', [0])).toBe(10)
+    expect(wanTrendCeiling('site_wan_loss_pct', [0, 2])).toBe(100)
+    expect(wanTrendCeiling('download_bps', [30])).toBe(40)
+  })
+
+  it('renders an explicit no-samples state instead of an empty plot', () => {
+    const { container } = render(<Trend label="Upload traffic" points={[
+      { ts: 0, value: null },
+      { ts: 1, value: null },
+    ]} tone="upload" />)
+
+    expect(screen.getByRole('img', { name: 'Upload traffic: no samples available in the past six hours' })).toBeTruthy()
+    expect(screen.getByText('No samples in the past 6 hours')).toBeTruthy()
+    expect(container.querySelector('.dashboard-trend-bar')).toBeNull()
+  })
+
+  it('explains partial coverage in the chart without weakening freshness', () => {
     render(<WANMetric label="Download traffic" format={(value) => `${value} bps`} metric={{
       kind: 'download_bps',
       unit: 'bps',
@@ -39,9 +66,10 @@ describe('dashboard WAN trend', () => {
       value: 30,
       as_of: Date.now(),
       points: [{ ts: 0, value: 10 }, { ts: 1, value: null }, { ts: 2, value: 30 }],
-    }} />)
+    }} tone="download" />)
 
-    expect(screen.getByText(/Updated .* · 1 missing/)).toBeTruthy()
+    expect(screen.getByText(/Updated /)).toBeTruthy()
+    expect(screen.getByText('2/3 samples')).toBeTruthy()
     expect(screen.getByRole('img').getAttribute('aria-label')).toContain('2 available and 1 unavailable')
   })
 })

--- a/ui/src/screens/Dashboard.tsx
+++ b/ui/src/screens/Dashboard.tsx
@@ -4,6 +4,7 @@ import type {
   Dashboard as DashboardData,
   DashboardMetric,
   DashboardMetricPoint,
+  DashboardWAN,
   SpeedTestCollection,
   SpeedTestJob,
   TopologySnapshot,
@@ -67,64 +68,124 @@ function speedTestProvenance(value: string | null | undefined) {
     : value || 'Controller host/container'
 }
 
-export function Trend({ label, points }: { label: string; points: DashboardMetricPoint[] }) {
-  const observed = points.flatMap((point) => point.value == null ? [] : [point.value])
-  if (observed.length === 0) return null
+type WANTrendTone = 'download' | 'upload' | 'latency' | 'loss'
 
-  const width = 180
-  const height = 38
-  const low = Math.min(...observed)
-  const high = Math.max(...observed)
-  const span = high - low
-  const x = (index: number) => points.length === 1 ? width / 2 : (index / (points.length - 1)) * width
-  const y = (value: number) => span === 0
-    ? height / 2
-    : height - 2 - ((value - low) / span) * (height - 4)
-  const segments: Array<{ path: string; count: number; x: number; y: number }> = []
-  const gaps: Array<{ from: number; to: number }> = []
-  let current = { path: '', count: 0, x: 0, y: 0 }
-  let gapStart = -1
+function validWANValue(kind: string, value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 &&
+    (!kind.endsWith('loss_pct') || value <= 100)
+}
+
+export function wanTrendCeiling(kind: string, values: number[]) {
+  if (kind.endsWith('loss_pct')) return 100
+  const peak = Math.max(0, ...values)
+  if (peak === 0) return kind.endsWith('latency_ms') ? 10 : 1
+  const target = peak * 1.1
+  const magnitude = 10 ** Math.floor(Math.log10(target))
+  const normalized = target / magnitude
+  const factor = [1, 1.25, 1.5, 2, 2.5, 3, 4, 5, 7.5, 10]
+    .find((candidate) => candidate >= normalized) ?? 10
+  return factor * magnitude
+}
+
+function missingRuns(points: DashboardMetricPoint[], kind: string) {
+  const runs: Array<{ from: number; to: number }> = []
+  let from = -1
   points.forEach((point, index) => {
-    if (point.value == null) {
-      if (current.count) segments.push(current)
-      current = { path: '', count: 0, x: 0, y: 0 }
-      if (gapStart < 0) gapStart = index
-      return
+    if (!validWANValue(kind, point.value)) {
+      if (from < 0) from = index
+    } else if (from >= 0) {
+      runs.push({ from, to: index - 1 })
+      from = -1
     }
-    if (gapStart >= 0) {
-      gaps.push({ from: gapStart, to: index - 1 })
-      gapStart = -1
-    }
-    const px = x(index)
-    const py = y(point.value)
-    current.path += `${current.path ? ' L' : 'M'} ${px.toFixed(1)} ${py.toFixed(1)}`
-    current.count++
-    current.x = px
-    current.y = py
   })
-  if (current.count) segments.push(current)
-  if (gapStart >= 0) gaps.push({ from: gapStart, to: points.length - 1 })
+  if (from >= 0) runs.push({ from, to: points.length - 1 })
+  return runs
+}
 
-  const gapX = (index: number) => Math.max(0, Math.min(width, x(index)))
+export function Trend({
+  label,
+  points,
+  kind = 'download_bps',
+  unit = 'bps',
+  tone = 'download',
+  format = formatRate,
+}: {
+  label: string
+  points: DashboardMetricPoint[]
+  kind?: string
+  unit?: string
+  tone?: WANTrendTone
+  format?: (value: number, unit?: string) => string
+}) {
+  const observed = points.flatMap((point) => validWANValue(kind, point.value) ? [point.value] : [])
   const missing = points.length - observed.length
+  if (observed.length === 0) {
+    return (
+      <div className="dashboard-trend-empty" role="img" aria-label={`${label}: no samples available in the past six hours`}>
+        No samples in the past 6 hours
+      </div>
+    )
+  }
+
+  const width = 320
+  const plotTop = 10
+  const plotBottom = 76
+  const railY = 84
+  const ceiling = wanTrendCeiling(kind, observed)
+  const slot = width / Math.max(1, points.length)
+  const barWidth = Math.max(1, slot * 0.68)
+  const gaps = missingRuns(points, kind)
 
   return (
-    <svg
-      className="dashboard-trend"
-      viewBox={`0 0 ${width} ${height}`}
-      role="img"
-      aria-label={`${label} six-hour trend: ${observed.length} available and ${missing} unavailable five-minute samples${missing ? '; shaded bands mark unavailable samples' : ''}`}
-      preserveAspectRatio="none"
-    >
-      {gaps.map(({ from, to }) => {
-        const left = gapX(from - 0.5)
-        const right = gapX(to + 0.5)
-        return <rect key={`${from}-${to}`} className="dashboard-trend-gap" x={left} width={right - left} height={height} />
-      })}
-      {segments.map((segment, index) => segment.count === 1
-        ? <circle key={index} className="dashboard-trend-point" cx={segment.x} cy={segment.y} r="2" />
-        : <path key={index} className="dashboard-trend-series" d={segment.path} />)}
-    </svg>
+    <figure className="dashboard-trend-figure" data-tone={tone}>
+      <div className="dashboard-trend-scale" aria-hidden>
+        <span>{format(ceiling, unit)}</span>
+        <span>0</span>
+      </div>
+      <svg
+        className="dashboard-trend"
+        viewBox={`0 0 ${width} 90`}
+        role="img"
+        aria-label={`${label}, past six hours in five-minute averages: ${observed.length} available and ${missing} unavailable samples; zero-based scale to ${format(ceiling, unit)}`}
+        preserveAspectRatio="none"
+      >
+        <line className="dashboard-trend-guide" x1="0" x2={width} y1={plotTop} y2={plotTop} />
+        <line className="dashboard-trend-guide" x1="0" x2={width} y1={(plotTop + plotBottom) / 2} y2={(plotTop + plotBottom) / 2} />
+        <line className="dashboard-trend-baseline" x1="0" x2={width} y1={plotBottom} y2={plotBottom} />
+        {points.map((point, index) => {
+          if (!validWANValue(kind, point.value)) return null
+          const scaled = point.value / ceiling
+          const height = point.value === 0 ? 2 : Math.max(2, scaled * (plotBottom - plotTop))
+          return (
+            <rect
+              key={`${point.ts}-${index}`}
+              className="dashboard-trend-bar"
+              data-zero={point.value === 0 ? 'true' : undefined}
+              x={index * slot + (slot - barWidth) / 2}
+              y={plotBottom - height}
+              width={barWidth}
+              height={height}
+            />
+          )
+        })}
+        <rect className="dashboard-trend-coverage" x="0" y={railY} width={width} height="4" />
+        {gaps.map(({ from, to }) => (
+          <rect
+            key={`${from}-${to}`}
+            className="dashboard-trend-gap"
+            x={from * slot}
+            y={railY}
+            width={(to - from + 1) * slot}
+            height="4"
+          />
+        ))}
+      </svg>
+      <figcaption className="dashboard-trend-caption">
+        <span>6h ago</span>
+        <span>{observed.length}/{points.length} samples</span>
+        <span>Now</span>
+      </figcaption>
+    </figure>
   )
 }
 
@@ -132,28 +193,40 @@ export function WANMetric({
   label,
   metric,
   format,
+  tone,
 }: {
   label: string
   metric?: DashboardMetric
   format: (value: number, unit?: string) => string
+  tone: WANTrendTone
 }) {
-  const available = metric?.value != null && metric.status !== 'unavailable'
-  const missing = metric?.points.filter((point) => point.value == null).length ?? 0
+  const available = validWANValue(metric?.kind ?? '', metric?.value) && metric?.status !== 'unavailable'
   const note = [
     metric?.status === 'fresh' && metric.as_of ? `Updated ${agoMilliseconds(metric.as_of)}` : '',
     metric?.status === 'last_observed' && metric.as_of ? `Last observed ${agoMilliseconds(metric.as_of)}` : '',
     !metric || metric.status === 'unavailable' ? 'Current value unavailable' : '',
-    missing ? `${missing} missing` : '',
   ].filter(Boolean).join(' · ')
   return (
-    <div className="dashboard-metric">
-      <div className="dashboard-metric-label">{label}</div>
+    <div className="dashboard-metric" data-tone={tone}>
+      <div className="dashboard-metric-heading">
+        <div className="dashboard-metric-label">{label}</div>
+        <span>Latest 5m average</span>
+      </div>
       <div className="dashboard-metric-value num">
         {available
           ? format(metric.value!, metric.unit)
           : <Unknown why={metric?.meaning || 'the controller has no matching WAN telemetry'} />}
       </div>
-      {metric && <Trend label={label} points={metric.points} />}
+      {metric && (
+        <Trend
+          label={label}
+          points={metric.points}
+          kind={metric.kind}
+          unit={metric.unit}
+          tone={tone}
+          format={format}
+        />
+      )}
       <div className="dashboard-metric-note">{note}</div>
     </div>
   )
@@ -573,7 +646,51 @@ function SpeedTestCard() {
   )
 }
 
+function WANHistoryTable({ wan }: { wan: DashboardWAN }) {
+  const metrics = [
+    wan.metrics.download_bps,
+    wan.metrics.upload_bps,
+    wan.metrics.latency_ms,
+    wan.metrics.loss_pct,
+  ]
+  const timestamps = [...new Set(metrics.flatMap((metric) => metric.points.map((point) => point.ts)))]
+    .sort((left, right) => left - right)
+  const values = metrics.map((metric) => new Map(metric.points.map((point) => [point.ts, point.value])))
+  const cell = (metric: DashboardMetric, value: number | null | undefined, format: (value: number, unit?: string) => string) =>
+    validWANValue(metric.kind, value) ? format(value, metric.unit) : 'Unavailable'
+
+  return (
+    <div className="dashboard-wan-table-wrap" role="region" aria-label="Internet health history table" tabIndex={0}>
+      <table className="speedtest-table dashboard-wan-table">
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Download</th>
+            <th>Upload</th>
+            <th>Latency</th>
+            <th>Loss</th>
+          </tr>
+        </thead>
+        <tbody>
+          {timestamps.map((timestamp) => (
+            <tr key={timestamp}>
+              <td>
+                <time dateTime={new Date(timestamp).toISOString()}>{new Date(timestamp).toLocaleString()}</time>
+              </td>
+              <td className="num">{cell(wan.metrics.download_bps, values[0].get(timestamp), formatRate)}</td>
+              <td className="num">{cell(wan.metrics.upload_bps, values[1].get(timestamp), formatRate)}</td>
+              <td className="num">{cell(wan.metrics.latency_ms, values[2].get(timestamp), (value) => `${value.toFixed(1)} ms`)}</td>
+              <td className="num">{cell(wan.metrics.loss_pct, values[3].get(timestamp), (value) => `${value.toFixed(1)}%`)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 function InternetHealth({ data }: { data: DashboardData }) {
+  const [view, setView] = useState<'chart' | 'table'>('chart')
   const wan = data.wan
   const missing = (data.gateway_uplinks ?? []).filter((gateway) => gateway.state === 'missing')
   const up = (data.gateway_uplinks ?? []).filter((gateway) => gateway.state === 'up')
@@ -590,37 +707,65 @@ function InternetHealth({ data }: { data: DashboardData }) {
         </span>
       )}
     >
-      <div className="dashboard-wan-context">
-        <div>
-          <strong>{wan?.gateway?.name ?? up[0]?.name ?? missing[0]?.name ?? 'Gateway unavailable'}</strong>
-          <div className="dashboard-metric-note">
-            {wan?.gateway?.route_interface
-              ? `Default route · ${wan.gateway.route_interface}`
-              : 'Default-route interface unavailable'}
+      <div className="dashboard-internet-health" role="region" aria-label="Internet health details">
+        <div className="dashboard-wan-path" role="group" aria-label="Observed gateway path">
+          <div className="dashboard-wan-path-node">
+            <span>Gateway</span>
+            <strong>{wan?.gateway?.name ?? up[0]?.name ?? missing[0]?.name ?? 'Unavailable'}</strong>
+          </div>
+          <span className="dashboard-wan-path-link" aria-hidden>→</span>
+          <div className="dashboard-wan-path-node">
+            <span>Default route</span>
+            <strong>{wan?.gateway?.route_interface ?? 'Unavailable'}</strong>
+          </div>
+          <span className="dashboard-wan-path-link" aria-hidden>→</span>
+          <div className="dashboard-wan-path-node" data-state={reachableValue == null ? 'unknown' : reachableValue > 0 ? 'up' : 'missing'}>
+            <span>External ICMP target · from gateway</span>
+            <strong>
+              {wan?.target ?? '1.1.1.1'} ·{' '}
+              {reachableValue == null || reachable?.status === 'unavailable'
+                ? <Unknown why={reachable?.meaning || 'fixed-target ICMP evidence is unavailable'} />
+                : reachableValue > 0 ? 'Reachable' : 'No reply'}
+            </strong>
           </div>
         </div>
-        <div className="dashboard-wan-reachability">
-          <span className="dashboard-metric-label">ICMP reachability to {wan?.target ?? '1.1.1.1'}</span>
-          <strong>
-            {reachableValue == null || reachable?.status === 'unavailable'
-              ? <Unknown why={reachable?.meaning || 'fixed-target ICMP evidence is unavailable'} />
-              : reachableValue > 0 ? 'Reachable' : 'No reply'}
-          </strong>
+
+        <div className="dashboard-wan-toolbar">
+          <div>
+            <div className="speedtest-history-heading">Recent network activity</div>
+            <div className="dashboard-metric-note">Past 6 hours · five-minute averages</div>
+          </div>
+          <div className="dashboard-wan-toolbar-actions">
+            <div className="dashboard-wan-coverage-key" aria-label="Sample coverage legend">
+              <span data-state="observed">Observed</span>
+              <span data-state="unavailable">Unavailable</span>
+            </div>
+            <div className="speedtest-view-toggle" role="group" aria-label="Internet health history view">
+              <Button aria-pressed={view === 'chart'} kind={view === 'chart' ? 'primary' : 'default'} onClick={() => setView('chart')}>
+                Chart
+              </Button>
+              <Button aria-pressed={view === 'table'} kind={view === 'table' ? 'primary' : 'default'} onClick={() => setView('table')}>
+                Table
+              </Button>
+            </div>
+          </div>
         </div>
-      </div>
 
-      <div className="dashboard-wan-metrics">
-        <WANMetric label="Download traffic" metric={wan?.metrics.download_bps} format={formatRate} />
-        <WANMetric label="Upload traffic" metric={wan?.metrics.upload_bps} format={formatRate} />
-        <WANMetric label="ICMP latency" metric={wan?.metrics.latency_ms} format={(value) => `${value.toFixed(1)} ms`} />
-        <WANMetric label="ICMP loss" metric={wan?.metrics.loss_pct} format={(value) => `${value.toFixed(1)}%`} />
-      </div>
+        {view === 'chart' ? (
+          <div className="dashboard-wan-metrics">
+            <WANMetric label="Download traffic" metric={wan?.metrics.download_bps} format={formatRate} tone="download" />
+            <WANMetric label="Upload traffic" metric={wan?.metrics.upload_bps} format={formatRate} tone="upload" />
+            <WANMetric label="ICMP latency" metric={wan?.metrics.latency_ms} format={(value) => `${value.toFixed(1)} ms`} tone="latency" />
+            <WANMetric label="ICMP loss" metric={wan?.metrics.loss_pct} format={(value) => `${value.toFixed(1)}%`} tone="loss" />
+          </div>
+        ) : wan ? <WANHistoryTable wan={wan} /> : (
+          <div className="dashboard-trend-empty">Internet health history is unavailable.</div>
+        )}
 
-      <div className="dashboard-wan-footnote">
-        Fixed-target ICMP to {wan?.target ?? 'an unavailable target'} measures reachability, not gateway uptime.
-        {' '}Traffic charts appear only when telemetry matches the active default-route interface. Shaded spans are unavailable samples;
-        {' '}trend lines never bridge them.
-        {wan?.as_of ? ` Evidence ${wan.freshness === 'fresh' ? 'updated' : 'last observed'} ${agoMilliseconds(wan.as_of)}.` : ''}
+        <div className="dashboard-wan-footnote">
+          Traffic uses the active default-route interface. ICMP measures target reachability from the gateway, not gateway or ISP uptime.
+          {wan?.as_of ? ` Evidence ${wan.freshness === 'fresh' ? 'updated' : 'last observed'} ${agoMilliseconds(wan.as_of)}.` : ''}
+        </div>
       </div>
     </Card>
   )

--- a/ui/src/screens/screens.test.tsx
+++ b/ui/src/screens/screens.test.tsx
@@ -5021,15 +5021,81 @@ describe('Dashboard', () => {
       } as never} />,
     )
 
-    expect(screen.getByText('Default route · wan')).toBeTruthy()
-    expect(screen.getByText('ICMP reachability to 1.1.1.1')).toBeTruthy()
-    expect(screen.getByText('Reachable')).toBeTruthy()
-    expect(screen.getByText('8.0 Mbps')).toBeTruthy()
-    expect(screen.getByText(/Last observed 2m ago/)).toBeTruthy()
-    expect(screen.getByText('12.4 ms')).toBeTruthy()
-    expect(screen.getByText('0.0%')).toBeTruthy()
-    expect(screen.getByText('Download traffic').parentElement?.textContent).not.toContain('0 bps')
-    expect(screen.getByText(/measures reachability, not gateway uptime/)).toBeTruthy()
+    const health = screen.getByRole('region', { name: 'Internet health details' })
+    const path = within(health).getByRole('group', { name: 'Observed gateway path' })
+    expect(within(path).getByText('Default route')).toBeTruthy()
+    expect(within(path).getByText('wan')).toBeTruthy()
+    expect(within(path).getByText('External ICMP target · from gateway')).toBeTruthy()
+    expect(within(path).getByText('1.1.1.1 · Reachable')).toBeTruthy()
+    expect(within(health).getByText('8.0 Mbps')).toBeTruthy()
+    expect(within(health).getByText(/Last observed 2m ago/)).toBeTruthy()
+    expect(within(health).getByText('12.4 ms')).toBeTruthy()
+    expect(within(health).getByText('0.0%')).toBeTruthy()
+    expect(within(health).getByText('Download traffic').closest('.dashboard-metric')?.textContent).not.toContain('0 bps')
+    expect(within(health).getAllByRole('img')).toHaveLength(4)
+    expect(within(health).getByText(/target reachability from the gateway, not gateway or ISP uptime/)).toBeTruthy()
+
+    const view = within(health).getByRole('group', { name: 'Internet health history view' })
+    fireEvent.click(within(view).getByRole('button', { name: 'Table' }))
+    expect(within(view).getByRole('button', { name: 'Table' }).getAttribute('aria-pressed')).toBe('true')
+    const tableRegion = within(health).getByRole('region', { name: 'Internet health history table' })
+    expect(within(tableRegion).getAllByRole('row')).toHaveLength(3)
+    expect(within(tableRegion).getAllByText('Unavailable')).toHaveLength(2)
+    expect(within(tableRegion).getAllByText('0.0%')).toHaveLength(2)
+    expect(within(tableRegion).getByText('8.0 Mbps')).toBeTruthy()
+  })
+
+  it('aligns sparse WAN history by timestamp and distinguishes unavailable samples from zero', async () => {
+    const now = Date.now() - 120_000
+    const timestamps = [now - 600_000, now - 300_000, now]
+    const metric = (kind: string, unit: string, points: Array<{ ts: number; value: number | null }>) => ({
+      kind,
+      unit,
+      meaning: `${kind} from the selected gateway`,
+      status: 'fresh',
+      value: points.at(-1)?.value ?? null,
+      as_of: now,
+      points,
+    })
+    const { Dashboard } = await import('./Dashboard')
+    render(<Dashboard data={{
+      ...data,
+      wan: {
+        target: '1.1.1.1', probe: 'icmp', freshness: 'fresh', as_of: now,
+        gateway: { device_id: 1, name: 'Gateway', route_interface: 'wan', series_key: 'wan' },
+        resolution: '5m', bucket_ms: 300_000, from: timestamps[0], to: timestamps[2],
+        metrics: {
+          download_bps: metric('download_bps', 'B/s', [
+            { ts: timestamps[0], value: 0 },
+            { ts: timestamps[2], value: null },
+          ]),
+          upload_bps: metric('upload_bps', 'B/s', [
+            { ts: timestamps[1], value: 125_000 },
+            { ts: timestamps[2], value: 0 },
+          ]),
+          latency_ms: metric('latency_ms', 'ms', [
+            { ts: timestamps[0], value: null },
+            { ts: timestamps[1], value: 0 },
+          ]),
+          loss_pct: metric('loss_pct', 'percent', [{ ts: timestamps[2], value: 0 }]),
+          reachable: metric('reachable', 'boolean', [{ ts: timestamps[2], value: 1 }]),
+        },
+      },
+    } as never} />)
+
+    const health = screen.getByRole('region', { name: 'Internet health details' })
+    const view = within(health).getByRole('group', { name: 'Internet health history view' })
+    fireEvent.click(within(view).getByRole('button', { name: 'Table' }))
+    const table = within(health).getByRole('region', { name: 'Internet health history table' })
+    const rows = within(table).getAllByRole('row')
+    expect(within(rows[0]).getAllByRole('columnheader').map((cell) => cell.textContent)).toEqual([
+      'Time', 'Download', 'Upload', 'Latency', 'Loss',
+    ])
+    expect(rows.slice(1).map((row) => within(row).getAllByRole('cell').slice(1).map((cell) => cell.textContent))).toEqual([
+      ['0 bps', 'Unavailable', 'Unavailable', 'Unavailable'],
+      ['Unavailable', '1.0 Mbps', '0.0 ms', 'Unavailable'],
+      ['Unavailable', '0 bps', 'Unavailable', '0.0%'],
+    ])
   })
 
   it('keeps the selected active gateway healthy when another gateway has no route', async () => {
@@ -5120,8 +5186,9 @@ describe('Dashboard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Review speed test' }))
     await screen.findByText(/safety disclosures are unavailable or incomplete/)
-    expect(screen.getAllByText('Unavailable')).toHaveLength(2)
-    expect(screen.getByText('Privacy disclosure unavailable.')).toBeTruthy()
+    const review = screen.getByRole('group', { name: 'Information: Controller speed test' })
+    expect(within(review).getAllByText('Unavailable')).toHaveLength(2)
+    expect(within(review).getByText('Privacy disclosure unavailable.')).toBeTruthy()
     fireEvent.click(screen.getByRole('checkbox', { name: /may use data/i }))
     expect((screen.getByRole('button', { name: 'Start speed test' }) as HTMLButtonElement).disabled).toBe(true)
     expect(api.startSpeedTest).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary

- replace fragmented WAN sparklines with zero-based five-minute activity charts, explicit coverage rails, and an aligned table view
- give Internet health and speed-test cards matching responsive layouts with clearer gateway, route, and external-probe provenance
- stop the normal two-second WAN ping cadence from falsely widening gateway polling while retaining full diagnostic duration
- cover null-versus-zero semantics, real API metric names, equal card heights, narrow layouts, and dark/light rendering

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- focused collector race tests
- `npm --prefix ui test` (385 tests)
- `CI=1 npm --prefix ui run test:browser` (11 tests)
- `npm --prefix ui run build`
- `./tools/budget_check.sh`
- `./tools/secret-scan.sh --tree`
- `git diff --check`