### PR TITLE
feat: streamline operations and prepare v0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
           release_dir="$RUNNER_TEMP/release"
           notes="RELEASE-NOTES-${GITHUB_REF_NAME}.md"
           test -f "$notes"
+          cmp -s "$notes" RELEASE-NOTES.md
           ./tools/release-build.sh "$GITHUB_REF_NAME" "$release_dir"
           (cd "$release_dir" && sha256sum --check SHA256SUMS)
           cp "$notes" "$release_dir/RELEASE-NOTES.md"

--- a/README.md
+++ b/README.md
@@ -110,21 +110,21 @@ cd oonfeewrt
 
 curl --fail --location \
   --output docker-compose.yml \
-  https://raw.githubusercontent.com/aiden0rchad/oonfeeWRT/v0.1.0/deploy/docker-compose.yml
+  https://raw.githubusercontent.com/aiden0rchad/oonfeeWRT/v0.1.1/deploy/docker-compose.yml
 
 umask 077
 head -c 32 /dev/urandom | base64 > passphrase
 sudo chown 65532:65532 passphrase
 sudo chmod 600 passphrase
 
-docker compose up -d
+OONFEE_VERSION=v0.1.1 docker compose up -d
 ```
 
 Open [http://127.0.0.1:8080](http://127.0.0.1:8080) and create the first owner
 account. The default Compose configuration publishes HTTP only on host
 loopback, runs as UID 65532, drops all capabilities, uses a read-only root
 filesystem, and stores controller state in a named volume. It pulls
-`ghcr.io/aiden0rchad/oonfeewrt:v0.1.0` for `linux/amd64` or `linux/arm64`.
+`ghcr.io/aiden0rchad/oonfeewrt:v0.1.1` for `linux/amd64` or `linux/arm64`.
 
 The `passphrase` file unlocks the controller keyring and is not your owner
 account password. Back it up with the controller state and keep both private.
@@ -231,7 +231,7 @@ passphrases.
   and can temporarily saturate the WAN. Loaded latency and jitter are not
   measured.
 - Native controller TLS, cloud remote access, and gateway-run speed tests are
-  not included in v0.1.0.
+  not included in v0.1.1.
 - Optional LLDP may install official-feed packages. Adoption itself never
   installs a package, daemon, service, firmware, or executable.
 
@@ -255,6 +255,7 @@ oonfeeWRT rejects passphrases supplied through environment variables.
 ## Documentation
 
 - [Install, upgrade, TLS, and recovery](docs/INSTALL.md)
+- [v0.1.1 release notes](RELEASE-NOTES-v0.1.1.md)
 - [v0.1.0 release notes](RELEASE-NOTES-v0.1.0.md)
 - [Architecture and security boundaries](docs/ARCHITECTURE.md)
 - [Hardware validation](docs/FRESH-START-VALIDATION.md)

--- a/RELEASE-NOTES-v0.1.1.md
+++ b/RELEASE-NOTES-v0.1.1.md
@@ -1,0 +1,55 @@
+# oonfeeWRT v0.1.1
+
+v0.1.1 is a patch release focused on clearer operational evidence, bounded
+controller storage, and a denser, more accessible interface. It manages stock
+OpenWrt through existing SSH/ubus interfaces; it is not firmware and installs no
+controller-authored executable on a router.
+
+Publication is complete only when the `v0.1.1` tag workflow succeeds. Verify
+downloaded archives with `SHA256SUMS`; the published OCI image also carries a
+keyless signature, SBOM, and provenance attestation.
+
+## Highlights
+
+- Reworked Dashboard WAN health into truthful five-minute activity charts with
+  explicit missing samples, route/probe provenance, a table view, and fixed
+  polling backoff that no longer mistakes the expected ICMP probe duration for
+  router load.
+- Added compact topology and warning/error summaries, responsive page layouts,
+  keyboard-accessible chart details, stronger contrast, and passive information
+  popovers while keeping warnings, errors, authorization, and Apply safety
+  details inline.
+- Simplified controller-host speed testing: the Run action is the explicit
+  plan-bound acknowledgement, exact impact/privacy details remain available in
+  a nonmodal popover, and the three newest terminal attempts are retained
+  separately from any active test.
+- Condensed the repeated OpenWrt IPv6 router-advertisement condition without
+  changing its warning severity or losing its raw evidence, bounded stored event
+  size, and made event pruning independent of telemetry folding failures.
+- Added desktop and narrow-width browser regression gates and clarified install,
+  project-scope, AI-assistance, and validation documentation.
+
+## Upgrade and rollback
+
+Back up the matching database/keyring pair before upgrading. v0.1.1 keeps schema
+19, so upgrading from v0.1.0 requires no schema migration and makes no router
+change. A clean binary/image rollback to v0.1.0 is schema-compatible; retain the
+v0.1.1 data pair before rollback as normal operational practice.
+
+On first v0.1.1 startup, completed or failed speed-test rows older than the
+newest three are permanently removed. Back up the controller data first if that
+history matters.
+
+See `INSTALL.md` for verified download, container, backup, restore, and
+signature commands.
+
+## Security and scope
+
+- The HTTP listener has no native TLS. The default Compose mapping is host
+  loopback; use a trusted reverse proxy before remote access.
+- Discovery, inspection, diagnostics, backup, and controller speed testing do
+  not change routers. Adoption, Apply, RF scans, and optional capability
+  installation remain separately acknowledged actions.
+- Gateway-run speed testing remains deferred. Loaded latency and jitter are
+  unavailable for the controller-host method.
+- No independent security audit or penetration test has been completed.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,55 @@
+# oonfeeWRT v0.1.1
+
+v0.1.1 is a patch release focused on clearer operational evidence, bounded
+controller storage, and a denser, more accessible interface. It manages stock
+OpenWrt through existing SSH/ubus interfaces; it is not firmware and installs no
+controller-authored executable on a router.
+
+Publication is complete only when the `v0.1.1` tag workflow succeeds. Verify
+downloaded archives with `SHA256SUMS`; the published OCI image also carries a
+keyless signature, SBOM, and provenance attestation.
+
+## Highlights
+
+- Reworked Dashboard WAN health into truthful five-minute activity charts with
+  explicit missing samples, route/probe provenance, a table view, and fixed
+  polling backoff that no longer mistakes the expected ICMP probe duration for
+  router load.
+- Added compact topology and warning/error summaries, responsive page layouts,
+  keyboard-accessible chart details, stronger contrast, and passive information
+  popovers while keeping warnings, errors, authorization, and Apply safety
+  details inline.
+- Simplified controller-host speed testing: the Run action is the explicit
+  plan-bound acknowledgement, exact impact/privacy details remain available in
+  a nonmodal popover, and the three newest terminal attempts are retained
+  separately from any active test.
+- Condensed the repeated OpenWrt IPv6 router-advertisement condition without
+  changing its warning severity or losing its raw evidence, bounded stored event
+  size, and made event pruning independent of telemetry folding failures.
+- Added desktop and narrow-width browser regression gates and clarified install,
+  project-scope, AI-assistance, and validation documentation.
+
+## Upgrade and rollback
+
+Back up the matching database/keyring pair before upgrading. v0.1.1 keeps schema
+19, so upgrading from v0.1.0 requires no schema migration and makes no router
+change. A clean binary/image rollback to v0.1.0 is schema-compatible; retain the
+v0.1.1 data pair before rollback as normal operational practice.
+
+On first v0.1.1 startup, completed or failed speed-test rows older than the
+newest three are permanently removed. Back up the controller data first if that
+history matters.
+
+See `INSTALL.md` for verified download, container, backup, restore, and
+signature commands.
+
+## Security and scope
+
+- The HTTP listener has no native TLS. The default Compose mapping is host
+  loopback; use a trusted reverse proxy before remote access.
+- Discovery, inspection, diagnostics, backup, and controller speed testing do
+  not change routers. Adoption, Apply, RF scans, and optional capability
+  installation remain separately acknowledged actions.
+- Gateway-run speed testing remains deferred. Loaded latency and jitter are
+  unavailable for the controller-host method.
+- No independent security audit or penetration test has been completed.

--- a/STATUS.md
+++ b/STATUS.md
@@ -475,8 +475,10 @@ backup/restore. Historical `v0.1.0-rc.1` remains the schema-17 upgrade baseline.
    interface-series key. The consent-bound controller-host Cloudflare job is
    single-stream, 15 MiB/30 seconds, one-active, cancellable, audited and
    restart-recovered; it makes no router management/API/SSH call or router
-   change. Consent is bound to the exact reviewed descriptor plan ID; a changed
-   plan is rejected before a job is created. Loaded latency/jitter remain
+   change. Selecting Run is a fresh acknowledgement bound to the exact current
+   descriptor plan ID; a changed plan is rejected before a job is created. The
+   three newest terminal attempts are retained separately from active work.
+   Loaded latency/jitter remain
    unavailable. Public-provider execution remains explicit and separate from
    deterministic release tests. A gateway-run test stays deferred to a separately
    installed official-feed capability with an exact plan and rollback.

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -47,7 +47,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /oonfeewrtd /oonfeewrtd
 COPY LICENSE NOTICE THIRD_PARTY_LICENSES /licenses/
-COPY RELEASE-NOTES-v0.1.0.md /release/
+COPY RELEASE-NOTES.md /release/
 COPY deploy/docker-compose.yml /release/docker-compose.yml
 
 # scratch has no /data, so Docker would create the mount point as root:root and

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,6 +1,6 @@
 # oonfeeWRT controller — self-hosted network management.
 #
-#   docker compose up -d
+#   OONFEE_VERSION=vX.Y.Z docker compose up -d
 #   open http://127.0.0.1:8080 on the controller host
 #
 # NETWORKING — the safe, portable bridge mode is the default:
@@ -15,7 +15,7 @@
 
 services:
   oonfeewrt:
-    image: ghcr.io/aiden0rchad/oonfeewrt:v0.1.0
+    image: "ghcr.io/aiden0rchad/oonfeewrt:${OONFEE_VERSION:?set OONFEE_VERSION to a release tag}"
     container_name: oonfeewrt
     restart: unless-stopped
 

--- a/deploy/release_contract_test.go
+++ b/deploy/release_contract_test.go
@@ -20,7 +20,7 @@ func TestReleaseBuildContract(t *testing.T) {
 		"golang:1.26.6-alpine@sha256:",
 		`LABEL org.opencontainers.image.licenses="Apache-2.0"`,
 		"COPY LICENSE NOTICE THIRD_PARTY_LICENSES /licenses/",
-		"COPY RELEASE-NOTES-v0.1.0.md /release/",
+		"COPY RELEASE-NOTES.md /release/",
 		"COPY deploy/docker-compose.yml /release/docker-compose.yml",
 		`HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD ["/oonfeewrtd", "-healthcheck"]`,
 	} {
@@ -124,14 +124,15 @@ func TestReleaseBuildContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, packaged := range []string{
-		"THIRD_PARTY_LICENSES", "RELEASE-NOTES-v0.1.0.md", "deploy/docker-compose.yml",
+		"THIRD_PARTY_LICENSES", `cp RELEASE-NOTES.md "$stage/RELEASE-NOTES.md"`,
+		"deploy/docker-compose.yml",
 		"generate-third-party-licenses.py --check",
 	} {
 		if !strings.Contains(string(releaseScript), packaged) {
 			t.Errorf("release archives lost %q", packaged)
 		}
 	}
-	for _, artifact := range []string{"../THIRD_PARTY_LICENSES", "../RELEASE-NOTES-v0.1.0.md"} {
+	for _, artifact := range []string{"../THIRD_PARTY_LICENSES", "../RELEASE-NOTES.md"} {
 		info, err := os.Stat(artifact)
 		if err != nil {
 			t.Fatal(err)
@@ -163,7 +164,8 @@ func TestReleaseBuildContract(t *testing.T) {
 	for _, hardening := range []string{
 		"read_only: true", "/tmp:rw,noexec,nosuid,nodev", "cap_drop:",
 		"- ALL", "no-new-privileges:true", "create_host_path: false",
-		"image: ghcr.io/aiden0rchad/oonfeewrt:v0.1.0", `- "127.0.0.1:8080:8080"`,
+		`image: "ghcr.io/aiden0rchad/oonfeewrt:${OONFEE_VERSION:?set OONFEE_VERSION to a release tag}"`,
+		`- "127.0.0.1:8080:8080"`,
 	} {
 		if !strings.Contains(string(compose), hardening) {
 			t.Errorf("compose lost runtime hardening %q", hardening)

--- a/deploy/workflow_release_contract_test.go
+++ b/deploy/workflow_release_contract_test.go
@@ -36,6 +36,7 @@ func TestReleaseWorkflowContract(t *testing.T) {
 		"echo \"$image:$minor\"",
 		"echo \"$image:latest\"",
 		"notes=\"RELEASE-NOTES-${GITHUB_REF_NAME}.md\"",
+		"cmp -s \"$notes\" RELEASE-NOTES.md",
 		"./tools/release-build.sh \"$GITHUB_REF_NAME\" \"$release_dir\"",
 		"path: ${{ runner.temp }}/release/*",
 		"--notes-file dist/RELEASE-NOTES.md",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1105,10 +1105,11 @@ long synchronous response. The default runner uses Cloudflare's direct download
 and upload endpoints from the controller host, with a 10 MiB download, 5 MiB
 upload, five idle-latency probes, one active job and a 30-second hard bound.
 The GET descriptor includes a deterministic `plan_id`; Start requires both
-`acknowledge_data_use:true` and that exact reviewed ID, and rejects a changed
-plan with 409 before creating a job. It rejects redirects and has no Fleet/router
-dependency. Loaded latency/jitter remain null because the single-stream method
-does not probe them under load.
+`acknowledge_data_use:true` and that exact current ID, and rejects a changed
+plan with 409 before creating a job. Terminal history retains the three newest
+attempts separately from the active job. It rejects redirects and has no
+Fleet/router dependency. Loaded latency/jitter remain null because the
+single-stream method does not probe them under load.
 No public-provider speed test has run; current evidence is source and local-test
 coverage only.
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -80,11 +80,13 @@ match exactly. The React Dashboard renders these semantics.
 The authenticated `/api/v1/speedtests` start/status/cancel/history surface uses
 a bounded controller-host runner: Cloudflare direct endpoints, method
 `controller-http-single-stream-v1`, 10 MiB download, 5 MiB upload, five idle
-latency probes, 30-second timeout, one active job and at most 50 terminal rows.
+latency probes, 30-second timeout, one active job and three terminal rows.
 The descriptor exposes endpoint/provenance/data estimate/privacy/saturation and
-a deterministic `plan_id` before consent. Start requires the current reviewed
-ID plus `acknowledge_data_use:true`; a changed plan returns 409 before creating
-a job. Redirects fail closed; lifecycle events are audited; cancel and
+a deterministic `plan_id` before acknowledgement. Material impact stays beside
+the Run action and exact details remain available in a nonmodal popover.
+Selecting Run sends the current ID plus `acknowledge_data_use:true`; a changed
+plan returns 409 before creating a job. Redirects fail closed; lifecycle events
+are audited; cancel and
 startup recovery reach durable terminal state. The package has no Fleet/router
 dependency and performs no router call or change. Loaded latency/jitter remain
 null because the method does not measure them. No public-provider speed test has

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -3,8 +3,8 @@
 oonfeeWRT is a controller that runs on a computer, NAS, or server. It does not
 replace OpenWrt firmware and no controller binary runs on a router.
 
-This guide targets final schema-19 release `v0.1.0`. The
-[GitHub release](https://github.com/aiden0rchad/oonfeeWRT/releases/tag/v0.1.0)
+This guide targets schema-19 patch release `v0.1.1`. The
+[GitHub release](https://github.com/aiden0rchad/oonfeeWRT/releases/tag/v0.1.1)
 and its completed tag workflow are the publication source of truth; run the
 download commands only after that release is available. Back up both the
 controller and each router before using it on a network you cannot afford to
@@ -51,7 +51,7 @@ Set the release and platform. On macOS, `uname -m` reports `x86_64` rather than
 the archive's `amd64`, so normalize it:
 
 ```sh
-VERSION=v0.1.0
+VERSION=v0.1.1
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 case "$(uname -m)" in
   x86_64) ARCH=amd64 ;;
@@ -86,7 +86,7 @@ sudo install -m 0755 "$NAME/oonfeewrt-recoverycheck" \
 
 Create separate private directories for persistent state and the unattended
 passphrase. The database and `keyring.json` are created in the data directory.
-Keep that directory mode `0700`. v0.1.0 also forces newly created SQLite
+Keep that directory mode `0700`. v0.1.0 and later force newly created SQLite
 database, WAL, and SHM files to mode `0600`. Historical `v0.1.0-rc.1` relied on
 the process umask for its sidecars, so keep `umask 077` during an RC upgrade.
 
@@ -113,7 +113,7 @@ first run and once after each restart.
 ## Run the container
 
 After the tag workflow succeeds, its immutable release tag is
-`ghcr.io/aiden0rchad/oonfeewrt:v0.1.0`. It is multi-platform, defaults to
+`ghcr.io/aiden0rchad/oonfeewrt:v0.1.1`. It is multi-platform, defaults to
 UID `65532`, and has no shell or package manager. The command below instead uses
 your non-root host UID with bind-mounted state, which keeps permissions and
 backups straightforward on both Linux and Docker Desktop.
@@ -121,8 +121,8 @@ backups straightforward on both Linux and Docker Desktop.
 Install `cosign` from the
 [official Sigstore instructions](https://docs.sigstore.dev/cosign/system_config/installation/),
 then verify the GitHub Actions keyless identity before first use. Stable aliases
-`0.1.0`, `0.1`, and `latest` resolve to the same final manifest, but deployments
-should pin `v0.1.0` or its reported digest.
+`0.1.1`, `0.1`, and `latest` resolve to the same final manifest, but deployments
+should pin `v0.1.1` or its reported digest.
 
 ```sh
 [ "$(id -u)" -ne 0 ] || { echo "run Docker as a non-root user" >&2; exit 1; }
@@ -139,9 +139,9 @@ to host loopback. Layer-2 discovery does not cross the bridge; adopt by address.
 
 ```sh
 cosign verify \
-  --certificate-identity "https://github.com/aiden0rchad/oonfeeWRT/.github/workflows/release.yml@refs/tags/v0.1.0" \
+  --certificate-identity "https://github.com/aiden0rchad/oonfeeWRT/.github/workflows/release.yml@refs/tags/v0.1.1" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  ghcr.io/aiden0rchad/oonfeewrt:v0.1.0
+  ghcr.io/aiden0rchad/oonfeewrt:v0.1.1
 
 docker run -d \
   --name oonfeewrt \
@@ -158,13 +158,19 @@ docker run -d \
   -e OONFEE_DATA_DIR=/data \
   -e OONFEE_LISTEN=:8080 \
   -e OONFEE_PASSPHRASE_FILE=/run/secrets/oonfee-passphrase \
-  ghcr.io/aiden0rchad/oonfeewrt:v0.1.0
+  ghcr.io/aiden0rchad/oonfeewrt:v0.1.1
 ```
 
 The release archive also includes `docker-compose.yml`. It uses the same final
 image, a named data volume, a mode-0600 passphrase file owned by UID 65532, and
 the loopback-only bridge mapping above. Host networking is documented in the
 file but remains an explicit Linux-only opt-in.
+
+Set the exact image version when using that file:
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose up -d
+```
 
 On Linux, full ARP/mDNS discovery requires host networking. Replace the `-p`
 line with `--network host` and set

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -468,23 +468,27 @@ open.
 
 ### 4.1.2 Speed tests
 
-Source status: controller mode is implemented as an explicitly consented,
+Source status: controller mode is implemented as an explicitly acknowledged,
 single-stream Cloudflare direct test with a 15 MiB estimate and 30-second hard
 limit. The pre-run descriptor names vantage point, endpoint, method, privacy and
 saturation; jobs are durable, one-active, bounded-history, cancellable, audited
-and restart-recovered. Consent is bound to the reviewed deterministic `plan_id`;
-a changed plan is rejected before job creation. There is no Fleet/router
+and restart-recovered. The launcher keeps material impact visible and puts exact
+details in a nonmodal popover; selecting Run is the fresh acknowledgement bound
+to the current deterministic `plan_id`. A changed plan is rejected before job
+creation. There is no Fleet/router
 dependency. Loaded latency and jitter remain null because this method does not
 measure them. No public-provider speed test has run; the live Dashboard route
 has passed signed-in smoke.
 
-The first implementation runs from the **controller host/container**. It changes
-nothing on a router and must say so beside the Start button. Before every run,
-show the vantage point, provider/endpoint, estimated data use, timeout, privacy
-implications and the fact that the test may temporarily saturate the WAN.
+The first implementation runs from the **controller host/container**. It makes
+no router call or change and must say so beside the Run button. Before every
+run, keep provider, vantage point, estimated data use, timeout, privacy and
+temporary WAN-saturation impact visible; exact endpoints and method remain
+available from the keyboard/touch-accessible impact popover.
 
-- Persist bounded history for download/upload throughput, idle/loaded latency,
-  jitter, method, provider, timestamp and provenance. Unknown fields stay null.
+- Persist the three newest terminal attempts with download/upload throughput,
+  idle/loaded latency, jitter, method, provider, timestamp and provenance.
+  Unknown fields stay null; the separate active job never crowds out history.
 - Use server-side `queued`, `running`, `cancelling`, `completed` and `failed`
   jobs; allow one active controller test, hard-limit time and bytes, expose
   progress/cancel, and audit start/cancel/complete/failure.
@@ -514,27 +518,31 @@ Source status: authored `Notice` summaries now cover Dashboard methodology,
 topology/radio/log coverage, Policy lifecycle and Zone Matrix scope, Apply
 readiness/behavior/management-path/driver-risk/per-device previews, adoption and
 optional capabilities, diagnostics, backup/restore, neighbour reports and
-wireless-uplink guidance. Actions and acknowledgements stay outside collapsed
-details, critical consequences remain visible, and RF scan consent remains fully
-visible. Remaining control-adjacent Settings help stays inline by design; other
-long Settings guidance remains an incremental cleanup.
+wireless-uplink guidance. Passive information on Dashboard methodology, general
+event sources, account/session guidance, Zone Matrix scope, neighbour reports
+and wireless uplinks now uses the shared nonmodal details popover. Warnings,
+errors, adoption authorization, Apply plans, actions and acknowledgements remain
+inline; critical consequences and RF scan consent remain fully visible.
+Remaining control-adjacent Settings help stays inline by design; other long
+Settings guidance remains an incremental cleanup.
 
-Extend the existing passive long-`Banner` collapse into one authored disclosure
-contract: `summary`, `details`, severity, affected component and always-visible
-actions. The collapsed view is one or two lines and `More information` exposes
-the complete technical text; nothing is discarded or duplicated for assistive
-technology.
+Use one authored disclosure contract: `summary`, `details`, severity, affected
+component and always-visible actions. A passive informational row stays one or
+two lines and `More information` opens the complete technical text without
+changing page height. Inline warnings and errors retain their existing details;
+nothing is discarded or duplicated for assistive technology.
 
 - Apply it to Dashboard explanations, topology/radio/log coverage, adoption and
   ACL prompts, LLDP and other optional capabilities, RF scans, Apply previews,
   diagnostics, backup/restore and long Settings help.
-- Informational, coverage and optional-feature details default closed.
+- Passive informational details may use the popover and default closed. Coverage
+  warnings, errors, authorization and optional-feature consent remain inline.
 - Security, destructive and connectivity-loss notices remain prominent. An
   optional capability starts as a compact summary plus `Review`; after Review,
   its exact router mutation/rollback, fresh checkbox and action remain visible
   and default-open. Never auto-collapse an active consent plan.
-- Mouse and keyboard expansion, `aria-expanded`, focus treatment and representative
-  collapsed desktop screenshots are release-tested.
+- Mouse, keyboard and touch opening, dismissal, `aria-expanded`, focus return,
+  narrow containment and representative desktop layouts are release-tested.
 
 ### 4.1.4 Accounts, roles and sessions
 

--- a/docs/UI-SPEC.md
+++ b/docs/UI-SPEC.md
@@ -134,8 +134,11 @@ ad hoc prose or character-count truncation. Its authored one- or two-line
 summary always names severity, affected component and consequence. `More
 information` expands the complete technical details with native keyboard
 semantics and `aria-expanded`; action buttons and acknowledgements remain
-visible outside the collapsed region. Informational and coverage details default
-closed. An optional capability initially shows a compact summary plus `Review`;
+visible outside the collapsed region. Routine, non-blocking guidance may use a
+compact row with a neutral perimeter and tone rail; warnings keep a visible
+severity label. Consent, retry, blocking, active-operation and critical notices
+retain the full treatment. Informational and coverage details default closed.
+An optional capability initially shows a compact summary plus `Review`;
 once reviewed, the exact router mutation/rollback, fresh acknowledgement and
 action remain visible/default-open. Security, destructive, connectivity-loss
 and active-operation essentials are never line-clamped. Apply this contract to

--- a/docs/UI-SPEC.md
+++ b/docs/UI-SPEC.md
@@ -55,10 +55,12 @@ shows the observed gateway, default-route interface and fixed-target probe as
 separate evidence, then plots server-selected six-hour throughput, latency and
 loss as zero-based five-minute activity columns. Missing buckets remain missing
 and appear only in a thin coverage rail; a table toggle exposes every aligned sample.
-The speed-test review shows controller-host vantage point, Cloudflare
-endpoint, single-stream method, 15 MiB estimate, 30-second limit, privacy and
-saturation before consent; Start binds a fresh acknowledgement to the reviewed
-`plan_id`, then shows progress/cancel and bounded history as paired
+The speed-test launcher keeps provider, controller-host vantage point, 15 MiB
+estimate, 30-second limit, no-router-change boundary, saturation and public-IP
+exposure visible beside `Run speed test`. A nonmodal popover exposes the exact
+endpoint and method before the run. Selecting Run is the fresh data-use
+acknowledgement bound to the current `plan_id`; it then shows progress/cancel
+and the three retained terminal attempts as paired
 download/upload bars on one zero-based Mbps scale, with a full table toggle.
 Loaded latency/jitter display unavailable. Schema 19 also supplies role-bearing
 sessions, exhaustive server-side RBAC, My Account, owner account administration,
@@ -131,19 +133,24 @@ and mini-charts. Used for: device detail, client detail, log entry detail.
 
 **Progressive disclosure.** Use one `Notice`/`Disclosure` primitive instead of
 ad hoc prose or character-count truncation. Its authored one- or two-line
-summary always names severity, affected component and consequence. `More
-information` expands the complete technical details with native keyboard
-semantics and `aria-expanded`; action buttons and acknowledgements remain
-visible outside the collapsed region. Routine, non-blocking guidance may use a
-compact row with a neutral perimeter and tone rail; warnings keep a visible
-severity label. Consent, retry, blocking, active-operation and critical notices
-retain the full treatment. Informational and coverage details default closed.
-An optional capability initially shows a compact summary plus `Review`;
-once reviewed, the exact router mutation/rollback, fresh acknowledgement and
-action remain visible/default-open. Security, destructive, connectivity-loss
-and active-operation essentials are never line-clamped. Apply this contract to
-coverage gaps, adoption/ACL, LLDP, RF scan, speed test, Apply preview,
-diagnostics, backup/restore and long Settings help.
+summary always names severity, affected component and consequence. Passive
+informational help may put its supplemental detail in a nonmodal popover that
+supports mouse, keyboard and touch, reports `aria-expanded`, closes on Escape or
+outside press, and never changes page height. Warnings, errors, authorization,
+consent, retry, blocking, active-operation and critical notices keep their
+details inline; their severity, consequence, action and acknowledgement never
+move into a popover. Routine guidance may use a compact row with a neutral
+perimeter and tone rail. Informational details default closed.
+An optional capability that mutates a router initially shows a compact summary
+plus `Review`; once reviewed, the exact mutation/rollback, fresh acknowledgement
+and action remain visible/default-open. The controller-host speed test is the
+bounded exception: material impact stays visible beside Run, exact details use
+a nonmodal popover, and Run itself is the fresh plan-bound acknowledgement.
+Security, destructive, connectivity-loss and active-operation essentials are
+never line-clamped. The adoption/ACL payload remains inline because it grants
+controller access. Apply this contract to coverage gaps, LLDP, RF scan, Apply
+preview, diagnostics, backup/restore and long Settings help without floating
+their warnings or controls.
 
 ---
 
@@ -397,17 +404,20 @@ Cards link to the corresponding filtered screen; count methodology moves behind
 The speed-test card defaults to **Controller test** and says `Runs from the
 controller host/container; makes no router management call or change`. It also
 states that test traffic follows the controller host's normal route and may
-saturate the gateway/WAN. Before Start, show
-vantage point, provider/endpoint, estimated data use, saturation impact, timeout
-and privacy implications. Start sends the descriptor's opaque `plan_id` with a
-fresh data-use acknowledgement; the server rejects a changed plan before
-creating a job. While running, show progress and Cancel; results show
+saturate the gateway/WAN. Before Run, keep provider, vantage point, estimated
+data use, saturation impact, timeout, privacy implications and the
+no-router-change boundary visible. Expose exact endpoints and method in a
+keyboard/touch-accessible nonmodal popover. Selecting Run sends the descriptor's
+opaque `plan_id` with a fresh data-use acknowledgement; the server rejects a
+changed plan before creating a job. While running, show progress and Cancel;
+results show
 download/upload, idle/loaded latency, jitter, time, method and provenance with
-honest unavailable fields. History defaults to grouped horizontal throughput
-bars; latency stays off the Mbps axis, and the table view retains every exact
-result and failure. A gateway-run test is a separately installed,
+honest unavailable fields. Retain the three newest terminal attempts. History
+defaults to grouped horizontal throughput bars; latency stays off the Mbps
+axis, and the table view retains every displayed result and failure. A
+gateway-run test is a separately installed,
 default-off official-feed capability and never appears to be part of ordinary
-adoption or the controller Start button.
+adoption or the controller Run button.
 
 **Topology.** Filter rail. Canvas: tidy tree, internet at top only when a
 gateway default-route observation supports it. Node = icon + label;

--- a/internal/api/speedtest.go
+++ b/internal/api/speedtest.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -48,11 +49,12 @@ type speedTestsResponse struct {
 }
 
 func (s *Server) handleSpeedTests(w http.ResponseWriter, r *http.Request) {
-	limit := 20
+	limit := speedtest.MaxHistory
 	if raw := r.URL.Query().Get("limit"); raw != "" {
 		parsed, err := strconv.Atoi(raw)
-		if err != nil || parsed < 1 || parsed > speedtest.MaxHistory {
-			writeErr(w, http.StatusBadRequest, "limit must be between 1 and 50")
+		if err != nil || parsed < 1 || parsed > speedtest.MaxListLimit {
+			writeErr(w, http.StatusBadRequest,
+				fmt.Sprintf("limit must be between 1 and %d", speedtest.MaxListLimit))
 			return
 		}
 		limit = parsed

--- a/internal/api/speedtest_test.go
+++ b/internal/api/speedtest_test.go
@@ -108,6 +108,10 @@ func TestSpeedTestAPIRequiresConsentAndNeverTouchesFleet(t *testing.T) {
 		t.Fatalf("list: %d %s", list.Code, list.Body.String())
 	}
 	body := h.json(list)
+	limits, ok := body["limits"].(map[string]any)
+	if !ok || limits["max_history"] != float64(speedtest.MaxHistory) {
+		t.Fatalf("limits=%v", body["limits"])
+	}
 	test, ok := body["test"].(map[string]any)
 	if !ok || test["provider"] != "local-test" || test["provenance"] != "controller-host" ||
 		test["endpoint"] != "http://127.0.0.1" || test["download_endpoint"] != "http://127.0.0.1/down" ||
@@ -198,6 +202,74 @@ func TestSpeedTestAPIRequiresConsentAndNeverTouchesFleet(t *testing.T) {
 			t.Errorf("missing audit event %s", event)
 		}
 	}
+}
+
+func TestSpeedTestAPIKeepsActiveSeparateFromThreeResultHistory(t *testing.T) {
+	h := newHarness(t)
+	h.setup()
+	runner := &controlledSpeedRunner{started: make(chan struct{}), release: make(chan struct{})}
+	installSpeedRunner(h, runner)
+	ctx := context.Background()
+	for i, id := range []string{"one", "two", "three", "four"} {
+		job := speedtest.Job{ID: id, State: "queued", Phase: "queued",
+			Provider: "local-test", Method: "controller-http-single-stream-v1",
+			Provenance: "controller-host", Endpoint: "http://127.0.0.1",
+			EstimatedBytes: 3000, PlanID: runner.Descriptor().PlanID(),
+			ActorAdminID: 1, ActorUsername: "admin", CreatedAt: int64(i + 1)}
+		if err := h.db.CreateSpeedTest(ctx, job, speedtest.MaxListLimit); err != nil {
+			t.Fatal(err)
+		}
+		if err := h.db.FinishSpeedTest(ctx, id, "completed", speedtest.Measurement{}, "",
+			job.CreatedAt+1, speedtest.MaxListLimit); err != nil {
+			t.Fatal(err)
+		}
+	}
+	started := h.do(http.MethodPost, "/api/v1/speedtests", map[string]any{
+		"acknowledge_data_use": true, "plan_id": runner.Descriptor().PlanID(),
+	})
+	if started.Code != http.StatusAccepted {
+		t.Fatalf("start: %d %s", started.Code, started.Body.String())
+	}
+	activeID := h.json(started)["id"].(string)
+	<-runner.started
+
+	list := h.do(http.MethodGet, "/api/v1/speedtests?limit=50", nil)
+	if list.Code != http.StatusOK {
+		t.Fatalf("list: %d %s", list.Code, list.Body.String())
+	}
+	body := h.json(list)
+	jobs, ok := body["jobs"].([]any)
+	if !ok || len(jobs) != 3 {
+		t.Fatalf("jobs=%v", body["jobs"])
+	}
+	for _, item := range jobs {
+		job := item.(map[string]any)
+		if job["id"] == activeID || (job["state"] != "completed" && job["state"] != "failed") {
+			t.Fatalf("active job leaked into history: %v", job)
+		}
+	}
+	active, ok := body["active"].(map[string]any)
+	if !ok || active["id"] != activeID {
+		t.Fatalf("active=%v", body["active"])
+	}
+	limits := body["limits"].(map[string]any)
+	if limits["max_history"] != float64(3) {
+		t.Fatalf("limits=%v", limits)
+	}
+	if oldest := h.do(http.MethodGet, "/api/v1/speedtests/one", nil); oldest.Code != http.StatusNotFound {
+		t.Fatalf("oldest: %d %s", oldest.Code, oldest.Body.String())
+	}
+	overLimit := h.do(http.MethodGet, "/api/v1/speedtests?limit=51", nil)
+	if overLimit.Code != http.StatusBadRequest ||
+		h.json(overLimit)["error"] != "limit must be between 1 and 50" {
+		t.Fatalf("over limit: %d %s", overLimit.Code, overLimit.Body.String())
+	}
+
+	cancelled := h.do(http.MethodPost, "/api/v1/speedtests/"+activeID+"/cancel", map[string]any{})
+	if cancelled.Code != http.StatusAccepted {
+		t.Fatalf("cancel: %d %s", cancelled.Code, cancelled.Body.String())
+	}
+	waitSpeedJob(t, h.db, activeID, "failed")
 }
 
 func TestSpeedTestAPICompletesWithNullableLoadedMetrics(t *testing.T) {

--- a/internal/speedtest/speedtest.go
+++ b/internal/speedtest/speedtest.go
@@ -15,13 +15,18 @@ import (
 	"time"
 )
 
-const MaxHistory = 50
+const (
+	// MaxHistory is the number of terminal results retained in the controller store.
+	MaxHistory = 3
+	// MaxListLimit preserves the public list endpoint's accepted query range.
+	MaxListLimit = 50
+)
 
 var (
 	ErrActive      = errors.New("a speed test is already active")
 	ErrNotFound    = errors.New("speed test not found")
 	ErrTerminal    = errors.New("speed test is already finished")
-	ErrPlanChanged = errors.New("speed test plan changed; review it and acknowledge again")
+	ErrPlanChanged = errors.New("speed test plan changed; refresh the plan and run again")
 )
 
 type Descriptor struct {

--- a/internal/speedtest/speedtest_test.go
+++ b/internal/speedtest/speedtest_test.go
@@ -8,15 +8,18 @@ import (
 )
 
 type memoryRepo struct {
-	mu       sync.Mutex
-	job      *Job
-	finished chan struct{}
+	mu               sync.Mutex
+	job              *Job
+	createMaxHistory int
+	finishMaxHistory int
+	finished         chan struct{}
 }
 
-func (r *memoryRepo) CreateSpeedTest(_ context.Context, job Job, _ int) error {
+func (r *memoryRepo) CreateSpeedTest(_ context.Context, job Job, maxHistory int) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.job = &job
+	r.createMaxHistory = maxHistory
 	return nil
 }
 
@@ -47,9 +50,10 @@ func (r *memoryRepo) UpdateSpeedTestProgress(context.Context, string, Progress) 
 func (r *memoryRepo) RequestSpeedTestCancel(context.Context, string) error            { return nil }
 
 func (r *memoryRepo) FinishSpeedTest(_ context.Context, _, state string, _ Measurement,
-	detail string, at int64, _ int) error {
+	detail string, at int64, maxHistory int) error {
 	r.mu.Lock()
 	r.job.State, r.job.FinishedAt = state, &at
+	r.finishMaxHistory = maxHistory
 	if detail != "" {
 		r.job.Error = &detail
 	}
@@ -100,6 +104,9 @@ func TestManagerClampsBackwardClock(t *testing.T) {
 	stored, err := repo.SpeedTest(context.Background(), job.ID)
 	if err != nil || stored.FinishedAt == nil || *stored.FinishedAt != job.CreatedAt {
 		t.Fatalf("finished job=%+v err=%v", stored, err)
+	}
+	if repo.createMaxHistory != 3 || repo.finishMaxHistory != 3 {
+		t.Fatalf("retention create=%d finish=%d, want 3", repo.createMaxHistory, repo.finishMaxHistory)
 	}
 	if !manager.Close(time.Second) {
 		t.Fatal("manager did not drain")

--- a/internal/store/speedtest.go
+++ b/internal/store/speedtest.go
@@ -48,14 +48,16 @@ func (db *DB) SpeedTest(ctx context.Context, id string) (*speedtest.Job, error) 
 		`SELECT `+speedTestColumns+` FROM speed_tests WHERE id=?`, id))
 }
 
+// SpeedTests returns terminal history; ActiveSpeedTest owns live job state.
 func (db *DB) SpeedTests(ctx context.Context, limit int) ([]speedtest.Job, error) {
 	if limit < 1 {
-		limit = 20
-	} else if limit > speedtest.MaxHistory {
 		limit = speedtest.MaxHistory
+	} else if limit > speedtest.MaxListLimit {
+		limit = speedtest.MaxListLimit
 	}
 	rows, err := db.sql.QueryContext(ctx, `SELECT `+speedTestColumns+`
-FROM speed_tests ORDER BY created_at DESC,id DESC LIMIT ?`, limit)
+FROM speed_tests WHERE state IN ('completed','failed')
+ORDER BY created_at DESC,id DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, fmt.Errorf("store: list speed tests: %w", err)
 	}
@@ -156,8 +158,8 @@ WHERE id=? AND state IN ('queued','running','cancelling')`, state, state, progre
 	return nil
 }
 
-// RecoverSpeedTests marks work abandoned by a previous controller process.
-// Daemon startup calls it before accepting requests.
+// RecoverSpeedTests marks work abandoned by a previous controller process and
+// enforces terminal retention. Daemon startup calls it before accepting requests.
 func (db *DB) RecoverSpeedTests(ctx context.Context, at int64) ([]speedtest.Job, error) {
 	tx, err := db.sql.BeginTx(ctx, nil)
 	if err != nil {
@@ -181,39 +183,35 @@ FROM speed_tests WHERE state IN ('queued','running','cancelling') ORDER BY creat
 	if err := rows.Close(); err != nil {
 		return nil, err
 	}
-	if len(jobs) == 0 {
-		if err := tx.Commit(); err != nil {
-			return nil, err
-		}
-		return jobs, nil
-	}
-	_, err = tx.ExecContext(ctx, `UPDATE speed_tests
+	if len(jobs) > 0 {
+		_, err = tx.ExecContext(ctx, `UPDATE speed_tests
 SET state='failed',phase='failed',finished_at=max(?,created_at,coalesce(started_at,created_at)),error='controller restarted before the speed test finished'
 WHERE state IN ('queued','running','cancelling')`, at)
-	if err != nil {
-		return nil, fmt.Errorf("store: recover interrupted speed tests: %w", err)
-	}
-	for _, job := range jobs {
-		recoveredAt := at
-		if recoveredAt < job.CreatedAt {
-			recoveredAt = job.CreatedAt
-		}
-		if job.StartedAt != nil && recoveredAt < *job.StartedAt {
-			recoveredAt = *job.StartedAt
-		}
-		event, detail, err := normalizeEvent(Event{TS: recoveredAt / 1000, IngestedAt: recoveredAt,
-			Category: "audit", Severity: "error", Event: "speedtest.failure",
-			Detail: map[string]any{
-				"job_id": job.ID, "username": job.ActorUsername,
-				"provider": job.Provider, "method": job.Method,
-				"provenance": job.Provenance, "plan_id": job.PlanID,
-				"reason": "controller restarted before the speed test finished",
-			}})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("store: recover interrupted speed tests: %w", err)
 		}
-		if _, err := tx.ExecContext(ctx, appendEventSQL, eventInsertArgs(event, detail)...); err != nil {
-			return nil, fmt.Errorf("store: audit interrupted speed test: %w", err)
+		for _, job := range jobs {
+			recoveredAt := at
+			if recoveredAt < job.CreatedAt {
+				recoveredAt = job.CreatedAt
+			}
+			if job.StartedAt != nil && recoveredAt < *job.StartedAt {
+				recoveredAt = *job.StartedAt
+			}
+			event, detail, err := normalizeEvent(Event{TS: recoveredAt / 1000, IngestedAt: recoveredAt,
+				Category: "audit", Severity: "error", Event: "speedtest.failure",
+				Detail: map[string]any{
+					"job_id": job.ID, "username": job.ActorUsername,
+					"provider": job.Provider, "method": job.Method,
+					"provenance": job.Provenance, "plan_id": job.PlanID,
+					"reason": "controller restarted before the speed test finished",
+				}})
+			if err != nil {
+				return nil, err
+			}
+			if _, err := tx.ExecContext(ctx, appendEventSQL, eventInsertArgs(event, detail)...); err != nil {
+				return nil, fmt.Errorf("store: audit interrupted speed test: %w", err)
+			}
 		}
 	}
 	if err := pruneSpeedTestsOn(ctx, tx, speedtest.MaxHistory); err != nil {

--- a/internal/store/speedtest_test.go
+++ b/internal/store/speedtest_test.go
@@ -56,6 +56,39 @@ func TestSpeedTestsEnforceOneActiveAndBoundHistory(t *testing.T) {
 	}
 }
 
+func TestSpeedTestsKeepActiveSeparateFromTerminalHistory(t *testing.T) {
+	db := open(t)
+	ctx := context.Background()
+	for i, id := range []string{"one", "two", "three", "four"} {
+		job := speedJob(id, int64(i+1))
+		if err := db.CreateSpeedTest(ctx, job, speedtest.MaxListLimit); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.FinishSpeedTest(ctx, id, "completed", speedtest.Measurement{}, "",
+			job.CreatedAt+1, speedtest.MaxListLimit); err != nil {
+			t.Fatal(err)
+		}
+	}
+	active := speedJob("active", 5)
+	if err := db.CreateSpeedTest(ctx, active, speedtest.MaxHistory); err != nil {
+		t.Fatal(err)
+	}
+	history, err := db.SpeedTests(ctx, speedtest.MaxListLimit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 3 || history[0].ID != "four" || history[1].ID != "three" || history[2].ID != "two" {
+		t.Fatalf("history=%+v", history)
+	}
+	gotActive, err := db.ActiveSpeedTest(ctx)
+	if err != nil || gotActive == nil || gotActive.ID != active.ID {
+		t.Fatalf("active=%+v err=%v", gotActive, err)
+	}
+	if _, err := db.SpeedTest(ctx, "one"); !errors.Is(err, speedtest.ErrNotFound) {
+		t.Fatalf("oldest terminal result was not pruned: %v", err)
+	}
+}
+
 func TestSpeedTestCreateAndFinishRollbackWhenPruneFails(t *testing.T) {
 	db := open(t)
 	ctx := context.Background()
@@ -188,6 +221,40 @@ func TestRecoverSpeedTestsBoundsHistory(t *testing.T) {
 	}
 	if _, err := db.SpeedTest(ctx, "complete-00"); !errors.Is(err, speedtest.ErrNotFound) {
 		t.Fatalf("oldest recovered history entry was not pruned: %v", err)
+	}
+}
+
+func TestRecoverSpeedTestsPrunesExistingHistoryWithoutActiveWork(t *testing.T) {
+	db := open(t)
+	ctx := context.Background()
+	for i, id := range []string{"one", "two", "three", "four"} {
+		job := speedJob(id, int64(i+1))
+		if err := db.CreateSpeedTest(ctx, job, speedtest.MaxListLimit); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.FinishSpeedTest(ctx, id, "completed", speedtest.Measurement{}, "",
+			job.CreatedAt+1, speedtest.MaxListLimit); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.LogEvent(ctx, Event{TS: job.CreatedAt, Category: "audit", Severity: "info",
+			Event: "speedtest.complete", Detail: map[string]any{"job_id": id}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	recovered, err := db.RecoverSpeedTests(ctx, 10)
+	if err != nil || len(recovered) != 0 {
+		t.Fatalf("recovered=%+v err=%v", recovered, err)
+	}
+	history, err := db.SpeedTests(ctx, speedtest.MaxListLimit)
+	if err != nil || len(history) != 3 || history[0].ID != "four" || history[1].ID != "three" || history[2].ID != "two" {
+		t.Fatalf("history=%+v err=%v", history, err)
+	}
+	if _, err := db.SpeedTest(ctx, "one"); !errors.Is(err, speedtest.ErrNotFound) {
+		t.Fatalf("oldest terminal result was not pruned: %v", err)
+	}
+	events, err := db.RecentEvents(ctx, 10)
+	if err != nil || len(events) != 4 {
+		t.Fatalf("audit events=%+v err=%v", events, err)
 	}
 }
 

--- a/tools/release-build.sh
+++ b/tools/release-build.sh
@@ -12,6 +12,10 @@ case "$version" in
     exit 2
     ;;
 esac
+test -f RELEASE-NOTES.md || {
+  echo "release build: missing RELEASE-NOTES.md" >&2
+  exit 1
+}
 if [ -L "$out" ] || { [ -d "$out" ] && [ -n "$(find "$out" -mindepth 1 -maxdepth 1 -print -quit)" ]; }; then
   echo "release build: output must be a new or empty directory: $out" >&2
   exit 1
@@ -47,8 +51,9 @@ for target in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64; do
   CGO_ENABLED=0 GOOS=$os GOARCH=$arch go build -trimpath -buildvcs=false \
     -ldflags "-s -w -buildid=" \
     -o "$stage/oonfeewrt-recoverycheck" ./tools/recoverycheck
-  cp LICENSE NOTICE THIRD_PARTY_LICENSES RELEASE-NOTES-v0.1.0.md \
-    deploy/docker-compose.yml docs/INSTALL.md docs/FRESH-START-VALIDATION.md "$stage/"
+  cp LICENSE NOTICE THIRD_PARTY_LICENSES deploy/docker-compose.yml \
+    docs/INSTALL.md docs/FRESH-START-VALIDATION.md "$stage/"
+  cp RELEASE-NOTES.md "$stage/RELEASE-NOTES.md"
 
   python3 - "$stage" "$out/$name.tar.gz" "$epoch" "$name" <<'PY'
 import gzip

--- a/ui/e2e/desktop.spec.ts
+++ b/ui/e2e/desktop.spec.ts
@@ -115,6 +115,14 @@ const speedTests = {
       download_mbps: 216.3, upload_mbps: 412.4, idle_latency_ms: 12.1, idle_jitter_ms: 1.8,
       loaded_latency_ms: null, loaded_jitter_ms: null, bytes_downloaded: 12_000_000, bytes_uploaded: 3_000_000,
     },
+    {
+      id: '33333333333333333333333333333333', plan_id: `sha256:${'a'.repeat(64)}`,
+      state: 'completed', phase: 'complete', progress_percent: 100,
+      provider: 'Cloudflare', method: 'single stream', provenance: 'controller-host', endpoint: 'speed.cloudflare.com',
+      estimated_bytes: 15_000_000, created_at: Date.now() - 259_230_000, finished_at: Date.now() - 259_200_000,
+      download_mbps: 117.8, upload_mbps: 105.5, idle_latency_ms: 15.4, idle_jitter_ms: 2.1,
+      loaded_latency_ms: null, loaded_jitter_ms: null, bytes_downloaded: 12_000_000, bytes_uploaded: 3_000_000,
+    },
   ],
   active: null,
   test: {
@@ -128,7 +136,7 @@ const speedTests = {
     estimated_bytes: 15_000_000,
     max_duration_seconds: 30,
   },
-  limits: { max_history: 20 },
+  limits: { max_history: 3 },
   disclosure: {
     vantage_point: 'controller-host',
     router_management_calls: false,
@@ -407,7 +415,7 @@ for (const viewport of [{ width: 1280, height: 720 }, { width: 1440, height: 900
       const health = page.getByRole('region', { name: 'Internet health details' })
       const healthCharts = health.locator('.dashboard-wan-metrics')
       await expect(healthCharts.getByRole('img')).toHaveCount(4)
-      await expect(page.getByLabel(/Throughput history for 2 completed tests/)).toBeVisible()
+      await expect(page.getByLabel(/Throughput history for 3 completed tests/)).toBeVisible()
       expect(await healthCharts.evaluate((element) =>
         getComputedStyle(element).gridTemplateColumns.split(/\s+/).length)).toBe(2)
       const operationCards = page.locator('.dashboard-operations-grid > section')
@@ -438,18 +446,27 @@ for (const viewport of [{ width: 1280, height: 720 }, { width: 1440, height: 900
 
       const disclosure = page
         .getByRole('group', { name: 'Information: Dashboard metrics' })
-        .locator('summary')
+        .locator('button[aria-haspopup="dialog"]')
+      await expect(disclosure).toHaveAccessibleName('How these counts are calculated')
       const details = page.getByText(/“Wireless clients” is the same count/)
       await expect(disclosure).toHaveAttribute('aria-expanded', 'false')
       await expect(details).toBeHidden()
       await disclosure.focus()
       await disclosure.press('Enter')
       await expect(disclosure).toHaveAttribute('aria-expanded', 'true')
-      await expect(disclosure).toBeFocused()
-      await expect(details).toBeVisible()
+      const metricDialog = page.getByRole('dialog', { name: 'Information: Dashboard metrics' })
+      await expect(metricDialog).toBeVisible()
+      await expect(metricDialog.getByRole('button', {
+        name: 'Close Information: Dashboard metrics',
+      })).toBeFocused()
+      await expectWithinMain(page, metricDialog)
+      await expect(metricDialog.getByText(/“Wireless clients” is the same count/)).toBeVisible()
       const expandedOverflow = await readOverflow(page)
       expect(expandedOverflow.document).toBeLessThanOrEqual(1)
       expect(expandedOverflow.main).toBeLessThanOrEqual(1)
+      await page.keyboard.press('Escape')
+      await expect(metricDialog).toBeHidden()
+      await expect(disclosure).toBeFocused()
       expect(unexpectedRequests).toEqual([])
     })
   }
@@ -460,32 +477,52 @@ for (const viewport of [
   { width: 390, height: 844 },
   { width: 320, height: 568 },
 ]) {
-  test(`${viewport.width}px routine notices stay compact without weakening warnings`, async ({ page }) => {
+  test(`${viewport.width}px routine help and speed-test impact stay compact`, async ({ page }) => {
     await page.setViewportSize(viewport)
     const unexpectedRequests = await installControllerFixture(page)
 
     await page.goto('/')
-    const speed = page.getByRole('group', { name: 'Information: Controller speed test' })
+    const speed = page.getByRole('group', { name: 'Controller speed test' })
     const metrics = page.getByRole('group', { name: 'Information: Dashboard metrics' })
-    for (const notice of [speed, metrics]) {
-      await expect(notice).toHaveAttribute('data-compact', 'true')
-      await expectWithinMain(page, notice)
-    }
-    await expect(speed.getByRole('button', { name: 'Review speed test' })).toBeVisible()
+    await expectWithinMain(page, speed)
+    await expect(metrics).toHaveAttribute('data-compact', 'true')
+    await expectWithinMain(page, metrics)
+    const run = speed.getByRole('button', { name: 'Run speed test' })
+    const impact = speed.getByRole('button', { name: 'Impact & consent' })
+    await expect(run).toBeVisible()
+    await expect(run).toHaveAttribute('aria-describedby', /.+/)
+    await expect(speed).toContainText(/15 MB \+ overhead.*30 seconds.*no router calls or changes.*public IP/i)
+    await expect(speed.getByRole('checkbox')).toHaveCount(0)
+    await impact.click()
+    const impactDialog = page.getByRole('dialog', { name: 'Speed test impact & consent' })
+    await expect(impactDialog).toBeVisible()
+    await expectWithinMain(page, impactDialog)
+    await page.mouse.move(2, viewport.height - 2)
+    await expect(impactDialog).toBeHidden()
+    await impact.focus()
+    await impact.press('Enter')
+    await expect(impactDialog).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(impactDialog).toBeHidden()
+    await expect(impact).toBeFocused()
     if (viewport.width >= 1000) {
-      expect((await speed.boundingBox())!.height).toBeLessThanOrEqual(84)
+      expect((await speed.boundingBox())!.height).toBeLessThanOrEqual(90)
       expect((await metrics.boundingBox())!.height).toBeLessThanOrEqual(64)
     }
 
-    const metricDisclosure = metrics.locator('summary')
+    const metricDisclosure = metrics.locator('button[aria-haspopup="dialog"]')
+    await expect(metricDisclosure).toHaveAccessibleName('How these counts are calculated')
     await expect(metricDisclosure).toHaveAttribute('aria-expanded', 'false')
     expect((await metricDisclosure.boundingBox())!.height).toBeGreaterThanOrEqual(24)
     await metricDisclosure.focus()
     await metricDisclosure.press('Enter')
     await expect(metricDisclosure).toHaveAttribute('aria-expanded', 'true')
-    await expect(metricDisclosure).toBeFocused()
-    await metricDisclosure.press('Space')
+    const metricDialog = page.getByRole('dialog', { name: 'Information: Dashboard metrics' })
+    await expect(metricDialog).toBeVisible()
+    await expectWithinMain(page, metricDialog)
+    await page.keyboard.press('Escape')
     await expect(metricDisclosure).toHaveAttribute('aria-expanded', 'false')
+    await expect(metricDisclosure).toBeFocused()
 
     await page.goto('/logs')
     const sources = page.getByRole('group', { name: 'Information: General event sources' })
@@ -496,6 +533,20 @@ for (const viewport of [
     }
     await expect(ipv6.getByText('Warning', { exact: true })).toBeVisible()
     await expect(ipv6.getByText(/IPv6-only.*does not indicate an IPv4 outage/)).toBeVisible()
+    const sourceDisclosure = sources.getByRole('button', {
+      name: 'More information about event sources',
+    })
+    await sourceDisclosure.focus()
+    await sourceDisclosure.press('Enter')
+    const sourceDialog = page.getByRole('dialog', { name: 'Information: General event sources' })
+    await expect(sourceDialog).toBeVisible()
+    await expectWithinMain(page, sourceDialog)
+    await expect(sourceDialog).toContainText(/Packet-flow\/NFLOG/)
+    await page.keyboard.press('Escape')
+    await expect(sourceDialog).toBeHidden()
+    await expect(sourceDisclosure).toBeFocused()
+    await expect(ipv6.locator('details')).toHaveCount(1)
+    await expect(ipv6.locator('.details-popover')).toHaveCount(0)
     if (viewport.width >= 1000) {
       expect((await sources.boundingBox())!.height).toBeLessThanOrEqual(64)
       expect((await ipv6.boundingBox())!.height).toBeLessThanOrEqual(72)
@@ -513,6 +564,16 @@ for (const viewport of [
       await expect(notice).toHaveAttribute('data-compact', 'true')
       await expectWithinMain(page, notice)
     }
+    const uplinkDisclosure = uplinks.getByRole('button', {
+      name: 'More information about wireless uplinks',
+    })
+    await uplinkDisclosure.focus()
+    await uplinkDisclosure.press('Enter')
+    const uplinkDialog = page.getByRole('dialog', { name: 'Information: Wireless uplinks' })
+    await expect(uplinkDialog).toBeVisible()
+    await expectWithinMain(page, uplinkDialog)
+    await page.keyboard.press('Escape')
+    await expect(uplinkDisclosure).toBeFocused()
 
     const overflow = await readOverflow(page)
     expect(overflow.document).toBeLessThanOrEqual(1)
@@ -655,7 +716,7 @@ test('320px narrow dashboard, Logs pager, and Channel Plan do not clip', async (
   await healthView.getByRole('button', { name: 'Table' }).click()
   await expectWithinMain(page, health.getByRole('region', { name: 'Internet health history table' }))
   await healthView.getByRole('button', { name: 'Chart' }).click()
-  const speedChart = page.getByLabel(/Throughput history for 2 completed tests/)
+  const speedChart = page.getByLabel(/Throughput history for 3 completed tests/)
   await expect(speedChart).toBeVisible()
   await expectWithinMain(page, speedChart)
   const downloadBar = page.getByRole('meter', { name: 'Download throughput' }).first()
@@ -669,7 +730,7 @@ test('320px narrow dashboard, Logs pager, and Channel Plan do not clip', async (
   expect(Math.abs(trackBox!.x + trackBox!.width - scaleBox!.x - scaleBox!.width)).toBeLessThanOrEqual(1)
   const lastUpload = page.getByRole('meter', { name: 'Upload throughput' }).last()
   await lastUpload.focus()
-  const lastTooltip = page.getByRole('tooltip').filter({ hasText: 'Upload 412.4 Mbps' })
+  const lastTooltip = page.getByRole('tooltip').filter({ hasText: 'Upload 105.5 Mbps' })
   await expect(lastTooltip).toBeVisible()
   await expectWithinMain(page, lastTooltip)
   const speedView = page.getByRole('group', { name: 'Speed test history view' })

--- a/ui/e2e/desktop.spec.ts
+++ b/ui/e2e/desktop.spec.ts
@@ -290,8 +290,36 @@ async function installControllerFixture(page: Page, topologyResponse: unknown = 
       '/api/v1/devices': { devices: [] },
       '/api/v1/clients': clientPage,
       '/api/v1/events': {
-        events: [],
-        total: 0,
+        events: [{
+          ID: 1,
+          TS: 1_788_000_000,
+          DeviceID: 1,
+          Category: 'system',
+          Severity: 'warning',
+          Event: 'openwrt.ipv6_ra_no_default_route',
+          Detail: {
+            message: 'odhcpd[81]: No default route present, setting ra_lifetime to 0!',
+            priority: 28,
+            occurrences: 37,
+          },
+          Source: 'openwrt-logd',
+          SourceID: '81',
+          SourceBoot: 'fixture',
+          IngestedAt: 1_788_000_000_000,
+          ClientMAC: '',
+          Action: '',
+          Direction: '',
+          InIface: '',
+          OutIface: '',
+          SrcIP: '',
+          DstIP: '',
+          SrcPort: null,
+          DstPort: null,
+          ZoneIn: '',
+          ZoneOut: '',
+          PolicyID: null,
+        }],
+        total: 1,
         limit: 100,
         scope: 'general',
         next_before: null,
@@ -400,7 +428,7 @@ for (const viewport of [{ width: 1280, height: 720 }, { width: 1440, height: 900
       expect(overflow.main).toBeLessThanOrEqual(1)
 
       const noticeSummary = page.locator('.notice-summary', {
-        hasText: 'Counts use current, scoped evidence',
+        hasText: 'Current scoped evidence',
       })
       const lines = await noticeSummary.evaluate((element) => {
         const style = getComputedStyle(element)
@@ -425,6 +453,72 @@ for (const viewport of [{ width: 1280, height: 720 }, { width: 1440, height: 900
       expect(unexpectedRequests).toEqual([])
     })
   }
+}
+
+for (const viewport of [
+  { width: 1280, height: 720 },
+  { width: 390, height: 844 },
+  { width: 320, height: 568 },
+]) {
+  test(`${viewport.width}px routine notices stay compact without weakening warnings`, async ({ page }) => {
+    await page.setViewportSize(viewport)
+    const unexpectedRequests = await installControllerFixture(page)
+
+    await page.goto('/')
+    const speed = page.getByRole('group', { name: 'Information: Controller speed test' })
+    const metrics = page.getByRole('group', { name: 'Information: Dashboard metrics' })
+    for (const notice of [speed, metrics]) {
+      await expect(notice).toHaveAttribute('data-compact', 'true')
+      await expectWithinMain(page, notice)
+    }
+    await expect(speed.getByRole('button', { name: 'Review speed test' })).toBeVisible()
+    if (viewport.width >= 1000) {
+      expect((await speed.boundingBox())!.height).toBeLessThanOrEqual(84)
+      expect((await metrics.boundingBox())!.height).toBeLessThanOrEqual(64)
+    }
+
+    const metricDisclosure = metrics.locator('summary')
+    await expect(metricDisclosure).toHaveAttribute('aria-expanded', 'false')
+    expect((await metricDisclosure.boundingBox())!.height).toBeGreaterThanOrEqual(24)
+    await metricDisclosure.focus()
+    await metricDisclosure.press('Enter')
+    await expect(metricDisclosure).toHaveAttribute('aria-expanded', 'true')
+    await expect(metricDisclosure).toBeFocused()
+    await metricDisclosure.press('Space')
+    await expect(metricDisclosure).toHaveAttribute('aria-expanded', 'false')
+
+    await page.goto('/logs')
+    const sources = page.getByRole('group', { name: 'Information: General event sources' })
+    const ipv6 = page.getByRole('group', { name: 'Warning: IPv6 router advertisements' })
+    for (const notice of [sources, ipv6]) {
+      await expect(notice).toHaveAttribute('data-compact', 'true')
+      await expectWithinMain(page, notice)
+    }
+    await expect(ipv6.getByText('Warning', { exact: true })).toBeVisible()
+    await expect(ipv6.getByText(/IPv6-only.*does not indicate an IPv4 outage/)).toBeVisible()
+    if (viewport.width >= 1000) {
+      expect((await sources.boundingBox())!.height).toBeLessThanOrEqual(64)
+      expect((await ipv6.boundingBox())!.height).toBeLessThanOrEqual(72)
+      const borders = await sources.evaluate((element) => {
+        const style = getComputedStyle(element)
+        return { perimeter: style.borderTopColor, rail: style.borderLeftColor }
+      })
+      expect(borders.perimeter).not.toBe(borders.rail)
+    }
+
+    await page.goto('/settings')
+    const uplinks = page.getByRole('group', { name: 'Information: Wireless uplinks' })
+    const neighbours = page.getByRole('group', { name: 'Information: 802.11k neighbour reports' })
+    for (const notice of [uplinks, neighbours]) {
+      await expect(notice).toHaveAttribute('data-compact', 'true')
+      await expectWithinMain(page, notice)
+    }
+
+    const overflow = await readOverflow(page)
+    expect(overflow.document).toBeLessThanOrEqual(1)
+    expect(overflow.main).toBeLessThanOrEqual(1)
+    expect(unexpectedRequests).toEqual([])
+  })
 }
 
 test('Topology keeps review actions visible while technical detail is collapsed', async ({ page }) => {

--- a/ui/src/components/ui.test.tsx
+++ b/ui/src/components/ui.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { useState } from 'react'
 import { Banner, Button, DataGrid, FilterRail, Notice, PageHeader, Pager, SlideOver, Stat, Unknown, useColumnPrefs } from './ui'
 import type { Column, ColumnPrefs } from './ui'
@@ -133,11 +133,10 @@ describe('Notice', () => {
 
     const disclosures = [info, warning].map((notice) => notice.querySelector('details') as HTMLDetailsElement)
     const controlledIDs = disclosures.map((disclosure) => {
-      const summary = disclosure.querySelector('summary') as HTMLElement
+      const toggle = disclosure.querySelector('summary') as HTMLElement
       expect(disclosure.open).toBe(false)
-      expect(summary.getAttribute('aria-expanded')).toBe('false')
-      const id = summary.getAttribute('aria-controls')
-      expect(id).toBeTruthy()
+      expect(toggle.getAttribute('aria-expanded')).toBe('false')
+      const id = toggle.getAttribute('aria-controls')
       expect(document.getElementById(id!)).toBeTruthy()
       return id
     })
@@ -145,30 +144,120 @@ describe('Notice', () => {
     expect(within(info).getByRole('button', { name: 'Review' }).closest('details')).toBeNull()
   })
 
-  it('keeps an authored summary visible and exposes details with native semantics', () => {
+  it('keeps summary and live severity semantics visible while details open in a nonmodal dialog', () => {
     render(
-      <Notice
-        tone="warning"
-        component="Topology"
-        summary="Some link evidence is unavailable."
-        details="The LLDP source did not report a neighbour on lan3."
-      />,
+      <div role="status" aria-live="polite">
+        <Notice
+          tone="accent"
+          component="Topology"
+          summary="Some link evidence is unavailable."
+          details="The LLDP source did not report a neighbour on lan3."
+          popoverDetails
+        />
+      </div>,
     )
 
-    expect(screen.getByRole('group', { name: 'Warning: Topology' })).toBeTruthy()
+    expect(screen.getByRole('status').getAttribute('aria-live')).toBe('polite')
+    expect(screen.getByRole('group', { name: 'Information: Topology' })).toBeTruthy()
     expect(screen.getByText('Some link evidence is unavailable.')).toBeTruthy()
-    const toggle = screen.getByText('More information').closest('summary') as HTMLElement
-    const disclosure = toggle.closest('details') as HTMLDetailsElement
-    expect(toggle.tagName).toBe('SUMMARY')
+    const toggle = screen.getByRole('button', { name: 'More information about Topology' })
     expect(toggle.getAttribute('aria-expanded')).toBe('false')
-    expect(disclosure.open).toBe(false)
 
     toggle.focus()
     expect(document.activeElement).toBe(toggle)
-    fireEvent.click(toggle)
-    expect(disclosure.open).toBe(true)
-    expect(screen.getByText('Hide information').getAttribute('aria-expanded')).toBe('true')
-    expect(screen.getByText('The LLDP source did not report a neighbour on lan3.')).toBeTruthy()
+    fireEvent.click(toggle, { detail: 0 })
+    expect(screen.getByRole('button', { name: 'Hide information about Topology' }).getAttribute('aria-expanded')).toBe('true')
+    const dialog = screen.getByRole('dialog', { name: 'Information: Topology' })
+    expect(dialog.getAttribute('aria-modal')).toBe('false')
+    expect(within(dialog).getByText('The LLDP source did not report a neighbour on lan3.')).toBeTruthy()
+  })
+
+  it('keeps warning details inline even when popover presentation is requested', () => {
+    render(
+      <Notice
+        popoverDetails
+        component="Optional controller access payload"
+        summary="Adoption adds one scoped rpcd ACL file and login."
+        details="Exact router changes remain reviewable inline."
+      />,
+    )
+
+    const warning = screen.getByRole('group', {
+      name: 'Warning: Optional controller access payload',
+    })
+    expect(warning.querySelector('details')).toBeTruthy()
+    expect(within(warning).queryByRole('button', {
+      name: /More information about Optional controller access payload/,
+    })).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('gives adjacent passive information triggers unique accessible names', () => {
+    render(
+      <>
+        <Notice
+          tone="accent"
+          popoverDetails
+          component="Controller sessions"
+          summary="Sessions expire automatically."
+          details="Session details."
+        />
+        <Notice
+          tone="accent"
+          popoverDetails
+          component="Account authorization"
+          summary="Roles are enforced by the server."
+          details="Authorization details."
+        />
+      </>,
+    )
+
+    expect(screen.getByRole('button', {
+      name: 'More information about Controller sessions',
+    })).toBeTruthy()
+    expect(screen.getByRole('button', {
+      name: 'More information about Account authorization',
+    })).toBeTruthy()
+  })
+
+  it('dismisses mouse-opened details on leave but pins keyboard and touch activation', async () => {
+    render(
+      <Notice
+        tone="accent"
+        component="Metrics"
+        summary="Counts use current scoped evidence."
+        details="Offline and unadopted devices are excluded."
+        popoverDetails
+      />,
+    )
+    const trigger = screen.getByRole('button', { name: 'More information about Metrics' })
+    const region = trigger.closest('.details-popover') as HTMLElement
+
+    fireEvent.pointerEnter(region, { pointerType: 'mouse' })
+    expect(screen.queryByRole('dialog')).toBeNull()
+    fireEvent.pointerDown(trigger, { pointerType: 'mouse' })
+    fireEvent.click(trigger, { detail: 1 })
+    expect(screen.getByRole('dialog', { name: 'Information: Metrics' })).toBeTruthy()
+    fireEvent.pointerLeave(region, { pointerType: 'mouse' })
+    expect(screen.queryByRole('dialog')).toBeNull()
+
+    fireEvent.click(trigger, { detail: 0 })
+    fireEvent.pointerLeave(region, { pointerType: 'mouse' })
+    expect(screen.getByRole('dialog', { name: 'Information: Metrics' })).toBeTruthy()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(document.activeElement).toBe(trigger))
+    expect(screen.queryByRole('dialog')).toBeNull()
+
+    fireEvent.pointerDown(trigger, { pointerType: 'touch' })
+    fireEvent.click(trigger, { detail: 1 })
+    fireEvent.pointerLeave(region, { pointerType: 'mouse' })
+    expect(screen.getByRole('dialog', { name: 'Information: Metrics' })).toBeTruthy()
+    fireEvent.pointerDown(document.body)
+    expect(screen.queryByRole('dialog')).toBeNull()
+
+    fireEvent.click(trigger, { detail: 0 })
+    fireEvent.click(screen.getByRole('button', { name: 'Close Information: Metrics' }))
+    await waitFor(() => expect(document.activeElement).toBe(trigger))
   })
 
   it('opens an active capability plan while keeping consent actions outside it', () => {
@@ -192,14 +281,17 @@ describe('Notice', () => {
     const review = screen.getByRole('button', { name: 'Review' })
     expect(review.closest('details')).toBeNull()
     expect((screen.getByText('More information').closest('details') as HTMLDetailsElement).open).toBe(false)
+    expect(screen.queryByRole('dialog')).toBeNull()
 
     fireEvent.click(review)
     const install = screen.getByRole('button', { name: 'Install capability' })
     const cancel = screen.getByRole('button', { name: 'Cancel' })
-    expect((screen.getByText('Hide information').closest('details') as HTMLDetailsElement).open).toBe(true)
+    const disclosure = screen.getByText('Hide information').closest('details') as HTMLDetailsElement
+    expect(disclosure.open).toBe(true)
     expect(install.closest('details')).toBeNull()
     expect(cancel.closest('details')).toBeNull()
-    expect(screen.getByText(/Install lldpd/)).toBeTruthy()
+    expect(within(disclosure).getByText(/Install lldpd/)).toBeTruthy()
+    expect(screen.queryByRole('dialog')).toBeNull()
 
     fireEvent.click(cancel)
     expect((screen.getByText('More information').closest('details') as HTMLDetailsElement).open).toBe(false)

--- a/ui/src/components/ui.test.tsx
+++ b/ui/src/components/ui.test.tsx
@@ -103,6 +103,48 @@ describe('Banner', () => {
 })
 
 describe('Notice', () => {
+  it('compacts routine guidance without weakening disclosure or action semantics', () => {
+    render(
+      <>
+        <Notice
+          tone="accent"
+          compact
+          component="Routine guidance"
+          summary="The short explanation stays visible."
+          details="The full explanation stays collapsed."
+          actions={<Button>Review</Button>}
+        />
+        <Notice
+          compact
+          component="Coverage"
+          summary="Some evidence is unavailable."
+          details="One router did not report."
+        />
+      </>,
+    )
+
+    const info = screen.getByRole('group', { name: 'Information: Routine guidance' })
+    const warning = screen.getByRole('group', { name: 'Warning: Coverage' })
+    expect(info.getAttribute('data-compact')).toBe('true')
+    expect(warning.getAttribute('data-compact')).toBe('true')
+    expect(within(info).getByText('Info')).toBeTruthy()
+    expect(within(warning).getByText('Warning')).toBeTruthy()
+    expect(within(info).getByText('The short explanation stays visible.')).toBeTruthy()
+
+    const disclosures = [info, warning].map((notice) => notice.querySelector('details') as HTMLDetailsElement)
+    const controlledIDs = disclosures.map((disclosure) => {
+      const summary = disclosure.querySelector('summary') as HTMLElement
+      expect(disclosure.open).toBe(false)
+      expect(summary.getAttribute('aria-expanded')).toBe('false')
+      const id = summary.getAttribute('aria-controls')
+      expect(id).toBeTruthy()
+      expect(document.getElementById(id!)).toBeTruthy()
+      return id
+    })
+    expect(new Set(controlledIDs).size).toBe(2)
+    expect(within(info).getByRole('button', { name: 'Review' }).closest('details')).toBeNull()
+  })
+
   it('keeps an authored summary visible and exposes details with native semantics', () => {
     render(
       <Notice

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -1,4 +1,4 @@
-import { Children, isValidElement, useEffect, useId, useRef, useState } from 'react'
+import { Children, isValidElement, useCallback, useEffect, useId, useRef, useState } from 'react'
 import type { CSSProperties, MouseEventHandler, ReactNode } from 'react'
 import { moveColumn, orderColumns, parsePrefs } from '../lib/columns'
 import type { ColumnPrefs } from '../lib/columns'
@@ -149,6 +149,7 @@ export function Button({
   type = 'button',
   style,
   'aria-label': ariaLabel,
+  'aria-describedby': ariaDescribedBy,
   'aria-pressed': ariaPressed,
 }: {
   children: ReactNode
@@ -158,12 +159,14 @@ export function Button({
   type?: 'button' | 'submit'
   style?: CSSProperties
   'aria-label'?: string
+  'aria-describedby'?: string
   'aria-pressed'?: boolean
 }) {
   return (
     <button
       type={type}
       aria-label={ariaLabel}
+      aria-describedby={ariaDescribedBy}
       aria-pressed={ariaPressed}
       onClick={onClick}
       disabled={disabled}
@@ -284,9 +287,145 @@ export function Unknown({ why }: { why: string }) {
 
 export type NoticeTone = 'warning' | 'critical' | 'accent'
 
-/** Authored progressive disclosure. Unlike Banner's compatibility-oriented
- *  length heuristic, Notice keeps the consequence, affected component and
- *  actions visible while native details/summary owns the full explanation. */
+/** Nonmodal details that stay out of the document flow. A mouse-opened panel
+ *  dismisses when the pointer leaves; keyboard and touch activation persist
+ *  until an explicit close, Escape, or an outside press. */
+export function DetailsPopover({
+  triggerLabel,
+  openTriggerLabel = triggerLabel,
+  triggerAriaLabel = triggerLabel,
+  openTriggerAriaLabel = openTriggerLabel,
+  title,
+  children,
+  className = '',
+  panelClassName = '',
+}: {
+  triggerLabel: string
+  openTriggerLabel?: string
+  triggerAriaLabel?: string
+  openTriggerAriaLabel?: string
+  title: string
+  children: ReactNode
+  className?: string
+  panelClassName?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const regionRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const closeRef = useRef<HTMLButtonElement>(null)
+  const openMode = useRef<'mouse' | 'persistent' | null>(null)
+  const pointerType = useRef('')
+  const focusPanelOnOpen = useRef(false)
+  const panelID = useId()
+  const titleID = useId()
+  const supportsPopover = typeof HTMLElement !== 'undefined' &&
+    typeof HTMLElement.prototype.showPopover === 'function'
+
+  const close = useCallback((restoreFocus = false) => {
+    setOpen(false)
+    openMode.current = null
+    pointerType.current = ''
+    focusPanelOnOpen.current = false
+    if (restoreFocus) window.requestAnimationFrame(() => triggerRef.current?.focus())
+  }, [])
+
+  useEffect(() => {
+    try {
+      if (open) panelRef.current?.showPopover?.()
+      else panelRef.current?.hidePopover?.()
+    } catch {
+      // `hidden` remains the fallback where the Popover API is unavailable.
+    }
+    if (open && focusPanelOnOpen.current) {
+      focusPanelOnOpen.current = false
+      window.requestAnimationFrame(() => closeRef.current?.focus())
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: PointerEvent) => {
+      if (!regionRef.current?.contains(event.target as Node)) close()
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      event.stopPropagation()
+      close(true)
+    }
+    document.addEventListener('pointerdown', onPointerDown, true)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown, true)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [close, open])
+
+  return (
+    <div
+      ref={regionRef}
+      className={`details-popover ${className}`.trim()}
+      onPointerLeave={(event) => {
+        if (event.pointerType === 'mouse' && openMode.current === 'mouse') close()
+      }}
+    >
+      <button
+        ref={triggerRef}
+        type="button"
+        className="details-popover-trigger"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={panelID}
+        aria-label={open ? openTriggerAriaLabel : triggerAriaLabel}
+        onPointerDown={(event) => { pointerType.current = event.pointerType }}
+        onClick={(event) => {
+          if (open) {
+            close()
+            return
+          }
+          const keyboard = event.detail === 0
+          const persistent = keyboard || pointerType.current !== 'mouse'
+          openMode.current = persistent ? 'persistent' : 'mouse'
+          focusPanelOnOpen.current = keyboard
+          pointerType.current = ''
+          setOpen(true)
+        }}
+      >
+        {open ? openTriggerLabel : triggerLabel}
+      </button>
+      <div
+        ref={panelRef}
+        id={panelID}
+        className={`details-popover-panel ${panelClassName}`.trim()}
+        role="dialog"
+        aria-modal="false"
+        aria-labelledby={titleID}
+        popover={supportsPopover ? 'manual' : undefined}
+        hidden={!supportsPopover && !open}
+        onFocusCapture={() => { openMode.current = 'persistent' }}
+      >
+        <div className="details-popover-heading">
+          <strong id={titleID}>{title}</strong>
+          <button
+            ref={closeRef}
+            type="button"
+            className="details-popover-close"
+            aria-label={`Close ${title}`}
+            onClick={() => close(true)}
+          >
+            ×
+          </button>
+        </div>
+        <div className="details-popover-content">{children}</div>
+      </div>
+    </div>
+  )
+}
+
+/** Authored progressive disclosure. Consequences, affected components, and
+ *  actions stay visible. Passive informational details use a nonmodal popover;
+ *  warnings, errors, actions, and active plans stay inline. */
 export function Notice({
   tone = 'warning',
   component,
@@ -297,6 +436,7 @@ export function Notice({
   actions,
   closedLabel = 'More information',
   openLabel = 'Hide information',
+  popoverDetails = false,
 }: {
   tone?: NoticeTone
   component: string
@@ -309,17 +449,19 @@ export function Notice({
   actions?: ReactNode
   closedLabel?: string
   openLabel?: string
+  /** Move supplemental detail into a nonmodal popover. Use only for passive
+   *  informational copy; warnings, errors, actions, and active plans stay inline. */
+  popoverDetails?: boolean
 }) {
-  const [open, setOpen] = useState(defaultOpen)
+  const [inlineOpen, setInlineOpen] = useState(defaultOpen)
   const detailsID = useId()
   const toneLabel = tone === 'accent' ? 'Information' : tone === 'critical' ? 'Critical' : 'Warning'
   const visibleToneLabel = compact && tone === 'accent' ? 'Info' : toneLabel
+  const popover = popoverDetails && tone === 'accent' && !defaultOpen &&
+    actions == null && !bannerHasAction(details)
 
-  // A capability can render compactly, fetch its exact plan from a visible
-  // Review action, then expand it. Synchronize both lifecycle transitions so
-  // Cancel closes details along with the active plan.
   useEffect(() => {
-    setOpen(defaultOpen)
+    setInlineOpen(defaultOpen)
   }, [defaultOpen])
 
   return (
@@ -337,18 +479,33 @@ export function Notice({
         <span>{component}</span>
       </div>
       <div className="notice-summary">{summary}</div>
-      <details
-        className="notice-disclosure"
-        open={open}
-        onToggle={(event) => setOpen(event.currentTarget.open)}
-      >
-        <summary aria-controls={detailsID} aria-expanded={open}>
-          {open ? openLabel : closedLabel}
-        </summary>
-        <div id={detailsID} className="notice-details">
+      {!popover ? (
+        <details
+          className="notice-disclosure"
+          data-mode="inline"
+          open={inlineOpen}
+          onToggle={(event) => setInlineOpen(event.currentTarget.open)}
+        >
+          <summary aria-controls={detailsID} aria-expanded={inlineOpen}>
+            {inlineOpen ? openLabel : closedLabel}
+          </summary>
+          <div id={detailsID} className="notice-inline-details">{details}</div>
+        </details>
+      ) : (
+        <DetailsPopover
+          className="notice-disclosure"
+          panelClassName="notice-details"
+          triggerLabel={closedLabel}
+          openTriggerLabel={openLabel}
+          triggerAriaLabel={closedLabel === 'More information'
+            ? `More information about ${component}` : closedLabel}
+          openTriggerAriaLabel={openLabel === 'Hide information'
+            ? `Hide information about ${component}` : openLabel}
+          title={`${toneLabel}: ${component}`}
+        >
           {details}
-        </div>
-      </details>
+        </DetailsPopover>
+      )}
       {actions != null && <div className="notice-actions">{actions}</div>}
     </div>
   )

--- a/ui/src/components/ui.tsx
+++ b/ui/src/components/ui.tsx
@@ -293,6 +293,7 @@ export function Notice({
   summary,
   details,
   defaultOpen = false,
+  compact = false,
   actions,
   closedLabel = 'More information',
   openLabel = 'Hide information',
@@ -302,6 +303,9 @@ export function Notice({
   summary: ReactNode
   details: ReactNode
   defaultOpen?: boolean
+  /** Use for routine guidance and non-blocking conditions. Consent, retry,
+   *  acknowledgement, active-operation and critical notices stay standard. */
+  compact?: boolean
   actions?: ReactNode
   closedLabel?: string
   openLabel?: string
@@ -309,6 +313,7 @@ export function Notice({
   const [open, setOpen] = useState(defaultOpen)
   const detailsID = useId()
   const toneLabel = tone === 'accent' ? 'Information' : tone === 'critical' ? 'Critical' : 'Warning'
+  const visibleToneLabel = compact && tone === 'accent' ? 'Info' : toneLabel
 
   // A capability can render compactly, fetch its exact plan from a visible
   // Review action, then expand it. Synchronize both lifecycle transitions so
@@ -321,11 +326,13 @@ export function Notice({
     <div
       className="notice"
       data-tone={tone}
+      data-compact={compact ? 'true' : undefined}
+      data-actions={actions != null ? 'true' : undefined}
       role="group"
       aria-label={`${toneLabel}: ${component}`}
     >
       <div className="notice-context">
-        <span>{toneLabel}</span>
+        <span>{visibleToneLabel}</span>
         <span aria-hidden="true">·</span>
         <span>{component}</span>
       </div>

--- a/ui/src/lib/api.test.ts
+++ b/ui/src/lib/api.test.ts
@@ -17,6 +17,14 @@ afterEach(() => {
 })
 
 describe('response trust boundary', () => {
+  it('requests the three retained speed-test attempts by default', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({ jobs: [], active: null }))
+
+    await api.speedTests()
+
+    expect(vi.mocked(fetch).mock.calls[0][0]).toBe('/api/v1/speedtests?limit=3')
+  })
+
   it.each([
     ['empty', '', 503],
     ['plain text', 'upstream unavailable', 502],
@@ -582,7 +590,7 @@ describe('radio scan API contract', () => {
 })
 
 describe('speed test API contract', () => {
-  it('binds the data-use acknowledgement to the exact reviewed plan', async () => {
+  it('binds the data-use acknowledgement to the exact current plan', async () => {
     vi.mocked(fetch).mockResolvedValue(ok({ id: 'job', state: 'queued' }))
     const planID = `sha256:${'a'.repeat(64)}`
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1813,7 +1813,7 @@ export const api = {
     }),
 
   dashboard: () => get<Dashboard>('/dashboard'),
-  speedTests: (limit = 20) =>
+  speedTests: (limit = 3) =>
     get<SpeedTestCollection>(`/speedtests?limit=${encodeURIComponent(limit)}`),
   speedTest: (id: string) => get<SpeedTestJob>(`/speedtests/${encodeURIComponent(id)}`),
   startSpeedTest: (planID: string, acknowledgeDataUse: boolean) =>

--- a/ui/src/lib/tokens.css
+++ b/ui/src/lib/tokens.css
@@ -359,6 +359,114 @@ a {
   margin-top: 8px;
 }
 
+/* Routine guidance is a quiet, single-row annotation. Explicit opt-in keeps
+   consent, recovery, active-operation and critical surfaces at full weight. */
+.notice[data-compact='true'] {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px 8px;
+  padding: 6px 8px;
+  border-color: var(--border);
+  border-left: 3px solid var(--notice-tone);
+  background: var(--surface-1);
+}
+
+.notice[data-compact='true'][data-tone='critical'] {
+  border-color: var(--critical);
+  border-left-color: var(--critical);
+}
+
+.notice[data-compact='true'] .notice-context {
+  flex: 0 0 auto;
+  gap: 4px;
+  line-height: 1.35;
+}
+
+.notice[data-compact='true'] .notice-summary {
+  flex: 1 1 120px;
+  min-width: 0;
+  margin-top: 0;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.notice[data-compact='true'] .notice-disclosure {
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
+.notice[data-compact='true'] .notice-disclosure > summary {
+  display: flex;
+  align-items: center;
+  min-height: 28px;
+  margin-top: 0;
+  line-height: 1.25;
+}
+
+.notice[data-compact='true'] .notice-disclosure[open] {
+  flex: 1 0 100%;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+}
+
+.notice[data-compact='true'] .notice-details {
+  margin-top: 6px;
+}
+
+.notice[data-compact='true'] .notice-actions {
+  flex: 0 0 auto;
+  margin-top: 0;
+}
+
+@media (min-width: 721px) {
+  .notice[data-compact='true'] {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .notice[data-compact='true'] .notice-context {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .notice[data-compact='true'] .notice-summary {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .notice[data-compact='true'] .notice-disclosure {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .notice[data-compact='true'] .notice-actions {
+    grid-column: 3;
+    grid-row: 2;
+  }
+
+  .notice[data-compact='true'] .notice-disclosure[open] {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .notice[data-compact='true'][data-actions='true'] .notice-summary {
+    grid-column: 2 / -1;
+  }
+
+  .notice[data-compact='true'][data-actions='true'] .notice-disclosure:not([open]) {
+    grid-column: 2;
+    grid-row: 2;
+    justify-self: end;
+  }
+
+  .notice[data-compact='true'][data-actions='true'] .notice-disclosure[open] ~ .notice-actions {
+    grid-column: 1 / -1;
+    grid-row: 3;
+    justify-self: end;
+  }
+}
+
 .settings-page,
 .account-page {
   display: grid;
@@ -449,6 +557,14 @@ a {
   display: grid;
   gap: 12px;
   min-width: 0;
+}
+
+.logs-notice-row {
+  padding: 8px 12px 0;
+}
+
+.settings-compact-notice {
+  margin-bottom: 6px;
 }
 
 .radio-stat-grid,

--- a/ui/src/lib/tokens.css
+++ b/ui/src/lib/tokens.css
@@ -303,6 +303,85 @@ a {
   display: inline;
 }
 
+.details-popover {
+  display: inline-flex;
+  min-width: 0;
+}
+
+.details-popover-trigger {
+  min-height: 28px;
+  padding: 0 4px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  text-align: left;
+}
+
+.details-popover-trigger:hover,
+.details-popover-trigger:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.details-popover-panel {
+  position: fixed;
+  z-index: 40;
+  inset: 56px 16px auto auto;
+  width: min(520px, calc(100vw - 32px));
+  max-height: calc(100dvh - 72px);
+  margin: 0;
+  padding: 12px;
+  overflow: auto;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--surface-1);
+  box-shadow: 0 14px 36px rgb(0 0 0 / 35%);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.45;
+  text-align: left;
+}
+
+.details-popover-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.details-popover-close {
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  padding: 0;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.details-popover-close:hover,
+.details-popover-close:focus-visible {
+  background: var(--surface-2);
+  color: var(--text-primary);
+}
+
+.details-popover-content > :first-child {
+  margin-top: 0;
+}
+
+.details-popover-content > :last-child {
+  margin-bottom: 0;
+}
+
 .notice {
   --notice-tone: var(--warning);
   --notice-tone-text: var(--warning);
@@ -340,7 +419,8 @@ a {
   font-weight: 600;
 }
 
-.notice-disclosure > summary {
+.notice-disclosure > summary,
+.notice-disclosure > .details-popover-trigger {
   width: fit-content;
   margin-top: 6px;
   color: var(--notice-tone-text);
@@ -349,6 +429,10 @@ a {
 }
 
 .notice-details {
+  border-left: 3px solid var(--notice-tone);
+}
+
+.notice-inline-details {
   margin-top: 8px;
 }
 
@@ -396,7 +480,8 @@ a {
   min-width: 0;
 }
 
-.notice[data-compact='true'] .notice-disclosure > summary {
+.notice[data-compact='true'] .notice-disclosure > summary,
+.notice[data-compact='true'] .notice-disclosure > .details-popover-trigger {
   display: flex;
   align-items: center;
   min-height: 28px;
@@ -404,13 +489,13 @@ a {
   line-height: 1.25;
 }
 
-.notice[data-compact='true'] .notice-disclosure[open] {
+.notice[data-compact='true'] details.notice-disclosure[open] {
   flex: 1 0 100%;
   padding-top: 6px;
   border-top: 1px solid var(--border);
 }
 
-.notice[data-compact='true'] .notice-details {
+.notice[data-compact='true'] .notice-inline-details {
   margin-top: 6px;
 }
 
@@ -445,7 +530,7 @@ a {
     grid-row: 2;
   }
 
-  .notice[data-compact='true'] .notice-disclosure[open] {
+  .notice[data-compact='true'] details.notice-disclosure[open] {
     grid-column: 1 / -1;
     grid-row: 2;
   }
@@ -454,16 +539,24 @@ a {
     grid-column: 2 / -1;
   }
 
-  .notice[data-compact='true'][data-actions='true'] .notice-disclosure:not([open]) {
+  .notice[data-compact='true'][data-actions='true'] details.notice-disclosure:not([open]) {
     grid-column: 2;
     grid-row: 2;
     justify-self: end;
   }
 
-  .notice[data-compact='true'][data-actions='true'] .notice-disclosure[open] ~ .notice-actions {
+  .notice[data-compact='true'][data-actions='true'] details.notice-disclosure[open] ~ .notice-actions {
     grid-column: 1 / -1;
     grid-row: 3;
     justify-self: end;
+  }
+}
+
+@media (max-width: 720px) {
+  .details-popover-panel {
+    inset: 56px 8px auto 72px;
+    width: auto;
+    max-height: calc(100dvh - 64px);
   }
 }
 
@@ -1737,18 +1830,107 @@ a {
   font-size: 18px !important;
 }
 
-.speedtest-consent {
+.speedtest-launch {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 7px 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+  background: var(--surface-0);
+}
+
+.speedtest-launch-consequence {
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.speedtest-launch-actions {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 8px;
+}
+
+.speedtest-impact {
+  position: relative;
+}
+
+.speedtest-impact-trigger,
+.speedtest-impact-close {
+  border: 0;
+  color: var(--accent-text);
+  background: transparent;
+  cursor: pointer;
+}
+
+.speedtest-impact-trigger {
+  min-height: 28px;
+  padding: 0 4px;
+  font-size: 12px;
   font-weight: 600;
 }
 
-.speedtest-consent input {
-  width: 16px;
-  height: 16px;
-  margin: 1px 0 0;
-  accent-color: var(--accent);
+.speedtest-impact-close {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 5px;
+  color: var(--text-secondary);
+  font-size: 20px;
+  line-height: 1;
+}
+
+.speedtest-impact-trigger:hover,
+.speedtest-impact-trigger:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.speedtest-impact-close:hover,
+.speedtest-impact-close:focus-visible {
+  color: var(--text-primary);
+  background: var(--surface-2);
+}
+
+.speedtest-impact-popover {
+  position: fixed;
+  z-index: 30;
+  inset: 76px 16px auto auto;
+  width: min(500px, calc(100vw - 32px));
+  max-height: calc(100dvh - 92px);
+  margin: 0;
+  padding: 12px;
+  overflow: auto;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  color: var(--text-primary);
+  background: var(--surface-1);
+  box-shadow: 0 14px 36px rgb(0 0 0 / 35%);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.speedtest-impact-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.speedtest-impact-popover p {
+  margin: 8px 0 0;
+}
+
+.speedtest-launch > .speedtest-plan-unavailable {
+  grid-column: 1 / -1;
 }
 
 .speedtest-plan {
@@ -2112,6 +2294,24 @@ a {
   .speedtest-chart-scale {
     margin-right: 83px;
     margin-left: 73px;
+  }
+
+  .speedtest-launch {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .speedtest-launch-actions {
+    justify-content: flex-start;
+  }
+
+  .speedtest-impact-popover {
+    inset: 56px 8px auto 72px;
+    width: auto;
+    max-height: calc(100dvh - 64px);
+  }
+
+  .speedtest-impact-popover .speedtest-plan {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/ui/src/screens/Account.tsx
+++ b/ui/src/screens/Account.tsx
@@ -151,6 +151,7 @@ export function Account({
         <div style={{ padding: 14, borderBottom: '1px solid var(--border)' }}>
           <Notice
             tone="accent"
+            popoverDetails
             component="Controller sessions"
             summary="Review where this account is signed in and revoke access you do not recognize."
             details="Session records live in controller memory. Restarting the controller invalidates all sessions. Peer addresses identify the connection seen by the controller and may be a proxy address."

--- a/ui/src/screens/Accounts.tsx
+++ b/ui/src/screens/Accounts.tsx
@@ -243,6 +243,7 @@ export function Accounts({
     <div className="account-page">
       <Notice
         tone="accent"
+        popoverDetails
         component="Account authorization"
         summary="Only owners can administer controller accounts."
         details="This tab is a convenience, not the security boundary. The controller checks the signed-in account role on every request and records account changes in the audit history."

--- a/ui/src/screens/Dashboard.tsx
+++ b/ui/src/screens/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { api } from '../lib/api'
 import type {
   Dashboard as DashboardData,
@@ -322,7 +322,7 @@ export function SpeedTestHistory({ jobs }: { jobs: SpeedTestJob[] }) {
       <div className="speedtest-history-toolbar">
         <div>
           <div className="speedtest-history-heading">Recent performance</div>
-          <div className="dashboard-metric-note">Five most recent tests · controller host/container</div>
+          <div className="dashboard-metric-note">Up to three recent attempts · controller host/container</div>
         </div>
         <div className="speedtest-view-toggle" role="group" aria-label="Speed test history view">
           <Button aria-pressed={view === 'chart'} kind={view === 'chart' ? 'primary' : 'default'} onClick={() => setView('chart')}>
@@ -415,21 +415,163 @@ export function SpeedTestHistory({ jobs }: { jobs: SpeedTestJob[] }) {
   )
 }
 
+function SpeedTestImpact({
+  plan,
+  disclosure,
+}: {
+  plan: SpeedTestCollection['test'] | undefined
+  disclosure: SpeedTestCollection['disclosure'] | undefined
+}) {
+  const [open, setOpen] = useState(false)
+  const regionRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const closeRef = useRef<HTMLButtonElement>(null)
+  const openMode = useRef<'mouse' | 'persistent' | null>(null)
+  const pointerType = useRef('')
+  const previousPlanID = useRef(plan?.plan_id)
+  const panelID = useId()
+  const titleID = useId()
+  const supportsPopover = typeof HTMLElement !== 'undefined' &&
+    typeof HTMLElement.prototype.showPopover === 'function'
+
+  const close = useCallback((restoreFocus = false) => {
+    setOpen(false)
+    openMode.current = null
+    if (restoreFocus) window.requestAnimationFrame(() => triggerRef.current?.focus())
+  }, [])
+
+  useEffect(() => {
+    try {
+      if (open) panelRef.current?.showPopover?.()
+      else panelRef.current?.hidePopover?.()
+    } catch {
+      // The panel is still rendered as a fixed-position fallback.
+    }
+    if (open && openMode.current === 'persistent' && pointerType.current === '') {
+      window.requestAnimationFrame(() => closeRef.current?.focus())
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: PointerEvent) => {
+      if (!regionRef.current?.contains(event.target as Node)) close()
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      close(true)
+    }
+    document.addEventListener('pointerdown', onPointerDown, true)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown, true)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [close, open])
+
+  useEffect(() => {
+    if (previousPlanID.current === plan?.plan_id) return
+    previousPlanID.current = plan?.plan_id
+    if (open) close()
+  }, [close, open, plan?.plan_id])
+
+  const data = plan?.estimated_bytes && plan.estimated_bytes > 0
+    ? `About ${formatBytes(plan.estimated_bytes)} plus protocol overhead`
+    : 'Data estimate unavailable'
+  const duration = plan?.max_duration_seconds && plan.max_duration_seconds > 0
+    ? `Up to ${plan.max_duration_seconds} seconds`
+    : 'Duration unavailable'
+
+  return (
+    <div
+      ref={regionRef}
+      className="speedtest-impact"
+      onPointerLeave={(event) => {
+        if (event.pointerType === 'mouse' && openMode.current !== 'persistent') close()
+      }}
+    >
+      <button
+        ref={triggerRef}
+        type="button"
+        className="speedtest-impact-trigger"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={panelID}
+        onPointerDown={(event) => { pointerType.current = event.pointerType }}
+        onClick={(event) => {
+          if (open) {
+            close()
+            return
+          }
+          const persistent = event.detail === 0 || pointerType.current !== 'mouse'
+          openMode.current = persistent ? 'persistent' : 'mouse'
+          if (event.detail === 0) pointerType.current = ''
+          setOpen(true)
+        }}
+      >
+        Impact &amp; consent
+      </button>
+      <div
+        ref={panelRef}
+        id={panelID}
+        className="speedtest-impact-popover"
+        role="dialog"
+        aria-modal="false"
+        aria-labelledby={titleID}
+        popover={supportsPopover ? 'manual' : undefined}
+        hidden={!supportsPopover && !open}
+        onFocusCapture={() => { openMode.current = 'persistent' }}
+      >
+        <div className="speedtest-impact-heading">
+          <strong id={titleID}>Speed test impact &amp; consent</strong>
+          <button
+            ref={closeRef}
+            type="button"
+            className="speedtest-impact-close"
+            aria-label="Close speed test impact and consent"
+            onClick={() => close(true)}
+          >
+            ×
+          </button>
+        </div>
+        <dl className="speedtest-plan">
+          <div><dt>Vantage point</dt><dd>{disclosure?.vantage_point ? speedTestProvenance(disclosure.vantage_point) : 'Unavailable'}</dd></div>
+          <div><dt>Provider</dt><dd>{plan?.provider || 'Unavailable'}</dd></div>
+          <div><dt>Provider origin</dt><dd>{plan?.endpoint || 'Unavailable'}</dd></div>
+          <div><dt>Method</dt><dd>{plan?.method || 'Unavailable'}</dd></div>
+          <div><dt>Data</dt><dd>{data}</dd></div>
+          <div><dt>Duration</dt><dd>{duration}</dd></div>
+          <div><dt>Download endpoint</dt><dd>{plan?.download_endpoint || 'Unavailable'}</dd></div>
+          <div><dt>Upload endpoint</dt><dd>{plan?.upload_endpoint || 'Unavailable'}</dd></div>
+          <div><dt>Router management calls</dt><dd><code>{typeof disclosure?.router_management_calls === 'boolean' ? String(disclosure.router_management_calls) : 'Unavailable'}</code></dd></div>
+          <div><dt>Router changes</dt><dd><code>{typeof disclosure?.router_changes === 'boolean' ? String(disclosure.router_changes) : 'Unavailable'}</code></dd></div>
+        </dl>
+        <p>{disclosure?.saturation_warning || 'Connection-impact disclosure unavailable.'}</p>
+        <p>{disclosure?.privacy || 'Public-IP disclosure unavailable.'}</p>
+        <p className="dashboard-metric-note">
+          Selecting Run speed test acknowledges this data use and possible temporary saturation.
+        </p>
+      </div>
+    </div>
+  )
+}
+
 function SpeedTestCard() {
   const [collection, setCollection] = useState<SpeedTestCollection | null>(null)
-  const [review, setReview] = useState(false)
-  const [acknowledgedPlanID, setAcknowledgedPlanID] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
   const refreshGeneration = useRef(0)
   const refreshInFlight = useRef<Promise<SpeedTestCollection | null> | null>(null)
+  const startInFlight = useRef(false)
   const planID = collection?.test?.plan_id ?? ''
-  const acknowledged = planID !== '' && acknowledgedPlanID === planID
+  const consequenceID = useId()
 
   const refresh = useCallback(async () => {
     if (refreshInFlight.current) return refreshInFlight.current
     const generation = ++refreshGeneration.current
-    const request = api.speedTests(20).then((next) => {
+    const request = api.speedTests(3).then((next) => {
       if (generation === refreshGeneration.current) {
         setCollection(next)
         setError('')
@@ -460,8 +602,8 @@ function SpeedTestCard() {
   }, [collection?.active?.id, refresh])
 
   const start = async () => {
-    if (!acknowledged || collection?.active) return
-    setAcknowledgedPlanID('')
+    if (startInFlight.current || busy || !planReady || !planID || collection?.active) return
+    startInFlight.current = true
     refreshGeneration.current++
     refreshInFlight.current = null
     setBusy(true)
@@ -471,13 +613,12 @@ function SpeedTestCard() {
       refreshGeneration.current++
       refreshInFlight.current = null
       setCollection((current) => mergeSpeedTest(current, job))
-      setReview(false)
-      setAcknowledgedPlanID('')
       void refresh()
     } catch (cause) {
       setError(errorText(cause))
       void refresh()
     } finally {
+      startInFlight.current = false
       setBusy(false)
     }
   }
@@ -517,7 +658,29 @@ function SpeedTestCard() {
   )
   const maxDuration = plan?.max_duration_seconds
   const estimatedBytes = plan?.estimated_bytes
-  const history = (collection?.jobs ?? []).filter((job) => !active || job.id !== active.id).slice(0, 5)
+  const history = (collection?.jobs ?? []).filter((job) => !active || job.id !== active.id).slice(0, 3)
+  const provider = plan?.provider || 'Provider unavailable'
+  const providerRoute = plan?.provider && plan.endpoint
+    ? `${plan.provider} via ${plan.endpoint}`
+    : 'provider or endpoint unavailable'
+  const vantage = disclosure?.vantage_point === 'controller-host'
+    ? 'controller host'
+    : 'vantage point unavailable'
+  const data = estimatedBytes && estimatedBytes > 0
+    ? `~${formatBytes(estimatedBytes)} + overhead`
+    : 'data estimate unavailable'
+  const duration = maxDuration && maxDuration > 0
+    ? `up to ${maxDuration} seconds`
+    : 'duration unavailable'
+  const saturation = disclosure?.saturation_warning?.trim()
+    ? 'may temporarily saturate WAN'
+    : 'saturation disclosure unavailable'
+  const privacy = disclosure?.privacy?.trim()
+    ? `public IP visible to ${provider}`
+    : 'public-IP disclosure unavailable'
+  const routerImpact = disclosure?.router_management_calls === false && disclosure.router_changes === false
+    ? 'no router calls or changes'
+    : 'router safety unavailable'
 
   return (
     <Card
@@ -564,68 +727,27 @@ function SpeedTestCard() {
           </div>
         </div>
       ) : (
-        <Notice
-          tone="accent"
-          compact={!review}
-          component="Controller speed test"
-          summary="Runs on the controller; it installs no packages and makes no router changes."
-          defaultOpen={review}
-          closedLabel="Impact and consent"
-          openLabel="Hide impact"
-          details={(
-            <div style={{ display: 'grid', gap: 8 }}>
-              <div>
-                The test can temporarily saturate the Internet connection for up to{' '}
-                {maxDuration ? `${maxDuration} seconds` : 'the controller limit'}
-                {' '}and transfers approximately{' '}
-                {estimatedBytes ? formatBytes(estimatedBytes) : 'an unavailable amount of data'}
-                {' '}plus protocol overhead.
-              </div>
-              {plan && (
-                <dl className="speedtest-plan">
-                  <div><dt>Vantage point</dt><dd>{disclosure?.vantage_point ? speedTestProvenance(disclosure.vantage_point) : 'Unavailable'}</dd></div>
-                  <div><dt>Provider</dt><dd>{plan.provider || 'Unavailable'}</dd></div>
-                  <div><dt>Provider origin</dt><dd>{plan.endpoint || 'Unavailable'}</dd></div>
-                  <div><dt>Download endpoint</dt><dd>{plan.download_endpoint || 'Unavailable'}</dd></div>
-                  <div><dt>Upload endpoint</dt><dd>{plan.upload_endpoint || 'Unavailable'}</dd></div>
-                  <div><dt>Method</dt><dd>{plan.method || 'Unavailable'}</dd></div>
-                  <div><dt>Router management calls</dt><dd><code>{typeof disclosure?.router_management_calls === 'boolean' ? String(disclosure.router_management_calls) : 'Unavailable'}</code></dd></div>
-                  <div><dt>Router changes</dt><dd><code>{typeof disclosure?.router_changes === 'boolean' ? String(disclosure.router_changes) : 'Unavailable'}</code></dd></div>
-                </dl>
-              )}
-              {!planReady && (
-                <div className="speedtest-plan-unavailable" role="status">
-                  Exact provider, endpoints, method, provenance, limits, and safety disclosures are unavailable or incomplete; Start remains disabled.
-                </div>
-              )}
-              <div>
-                {disclosure?.privacy || 'Privacy disclosure unavailable.'}
-              </div>
-              {disclosure?.saturation_warning && <div>{disclosure.saturation_warning}</div>}
-              <label className="speedtest-consent">
-                <input
-                  type="checkbox"
-                  checked={acknowledged}
-                  onChange={(event) => setAcknowledgedPlanID(event.target.checked ? planID : '')}
-                />
-                <span>I understand this may use data and temporarily saturate the connection.</span>
-              </label>
+        <div className="speedtest-launch" role="group" aria-label="Controller speed test">
+          <div id={consequenceID} className="speedtest-launch-consequence">
+            {providerRoute} · {vantage} · {data} · {duration} · {routerImpact} · {saturation} · {privacy}
+          </div>
+          {!planReady && (
+            <div className="speedtest-plan-unavailable" role="status">
+              Exact provider, endpoints, method, provenance, limits, and safety disclosures are unavailable or incomplete; Run remains disabled.
             </div>
           )}
-          actions={review ? (
-            <>
-              <Button disabled={busy} onClick={() => {
-                setReview(false)
-                setAcknowledgedPlanID('')
-              }}>Cancel review</Button>
-              <Button kind="primary" disabled={busy || !acknowledged || !planReady} onClick={start}>
-                {busy ? 'Starting…' : 'Start speed test'}
-              </Button>
-            </>
-          ) : (
-            <Button onClick={() => setReview(true)}>Review speed test</Button>
-          )}
-        />
+          <div className="speedtest-launch-actions">
+            <SpeedTestImpact plan={plan} disclosure={disclosure} />
+            <Button
+              kind="primary"
+              disabled={busy || !planReady}
+              aria-describedby={consequenceID}
+              onClick={start}
+            >
+              {busy ? 'Starting…' : 'Run speed test'}
+            </Button>
+          </div>
+        </div>
       )}
 
       {error && (
@@ -1024,6 +1146,7 @@ export function Dashboard({
 
       <Notice
         tone="accent"
+        popoverDetails
         compact
         component="Dashboard metrics"
         summary="Current scoped evidence; definitions and exclusions are available."

--- a/ui/src/screens/Dashboard.tsx
+++ b/ui/src/screens/Dashboard.tsx
@@ -566,11 +566,12 @@ function SpeedTestCard() {
       ) : (
         <Notice
           tone="accent"
+          compact={!review}
           component="Controller speed test"
-          summary="Runs from this controller host/container; it does not install packages or change router settings."
+          summary="Runs on the controller; it installs no packages and makes no router changes."
           defaultOpen={review}
-          closedLabel="Test impact and consent"
-          openLabel="Hide test impact"
+          closedLabel="Impact and consent"
+          openLabel="Hide impact"
           details={(
             <div style={{ display: 'grid', gap: 8 }}>
               <div>
@@ -1023,8 +1024,9 @@ export function Dashboard({
 
       <Notice
         tone="accent"
+        compact
         component="Dashboard metrics"
-        summary="Counts use current, scoped evidence; definitions and exclusions are available below."
+        summary="Current scoped evidence; definitions and exclusions are available."
         closedLabel="How these counts are calculated"
         openLabel="Hide count definitions"
         details={(

--- a/ui/src/screens/Logs.tsx
+++ b/ui/src/screens/Logs.tsx
@@ -316,6 +316,7 @@ export function Logs() {
             <div className="logs-notice-row">
               <Notice
                 tone="accent"
+                popoverDetails
                 compact
                 component="General event sources"
                 summary="Controller events, router syslog, and hostapd association events."

--- a/ui/src/screens/Logs.tsx
+++ b/ui/src/screens/Logs.tsx
@@ -313,11 +313,12 @@ export function Logs() {
             </div>
           )}
           {scope === 'general' && (
-            <div style={{ padding: '12px 12px 0' }}>
+            <div className="logs-notice-row">
               <Notice
                 tone="accent"
+                compact
                 component="General event sources"
-                summary="General combines controller events, router syslog and hostapd association events."
+                summary="Controller events, router syslog, and hostapd association events."
                 details="Packet-flow/NFLOG, GeoIP and application identity are not collected in this phase; blank enrichment fields mean unavailable, not no traffic."
                 closedLabel="More information about event sources"
                 openLabel="Hide event source information"
@@ -325,8 +326,9 @@ export function Logs() {
             </div>
           )}
           {scope === 'general' && page && !coverage.complete && (
-            <div style={{ padding: '12px 12px 0' }}>
+            <div className="logs-notice-row">
               <Notice
+                compact
                 component="Router log coverage"
                 summary={(
                   <div role="status">
@@ -344,8 +346,9 @@ export function Logs() {
             </div>
           )}
           {clockSkew && (
-            <div style={{ padding: '12px 12px 0' }}>
+            <div className="logs-notice-row">
               <Notice
+                compact
                 component="Router clock"
                 summary={(
                   <div role="status">
@@ -361,14 +364,15 @@ export function Logs() {
             </div>
           )}
           {scope === 'general' && ipv6RAConditions.length > 0 && (
-            <div style={{ padding: '12px 12px 0' }}>
+            <div className="logs-notice-row">
               <Notice
                 tone="warning"
+                compact
                 component="IPv6 router advertisements"
                 summary={(
                   <div role="status">
-                    OpenWrt reported no usable IPv6 default route while sending router
-                    advertisements. This concerns IPv6 and does not indicate an IPv4 outage.
+                    OpenWrt found no usable IPv6 default route for router advertisements.
+                    {' '}This warning is IPv6-only; it does not indicate an IPv4 outage.
                   </div>
                 )}
                 details={`${ipv6RAOccurrences.toLocaleString()} reported occurrence${ipv6RAOccurrences === 1 ? '' : 's'} ${ipv6RAOccurrences === 1 ? 'is' : 'are'} condensed into ${ipv6RAConditions.length} condition record${ipv6RAConditions.length === 1 ? '' : 's'} on this page. The original warning priority, message, first and latest source timestamps remain in event detail.`}

--- a/ui/src/screens/PolicyEngine.test.tsx
+++ b/ui/src/screens/PolicyEngine.test.tsx
@@ -157,21 +157,26 @@ describe('Policy Engine', () => {
     expect(screen.queryByRole('button', { name: /Edit Internet \/ WAN policy/i })).toBeNull()
     const scope = screen.getByRole('group', { name: 'Information: Zone Matrix scope' })
     expect(within(scope).getByText(/manages whole-zone forwarding only/i)).toBeTruthy()
-    const scopeToggle = within(scope).getByText('More information about Zone Matrix scope')
-    const scopeDetails = scopeToggle.closest('details')
-    expect(scopeDetails?.open).toBe(false)
+    const scopeToggle = within(scope).getByRole('button', {
+      name: 'More information about Zone Matrix scope',
+    })
+    expect(scopeToggle.getAttribute('aria-expanded')).toBe('false')
+    expect(scope.querySelector('details')).toBeNull()
     fireEvent.click(scopeToggle)
-    expect(scopeDetails?.open).toBe(true)
-    expect(scope.textContent).toMatch(
+    expect(scopeToggle.getAttribute('aria-expanded')).toBe('true')
+    const scopeDetails = screen.getByRole('dialog', {
+      name: 'Information: Zone Matrix scope',
+    })
+    expect(scopeDetails.textContent).toMatch(
       /WAN-initiated allow rules, port forwards, per-client or per-port rules, application filtering, QoS, and DPI are not implemented by this Zone Matrix editor/i,
     )
-    expect(scope.textContent).toMatch(
+    expect(scopeDetails.textContent).toMatch(
       /explicit gateway policies it also reads active nftables transit hooks and reachable rules/i,
     )
-    expect(scope.textContent).toMatch(
+    expect(scopeDetails.textContent).toMatch(
       /terse runtime view cannot prove include-file provenance or inspect set contents/i,
     )
-    expect(scope.textContent).toMatch(
+    expect(scopeDetails.textContent).toMatch(
       /!fw4: attribution comments can be imitated by direct custom rules/i,
     )
   })

--- a/ui/src/screens/PolicyEngine.tsx
+++ b/ui/src/screens/PolicyEngine.tsx
@@ -412,6 +412,7 @@ function ZoneMatrix({ zones, openEditor }: {
     <div style={{ display: 'grid', gap: 14 }}>
       <Notice
         tone="accent"
+        popoverDetails
         component="Zone Matrix scope"
         summary="The Zone Matrix manages whole-zone forwarding only. Use Master Table for explicit firewall, port-forward, and route records."
         closedLabel="More information about Zone Matrix scope"

--- a/ui/src/screens/Settings.tsx
+++ b/ui/src/screens/Settings.tsx
@@ -2839,6 +2839,7 @@ function Neighbours({ site }: { site: Site }) {
       <div className="settings-compact-notice">
         <Notice
           tone="accent"
+          popoverDetails
           compact
           component="802.11k neighbour reports"
           summary="Refreshes automatically every 15 minutes and after Apply."
@@ -3148,6 +3149,7 @@ function Uplinks({
       <div className="settings-compact-notice">
         <Notice
           tone="accent"
+          popoverDetails
           compact
           component="Wireless uplinks"
           summary="Bridges an uncabled device over Wi-Fi; the target network must allow wireless bridges."

--- a/ui/src/screens/Settings.tsx
+++ b/ui/src/screens/Settings.tsx
@@ -2836,11 +2836,12 @@ function Neighbours({ site }: { site: Site }) {
     >
       {err && <div role="alert"><Banner tone="critical">{err}</Banner></div>}
 
-      <div style={{ marginBottom: 10 }}>
+      <div className="settings-compact-notice">
         <Notice
           tone="accent"
+          compact
           component="802.11k neighbour reports"
-          summary="Automatically refreshes neighbour reports every 15 minutes and after every Apply."
+          summary="Refreshes automatically every 15 minutes and after Apply."
           closedLabel="More information about neighbour reports"
           openLabel="Hide neighbour report information"
           details="Each access point is told the BSSIDs and channels of the others carrying the same SSID, so a roaming client scans those channels instead of all of them. No AP can learn this by itself. An AP that restarts comes back with an empty list, so it is re-checked rather than assumed."
@@ -3144,11 +3145,12 @@ function Uplinks({
     <Card title="Wireless uplinks">
       {err && <div role="alert"><Banner tone="critical">{err}</Banner></div>}
 
-      <div style={{ marginBottom: 10 }}>
+      <div className="settings-compact-notice">
         <Notice
           tone="accent"
+          compact
           component="Wireless uplinks"
-          summary="Lets an uncabled device bridge a network over the air; that network must accept wireless bridges first."
+          summary="Bridges an uncabled device over Wi-Fi; the target network must allow wireless bridges."
           closedLabel="More information about wireless uplinks"
           openLabel="Hide wireless uplink information"
           details={(

--- a/ui/src/screens/screens.test.tsx
+++ b/ui/src/screens/screens.test.tsx
@@ -2599,7 +2599,8 @@ describe('Settings — neighbour reports', () => {
     const notice = await screen.findByRole('group', {
       name: 'Information: 802.11k neighbour reports',
     })
-    expect(within(notice).getByText(/every 15 minutes and after every Apply/)).toBeTruthy()
+    expect(notice.getAttribute('data-compact')).toBe('true')
+    expect(within(notice).getByText(/every 15 minutes and after Apply/)).toBeTruthy()
     const toggle = within(notice).getByText('More information about neighbour reports')
     const details = toggle.closest('details') as HTMLDetailsElement
     expect(details.open).toBe(false)
@@ -2995,7 +2996,8 @@ describe('Settings — wireless uplinks', () => {
     render(<Settings devices={[{ id: 7, name: 'no-cable' } as never]} />)
 
     const notice = await screen.findByRole('group', { name: 'Information: Wireless uplinks' })
-    expect(within(notice).getByText(/network must accept wireless bridges first/)).toBeTruthy()
+    expect(notice.getAttribute('data-compact')).toBe('true')
+    expect(within(notice).getByText(/target network must allow wireless bridges/)).toBeTruthy()
     const toggle = within(notice).getByText('More information about wireless uplinks')
     const details = toggle.closest('details') as HTMLDetailsElement
     expect(details.open).toBe(false)
@@ -4246,7 +4248,10 @@ describe('Logs', () => {
     const { unmount } = render(<Logs />)
     expectSinglePageHeading('Logs')
     expect(screen.getByText(/Controller, router, and audit events/)).toBeTruthy()
+    const sourceNotice = screen.getByRole('group', { name: 'Information: General event sources' })
+    expect(sourceNotice.getAttribute('data-compact')).toBe('true')
     const coverageNotice = await screen.findByRole('group', { name: 'Warning: Router log coverage' })
+    expect(coverageNotice.getAttribute('data-compact')).toBe('true')
     expect(within(coverageNotice).getByText(/Router log coverage is incomplete/)).toBeTruthy()
     expect(within(coverageNotice).getByText(/an empty result is not proven/)).toBeTruthy()
     const coverageToggle = within(coverageNotice).getByText('More information about log coverage')
@@ -4427,8 +4432,9 @@ describe('Logs', () => {
 
 	expect(await screen.findByText(/IPv6 router advertisements have no usable default route · 37 occurrences/)).toBeTruthy()
 	const notice = screen.getByRole('group', { name: 'Warning: IPv6 router advertisements' })
+	expect(notice.getAttribute('data-compact')).toBe('true')
 	expect(within(notice).getByRole('status').textContent ?? '').toMatch(
-	  /does not indicate an IPv4 outage/i,
+	  /IPv6-only.*does not indicate an IPv4 outage/i,
 	)
 	const toggle = within(notice).getByText('More information about this IPv6 warning')
 	const details = toggle.closest('details') as HTMLDetailsElement
@@ -4926,7 +4932,9 @@ describe('Dashboard', () => {
     const { Dashboard } = await import('./Dashboard')
     render(<Dashboard data={data as never} />)
 
-    expect(screen.getByText(/Counts use current, scoped evidence/)).toBeTruthy()
+    const metricNotice = screen.getByRole('group', { name: 'Information: Dashboard metrics' })
+    expect(metricNotice.getAttribute('data-compact')).toBe('true')
+    expect(within(metricNotice).getByText(/Current scoped evidence/)).toBeTruthy()
     const summary = screen.getByText('How these counts are calculated').closest('summary') as HTMLElement
     const disclosure = summary.closest('details') as HTMLDetailsElement
     expect(disclosure.open).toBe(false)
@@ -5144,7 +5152,12 @@ describe('Dashboard', () => {
     render(<Dashboard data={data as never} />)
     await waitFor(() => expect(api.speedTests).toHaveBeenCalledWith(20))
 
-    fireEvent.click(screen.getByRole('button', { name: 'Review speed test' }))
+    const speedNotice = screen.getByRole('group', { name: 'Information: Controller speed test' })
+    const reviewSpeedTest = screen.getByRole('button', { name: 'Review speed test' })
+    expect(speedNotice.getAttribute('data-compact')).toBe('true')
+    expect(reviewSpeedTest.closest('details')).toBeNull()
+    fireEvent.click(reviewSpeedTest)
+    expect(speedNotice.getAttribute('data-compact')).toBeNull()
     expect(screen.getByText('librespeed')).toBeTruthy()
     expect(screen.getByText('https://speed.example')).toBeTruthy()
     expect(screen.getByText('https://speed.example/down')).toBeTruthy()

--- a/ui/src/screens/screens.test.tsx
+++ b/ui/src/screens/screens.test.tsx
@@ -2601,13 +2601,18 @@ describe('Settings — neighbour reports', () => {
     })
     expect(notice.getAttribute('data-compact')).toBe('true')
     expect(within(notice).getByText(/every 15 minutes and after Apply/)).toBeTruthy()
-    const toggle = within(notice).getByText('More information about neighbour reports')
-    const details = toggle.closest('details') as HTMLDetailsElement
-    expect(details.open).toBe(false)
-    expect(screen.getByRole('button', { name: 'Distribute now' }).closest('details')).toBeNull()
+    const toggle = within(notice).getByRole('button', {
+      name: 'More information about neighbour reports',
+    })
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(notice.querySelector('details')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Distribute now' }).closest('.details-popover-panel')).toBeNull()
     fireEvent.click(toggle)
-    expect(details.open).toBe(true)
-    expect(within(notice).getByText(/An AP that restarts comes back with an empty list/)).toBeTruthy()
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    const details = screen.getByRole('dialog', {
+      name: 'Information: 802.11k neighbour reports',
+    })
+    expect(within(details).getByText(/An AP that restarts comes back with an empty list/)).toBeTruthy()
   })
 
   // The distinction the whole capability model exists to protect, at the UI
@@ -2998,13 +3003,16 @@ describe('Settings — wireless uplinks', () => {
     const notice = await screen.findByRole('group', { name: 'Information: Wireless uplinks' })
     expect(notice.getAttribute('data-compact')).toBe('true')
     expect(within(notice).getByText(/target network must allow wireless bridges/)).toBeTruthy()
-    const toggle = within(notice).getByText('More information about wireless uplinks')
-    const details = toggle.closest('details') as HTMLDetailsElement
-    expect(details.open).toBe(false)
-    expect(screen.getByRole('button', { name: 'Add uplink' }).closest('details')).toBeNull()
+    const toggle = within(notice).getByRole('button', {
+      name: 'More information about wireless uplinks',
+    })
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(notice.querySelector('details')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Add uplink' }).closest('.details-popover-panel')).toBeNull()
     fireEvent.click(toggle)
-    expect(details.open).toBe(true)
-    expect(within(notice).getByText(/joins as a 4-address bridge/)).toBeTruthy()
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    const details = screen.getByRole('dialog', { name: 'Information: Wireless uplinks' })
+    expect(within(details).getByText(/joins as a 4-address bridge/)).toBeTruthy()
   })
 
   // One per device, and the reason is said rather than merely enforced: a
@@ -4935,13 +4943,17 @@ describe('Dashboard', () => {
     const metricNotice = screen.getByRole('group', { name: 'Information: Dashboard metrics' })
     expect(metricNotice.getAttribute('data-compact')).toBe('true')
     expect(within(metricNotice).getByText(/Current scoped evidence/)).toBeTruthy()
-    const summary = screen.getByText('How these counts are calculated').closest('summary') as HTMLElement
-    const disclosure = summary.closest('details') as HTMLDetailsElement
-    expect(disclosure.open).toBe(false)
+    const summary = within(metricNotice).getByRole('button', {
+      name: 'How these counts are calculated',
+    })
+    expect(summary.getAttribute('aria-expanded')).toBe('false')
+    expect(metricNotice.querySelector('details')).toBeNull()
 
     fireEvent.click(summary)
-    expect(disclosure.open).toBe(true)
-    expect(screen.getByText('Hide count definitions')).toBeTruthy()
+    expect(summary.getAttribute('aria-expanded')).toBe('true')
+    const definitions = screen.getByRole('dialog', { name: 'Information: Dashboard metrics' })
+    expect(within(definitions).getByText(/Wireless clients/)).toBeTruthy()
+    expect(within(metricNotice).getByRole('button', { name: 'Hide count definitions' })).toBeTruthy()
   })
 
   it('withholds a fleet total when any device station set is unknown', async () => {
@@ -5127,11 +5139,20 @@ describe('Dashboard', () => {
     expect(screen.getByRole('alert').textContent).toContain('Backup')
   })
 
-  it('requires explicit data-use consent before starting a controller speed test', async () => {
+  it('uses the explicit Run action as plan-bound acknowledgement and keeps exact impact in a popover', async () => {
     const { Dashboard } = await import('./Dashboard')
+    const attempts = ['history-newest', 'history-second', 'history-third', 'history-hidden'].map((provider, index) => ({
+      id: `${index + 1}`.repeat(32), plan_id: speedPlanID,
+      state: 'completed', phase: 'complete', progress_percent: 100,
+      provider, method: 'embedded HTTP', provenance: 'controller-host', endpoint: 'https://speed.example',
+      estimated_bytes: 500_000_000, created_at: 30 - index, finished_at: 31 - index,
+      download_mbps: 100 - index, upload_mbps: 50 - index,
+      idle_latency_ms: 10, idle_jitter_ms: 1, loaded_latency_ms: null, loaded_jitter_ms: null,
+      bytes_downloaded: 10, bytes_uploaded: 10,
+    }))
     api.speedTests.mockResolvedValueOnce({
-      jobs: [], active: null,
-      limits: { max_history: 20 },
+      jobs: attempts, active: null,
+      limits: { max_history: 3 },
       test: {
         plan_id: speedPlanID,
         provider: 'librespeed', method: 'embedded HTTP', provenance: 'controller-host',
@@ -5150,37 +5171,91 @@ describe('Dashboard', () => {
       estimated_bytes: 500_000_000, created_at: 1, bytes_downloaded: 0, bytes_uploaded: 0,
     })
     render(<Dashboard data={data as never} />)
-    await waitFor(() => expect(api.speedTests).toHaveBeenCalledWith(20))
+    await waitFor(() => expect(api.speedTests).toHaveBeenCalledWith(3))
+    expect(screen.getByLabelText(/Throughput history for 3 completed tests/)).toBeTruthy()
+    expect(screen.getAllByText(/history-third/).length).toBeGreaterThan(0)
+    expect(screen.queryByText(/history-hidden/)).toBeNull()
 
-    const speedNotice = screen.getByRole('group', { name: 'Information: Controller speed test' })
-    const reviewSpeedTest = screen.getByRole('button', { name: 'Review speed test' })
-    expect(speedNotice.getAttribute('data-compact')).toBe('true')
-    expect(reviewSpeedTest.closest('details')).toBeNull()
-    fireEvent.click(reviewSpeedTest)
-    expect(speedNotice.getAttribute('data-compact')).toBeNull()
-    expect(screen.getByText('librespeed')).toBeTruthy()
-    expect(screen.getByText('https://speed.example')).toBeTruthy()
-    expect(screen.getByText('https://speed.example/down')).toBeTruthy()
-    expect(screen.getByText('https://speed.example/up')).toBeTruthy()
-    expect(screen.getByText('embedded HTTP')).toBeTruthy()
-    expect(screen.getByText(/public IP are visible to the provider/)).toBeTruthy()
-    expect(screen.getByText(/approximately 500 MB plus protocol overhead/)).toBeTruthy()
-    expect(screen.getAllByText('false')).toHaveLength(2)
-    const consent = screen.getByRole('checkbox', {
-      name: /may use data and temporarily saturate the connection/i,
-    }) as HTMLInputElement
-    const start = screen.getByRole('button', { name: 'Start speed test' }) as HTMLButtonElement
-    expect(start.disabled).toBe(true)
-    fireEvent.click(consent)
-    expect(start.disabled).toBe(false)
-    fireEvent.click(start)
+    const speed = screen.getByRole('group', { name: 'Controller speed test' })
+    const run = within(speed).getByRole('button', { name: 'Run speed test' }) as HTMLButtonElement
+    expect(run.disabled).toBe(false)
+    expect(screen.queryByRole('checkbox')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Review speed test' })).toBeNull()
+    const consequence = document.getElementById(run.getAttribute('aria-describedby') || '')
+    expect(consequence?.textContent).toMatch(
+      /librespeed via https:\/\/speed\.example.*controller host.*500 MB \+ overhead.*up to 90 seconds.*no router calls or changes.*saturate WAN.*public IP/i,
+    )
+
+    const impact = within(speed).getByRole('button', { name: 'Impact & consent' })
+    expect(document.getElementById(impact.getAttribute('aria-controls') || '')).toBeTruthy()
+    expect(impact.getAttribute('aria-expanded')).toBe('false')
+    fireEvent.click(impact)
+    const dialog = screen.getByRole('dialog', { name: 'Speed test impact & consent' })
+    expect(impact.getAttribute('aria-expanded')).toBe('true')
+    expect(within(dialog).getByText('https://speed.example')).toBeTruthy()
+    expect(within(dialog).getByText('https://speed.example/down')).toBeTruthy()
+    expect(within(dialog).getByText('https://speed.example/up')).toBeTruthy()
+    expect(within(dialog).getByText('embedded HTTP')).toBeTruthy()
+    expect(within(dialog).getByText(/public IP are visible to the provider/)).toBeTruthy()
+    expect(within(dialog).getByText('About 500 MB plus protocol overhead')).toBeTruthy()
+    expect(within(dialog).getAllByText('false')).toHaveLength(2)
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Close speed test impact and consent' }))
+    await waitFor(() => expect(document.activeElement).toBe(impact))
+
+    fireEvent.click(run)
+    fireEvent.click(run)
     await waitFor(() => expect(api.startSpeedTest).toHaveBeenCalledWith(speedPlanID, true))
+    expect(api.startSpeedTest).toHaveBeenCalledTimes(1)
   })
 
-  it('never invents absent safety disclosures or enables Start for a partial plan', async () => {
+  it('dismisses mouse-opened impact on pointer leave but pins keyboard and touch activation', async () => {
     const { Dashboard } = await import('./Dashboard')
     api.speedTests.mockResolvedValueOnce({
-      jobs: [], active: null, limits: { max_history: 20 },
+      jobs: [], active: null, limits: { max_history: 3 },
+      test: {
+        plan_id: speedPlanID,
+        provider: 'Cloudflare', method: 'embedded HTTP', provenance: 'controller-host',
+        endpoint: 'https://speed.example', download_endpoint: 'https://speed.example/down',
+        upload_endpoint: 'https://speed.example/up', estimated_bytes: 15_000_000, max_duration_seconds: 30,
+      },
+      disclosure: {
+        vantage_point: 'controller-host', router_management_calls: false, router_changes: false,
+        saturation_warning: 'May temporarily saturate the gateway/WAN.',
+        privacy: "The controller host's public IP is visible to Cloudflare.",
+      },
+    })
+    render(<Dashboard data={data as never} />)
+    const impact = await screen.findByRole('button', { name: 'Impact & consent' })
+    const region = impact.closest('.speedtest-impact') as HTMLElement
+
+    fireEvent.pointerEnter(region, { pointerType: 'mouse' })
+    expect(screen.queryByRole('dialog', { name: 'Speed test impact & consent' })).toBeNull()
+    fireEvent.pointerDown(impact, { pointerType: 'mouse' })
+    fireEvent.click(impact, { detail: 1 })
+    expect(screen.getByRole('dialog', { name: 'Speed test impact & consent' })).toBeTruthy()
+    fireEvent.pointerLeave(region, { pointerType: 'mouse' })
+    expect(screen.queryByRole('dialog', { name: 'Speed test impact & consent' })).toBeNull()
+
+    fireEvent.click(impact, { detail: 0 })
+    const keyboardDialog = screen.getByRole('dialog', { name: 'Speed test impact & consent' })
+    fireEvent.pointerLeave(region, { pointerType: 'mouse' })
+    expect(screen.getByRole('dialog', { name: 'Speed test impact & consent' })).toBe(keyboardDialog)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(document.activeElement).toBe(impact))
+    expect(screen.queryByRole('dialog', { name: 'Speed test impact & consent' })).toBeNull()
+
+    fireEvent.pointerDown(impact, { pointerType: 'touch' })
+    fireEvent.click(impact, { detail: 1 })
+    fireEvent.pointerLeave(region, { pointerType: 'mouse' })
+    expect(screen.getByRole('dialog', { name: 'Speed test impact & consent' })).toBeTruthy()
+    fireEvent.pointerDown(document.body)
+    expect(screen.queryByRole('dialog', { name: 'Speed test impact & consent' })).toBeNull()
+  })
+
+  it('never invents absent safety disclosures or enables Run for a partial plan', async () => {
+    const { Dashboard } = await import('./Dashboard')
+    api.speedTests.mockResolvedValueOnce({
+      jobs: [], active: null, limits: { max_history: 3 },
       test: {
         plan_id: speedPlanID,
         provider: 'librespeed', method: 'embedded HTTP', provenance: 'controller-host',
@@ -5197,13 +5272,15 @@ describe('Dashboard', () => {
     } as never)
     render(<Dashboard data={data as never} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Review speed test' }))
-    await screen.findByText(/safety disclosures are unavailable or incomplete/)
-    const review = screen.getByRole('group', { name: 'Information: Controller speed test' })
-    expect(within(review).getAllByText('Unavailable')).toHaveLength(2)
-    expect(within(review).getByText('Privacy disclosure unavailable.')).toBeTruthy()
-    fireEvent.click(screen.getByRole('checkbox', { name: /may use data/i }))
-    expect((screen.getByRole('button', { name: 'Start speed test' }) as HTMLButtonElement).disabled).toBe(true)
+    const impact = await screen.findByRole('button', { name: 'Impact & consent' })
+    expect(screen.getByText(/safety disclosures are unavailable or incomplete/)).toBeTruthy()
+    expect(screen.getByRole('group', { name: 'Controller speed test' })
+      .querySelector('.speedtest-launch-consequence')?.textContent).toMatch(/public-IP disclosure unavailable/i)
+    fireEvent.click(impact)
+    const dialog = screen.getByRole('dialog', { name: 'Speed test impact & consent' })
+    expect(within(dialog).getAllByText('Unavailable')).toHaveLength(2)
+    expect(within(dialog).getByText('Public-IP disclosure unavailable.')).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'Run speed test' }) as HTMLButtonElement).disabled).toBe(true)
     expect(api.startSpeedTest).not.toHaveBeenCalled()
   })
 
@@ -5215,7 +5292,7 @@ describe('Dashboard', () => {
         endpoint: 'https://speed.example', download_endpoint: 'https://speed.example/down',
         upload_endpoint: 'https://speed.example/up', estimated_bytes: 400_000_000, max_duration_seconds: 90,
       },
-      limits: { max_history: 20 },
+      limits: { max_history: 3 },
       disclosure: {
         vantage_point: 'controller-host', router_management_calls: false, router_changes: false,
         saturation_warning: 'May saturate the WAN.', privacy: 'Public IP is visible to the provider.',
@@ -5238,18 +5315,14 @@ describe('Dashboard', () => {
     const { Dashboard } = await import('./Dashboard')
     render(<Dashboard data={data as never} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Review speed test' }))
-    await screen.findByText('librespeed')
-    fireEvent.click(screen.getByRole('checkbox', { name: /may use data/i }))
-    fireEvent.click(screen.getByRole('button', { name: 'Start speed test' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Run speed test' }))
 
     const progress = await screen.findByRole('progressbar', { name: 'Controller speed test progress' })
     expect(progress.getAttribute('aria-valuetext')).toContain('latency')
     expect(api.speedTests).toHaveBeenCalledTimes(2)
-    const retry = await screen.findByRole('button', { name: 'Start speed test' }, { timeout: 2_500 }) as HTMLButtonElement
-    const freshConsent = screen.getByRole('checkbox', { name: /may use data/i }) as HTMLInputElement
-    expect(freshConsent.checked).toBe(false)
-    expect(retry.disabled).toBe(true)
+    const retry = await screen.findByRole('button', { name: 'Run speed test' }, { timeout: 2_500 }) as HTMLButtonElement
+    expect(retry.disabled).toBe(false)
+    expect(api.startSpeedTest).toHaveBeenCalledTimes(1)
   })
 
   it('shows controller provenance, progress, cancellation and result history', async () => {
@@ -5269,7 +5342,7 @@ describe('Dashboard', () => {
     }
     api.speedTests.mockResolvedValueOnce({
       jobs: [active, completed], active,
-      limits: { max_history: 20 },
+      limits: { max_history: 3 },
     })
     api.cancelSpeedTest.mockResolvedValue({ ...active, state: 'cancelling', phase: 'cancelling' })
     const { Dashboard } = await import('./Dashboard')
@@ -5295,7 +5368,7 @@ describe('Dashboard', () => {
       bytes_downloaded: 30_000_000, bytes_uploaded: 10_000_000,
     }
     const collection = {
-      jobs: [active], active, limits: { max_history: 20 },
+      jobs: [active], active, limits: { max_history: 3 },
       test: {
         plan_id: speedPlanID,
         provider: 'librespeed', method: 'embedded', provenance: 'controller-host',


### PR DESCRIPTION
## Summary\n\n- simplify controller speed-test consent and retain the three newest terminal attempts\n- move passive informational detail into accessible popovers while keeping warnings and safety actions inline\n- add version-safe v0.1.1 release notes, archive/container packaging, and install guidance\n\n## Validation\n\n- [x] go mod verify / tidy\n- [x] go test ./... / go vet ./...\n- [x] go test -race ./...\n- [x] UI unit, browser, audit, build, budget\n- [x] tree/history secret scans\n- [x] reproducible v0.1.1 archives\n- [x] container backup/restore smoke