### PR TITLE
docs: add comprehensive documentation portal

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,75 @@
+name: Documentation
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "README.md"
+      - ".github/workflows/docs.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "README.md"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.event_name == 'pull_request' && github.ref || 'pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: Build and validate
+    permissions:
+      contents: read
+      pages: read
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+      - name: Install dependencies
+        run: npm --prefix docs ci
+      - name: Audit dependencies
+        run: npm --prefix docs audit --audit-level=high
+      - name: Build documentation
+        run: npm --prefix docs run build
+      - name: Configure GitHub Pages
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - name: Upload GitHub Pages artifact
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Deploy documentation
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ __pycache__/
 /dist/
 ui/playwright-report/
 ui/test-results/
+docs/.vitepress/cache/
+docs/.vitepress/dist/
+docs/node_modules/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Self-hosted, UniFi-inspired management for stock OpenWrt.
 [![Release](https://img.shields.io/github/v/release/aiden0rchad/oonfeeWRT)](https://github.com/aiden0rchad/oonfeeWRT/releases)
 [![CI](https://github.com/aiden0rchad/oonfeeWRT/actions/workflows/ci.yml/badge.svg)](https://github.com/aiden0rchad/oonfeeWRT/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/aiden0rchad/oonfeeWRT)](LICENSE)
+[![Documentation](https://img.shields.io/badge/docs-capabilities%20%26%20guides-2a78d6)](https://aiden0rchad.github.io/oonfeeWRT/)
+
+**[Explore the complete documentation →](https://aiden0rchad.github.io/oonfeeWRT/)**
+Capabilities, guided setup, safe configuration, operations, security,
+troubleshooting, and engineering reference—with full-text search and light/dark
+themes.
 
 oonfeeWRT is a controller, not firmware. It runs on your server, NAS, mini-PC,
 or Mac and manages OpenWrt devices through their existing interfaces. Your
@@ -254,6 +260,7 @@ oonfeeWRT rejects passphrases supplied through environment variables.
 
 ## Documentation
 
+- [Documentation site — capabilities, setup, guides, and troubleshooting](https://aiden0rchad.github.io/oonfeeWRT/)
 - [Install, upgrade, TLS, and recovery](docs/INSTALL.md)
 - [v0.1.1 release notes](RELEASE-NOTES-v0.1.1.md)
 - [v0.1.0 release notes](RELEASE-NOTES-v0.1.0.md)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,122 @@
+import { defineConfig } from 'vitepress'
+
+const start = [
+  { text: 'What oonfeeWRT does', link: '/getting-started/' },
+  { text: 'Quick start', link: '/getting-started/quick-start' },
+  { text: 'Adopt your first device', link: '/getting-started/first-adoption' },
+]
+
+const install = [
+  { text: 'Standalone binary', link: '/installation/binary' },
+  { text: 'Docker Compose', link: '/installation/docker' },
+  { text: 'Reverse proxy and TLS', link: '/installation/reverse-proxy' },
+  { text: 'Upgrade and roll back', link: '/installation/upgrades' },
+]
+
+const use = [
+  { text: 'Dashboard and speed tests', link: '/guide/dashboard' },
+  { text: 'Discovery, adoption, and devices', link: '/guide/devices' },
+  { text: 'Networks, VLANs, and DHCP', link: '/guide/networks' },
+  { text: 'Wi-Fi, roaming, and overrides', link: '/guide/wifi' },
+  { text: 'Radios and channel planning', link: '/guide/radios' },
+  { text: 'Clients and topology', link: '/guide/clients-topology' },
+  { text: 'Policy Engine and firewall', link: '/guide/policy-engine' },
+  { text: 'Logs and diagnostics', link: '/guide/logs-diagnostics' },
+]
+
+const operate = [
+  { text: 'Accounts, roles, and sessions', link: '/operations/accounts' },
+  { text: 'Backup and staged restore', link: '/operations/backups' },
+  { text: 'Routine maintenance', link: '/operations/maintenance' },
+]
+
+const understand = [
+  { text: 'How the controller works', link: '/concepts/architecture' },
+  { text: 'Safety and ownership model', link: '/concepts/safety' },
+  { text: 'Telemetry and retention', link: '/concepts/data-retention' },
+  { text: 'Permissions', link: '/concepts/permissions' },
+]
+
+const reference = [
+  { text: 'Requirements and compatibility', link: '/reference/requirements' },
+  { text: 'CLI and environment', link: '/reference/cli' },
+  { text: 'Capability and support matrix', link: '/reference/capabilities' },
+  { text: 'Troubleshooting', link: '/reference/troubleshooting' },
+  { text: 'FAQ', link: '/reference/faq' },
+  { text: 'Engineering reference', link: '/reference/engineering' },
+  { text: 'Release notes', link: '/reference/releases' },
+]
+
+export default defineConfig({
+  lang: 'en-US',
+  title: 'oonfeeWRT',
+  titleTemplate: ':title | oonfeeWRT Docs',
+  description: 'Install, configure, operate, and understand the oonfeeWRT OpenWrt controller.',
+  base: '/oonfeeWRT/',
+  cleanUrls: true,
+  lastUpdated: true,
+  sitemap: { hostname: 'https://aiden0rchad.github.io/oonfeeWRT/' },
+  head: [
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/oonfeeWRT/favicon.svg' }],
+    ['meta', { name: 'theme-color', content: '#f5f6f8', media: '(prefers-color-scheme: light)' }],
+    ['meta', { name: 'theme-color', content: '#0f1114', media: '(prefers-color-scheme: dark)' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:title', content: 'oonfeeWRT Documentation' }],
+    ['meta', { property: 'og:description', content: 'Self-hosted, UniFi-inspired management for stock OpenWrt.' }],
+    ['meta', { property: 'og:image', content: 'https://aiden0rchad.github.io/oonfeeWRT/social-card.svg' }],
+  ],
+  markdown: {
+    lineNumbers: true,
+  },
+  themeConfig: {
+    logo: {
+      light: '/logo-light.svg',
+      dark: '/logo-dark.svg',
+      alt: 'oonfeeWRT',
+    },
+    siteTitle: 'oonfeeWRT Docs',
+    nav: [
+      { text: 'Start here', link: '/getting-started/' },
+      { text: 'Guides', link: '/guide/dashboard' },
+      { text: 'Operations', link: '/operations/accounts' },
+      { text: 'Reference', link: '/reference/requirements' },
+      {
+        text: 'v0.1.1',
+        items: [
+          { text: 'Release notes', link: '/reference/releases' },
+          { text: 'Download', link: 'https://github.com/aiden0rchad/oonfeeWRT/releases/tag/v0.1.1' },
+        ],
+      },
+    ],
+    sidebar: [
+      { text: 'Start here', items: start },
+      { text: 'Install and upgrade', collapsed: false, items: install },
+      { text: 'Use oonfeeWRT', collapsed: false, items: use },
+      { text: 'Operate', collapsed: false, items: operate },
+      { text: 'Understand', collapsed: true, items: understand },
+      { text: 'Reference and help', collapsed: true, items: reference },
+    ],
+    search: { provider: 'local' },
+    outline: { level: [2, 3], label: 'On this page' },
+    docFooter: { prev: 'Previous', next: 'Next' },
+    editLink: {
+      pattern: 'https://github.com/aiden0rchad/oonfeeWRT/edit/main/docs/:path',
+      text: 'Edit this page on GitHub',
+    },
+    lastUpdated: {
+      text: 'Last updated',
+      formatOptions: { dateStyle: 'medium' },
+    },
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/aiden0rchad/oonfeeWRT' },
+    ],
+    footer: {
+      message: 'Self-hosted management for stock OpenWrt. No cloud broker. No custom firmware.',
+      copyright: 'Apache-2.0 · oonfeeWRT contributors',
+    },
+    darkModeSwitchLabel: 'Theme',
+    sidebarMenuLabel: 'Menu',
+    returnToTopLabel: 'Back to top',
+    externalLinkIcon: true,
+  },
+})

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,281 @@
+:root {
+  --vp-c-brand-1: #1d5fae;
+  --vp-c-brand-2: #18569f;
+  --vp-c-brand-3: #144980;
+  --vp-c-brand-soft: rgb(42 120 214 / 12%);
+  --vp-c-bg: #f5f6f8;
+  --vp-c-bg-alt: #eef0f4;
+  --vp-c-bg-elv: #fff;
+  --vp-c-bg-soft: #eef0f4;
+  --vp-c-divider: #dcdfe5;
+  --vp-c-border: #d1d5dc;
+  --vp-c-text-1: #14171c;
+  --vp-c-text-2: #545b66;
+  --vp-c-text-3: #656c78;
+  --vp-code-bg: #e9ecf1;
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(120deg, #18569f 10%, #2a78d6 52%, #178f8a 92%);
+  --vp-home-hero-image-background-image: radial-gradient(circle at 45% 40%, rgb(42 120 214 / 22%), transparent 62%);
+  --vp-home-hero-image-filter: blur(42px);
+  --vp-font-family-base: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --vp-font-family-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+.dark {
+  --vp-c-brand-1: #62a8f6;
+  --vp-c-brand-2: #3987e5;
+  --vp-c-brand-3: #2f75c9;
+  --vp-c-brand-soft: rgb(57 135 229 / 17%);
+  --vp-c-bg: #0f1114;
+  --vp-c-bg-alt: #16181c;
+  --vp-c-bg-elv: #1e2126;
+  --vp-c-bg-soft: #191c21;
+  --vp-c-divider: #2a2e35;
+  --vp-c-border: #353a43;
+  --vp-c-text-1: #f2f4f7;
+  --vp-c-text-2: #aeb4be;
+  --vp-c-text-3: #858c98;
+  --vp-code-bg: #191c21;
+  --vp-home-hero-name-background: linear-gradient(120deg, #8bc0fb 8%, #62a8f6 48%, #54cbc2 92%);
+  --vp-home-hero-image-background-image: radial-gradient(circle at 45% 40%, rgb(57 135 229 / 28%), transparent 62%);
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  text-rendering: optimizeLegibility;
+}
+
+.VPNavBarTitle .title {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.VPDoc .content-container {
+  max-width: 820px;
+}
+
+.vp-doc {
+  font-size: 16px;
+  line-height: 1.72;
+}
+
+.vp-doc h1,
+.vp-doc h2,
+.vp-doc h3 {
+  letter-spacing: -0.025em;
+}
+
+.vp-doc h1 {
+  font-size: 2.35rem;
+  line-height: 1.12;
+}
+
+.vp-doc h2 {
+  margin-top: 2.75rem;
+  padding-top: 1.2rem;
+}
+
+.vp-doc a {
+  text-underline-offset: 3px;
+}
+
+.vp-doc table {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.vp-doc th {
+  background: var(--vp-c-bg-soft);
+}
+
+.vp-doc img {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+}
+
+.vp-doc div[class*='language-'],
+.vp-doc .custom-block,
+.VPFeature {
+  border-radius: 8px;
+}
+
+.VPFeature {
+  border-color: var(--vp-c-divider) !important;
+  background: var(--vp-c-bg-elv) !important;
+  transition: border-color 160ms ease, transform 160ms ease;
+}
+
+.VPFeature:hover {
+  border-color: var(--vp-c-brand-1) !important;
+  transform: translateY(-2px);
+}
+
+.VPHero .name,
+.VPHero .text {
+  letter-spacing: -0.04em;
+}
+
+.VPHero .tagline {
+  max-width: 660px;
+  line-height: 1.55;
+}
+
+.VPHero .image-bg {
+  opacity: 0.85;
+}
+
+.VPSidebarItem.level-0 > .item .text {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+
+.doc-kicker {
+  margin: 0 0 12px;
+  color: var(--vp-c-brand-1);
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.capability-grid,
+.path-grid,
+.evidence-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin: 24px 0;
+}
+
+.capability-card,
+.path-card,
+.evidence-card {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  background: var(--vp-c-bg-elv);
+  padding: 18px;
+}
+
+.capability-card h3,
+.path-card h3,
+.evidence-card h3 {
+  margin: 0 0 8px;
+  border: 0;
+  padding: 0;
+  font-size: 17px;
+}
+
+.capability-card p,
+.path-card p,
+.evidence-card p {
+  margin: 0;
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.path-card {
+  color: inherit !important;
+  text-decoration: none !important;
+  transition: border-color 160ms ease, transform 160ms ease;
+}
+
+.path-card:hover {
+  border-color: var(--vp-c-brand-1);
+  transform: translateY(-2px);
+}
+
+.status-strip {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 20px 0 28px;
+}
+
+.status-pill {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  background: var(--vp-c-bg-soft);
+  padding: 5px 10px;
+  color: var(--vp-c-text-2);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.docs-screenshot {
+  margin: 28px 0;
+}
+
+.docs-screenshot figcaption {
+  margin-top: 8px;
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  text-align: center;
+}
+
+.write-impact {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  margin: 18px 0 24px;
+  border: 1px solid var(--vp-c-divider);
+  border-left: 4px solid #178f8a;
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+  padding: 14px 16px;
+}
+
+.write-impact.warning {
+  border-left-color: #d68a19;
+}
+
+.write-impact.danger {
+  border-left-color: #d24747;
+}
+
+.write-impact strong {
+  white-space: nowrap;
+}
+
+:focus-visible {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: 2px;
+}
+
+@media (max-width: 720px) {
+  .vp-doc h1 {
+    font-size: 2rem;
+  }
+
+  .capability-grid,
+  .path-grid,
+  .evidence-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .write-impact {
+    display: block;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,4 @@
+import DefaultTheme from 'vitepress/theme-without-fonts'
+import './custom.css'
+
+export default DefaultTheme

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -181,7 +181,7 @@ line with `--network host` and set
 Keep the controller on loopback and proxy it from the same host. A minimal Caddy
 site is:
 
-```caddyfile
+```text
 oonfeewrt.example.internal {
     reverse_proxy 127.0.0.1:8080
 }

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -1,0 +1,211 @@
+---
+title: Architecture
+description: How oonfeeWRT is divided, where it runs, and how controller intent becomes safe OpenWrt configuration.
+---
+
+# Architecture
+
+This page describes the architecture shipped in **oonfeeWRT v0.1.1**. For the
+implementation record and historical design decisions, see
+[`ARCHITECTURE.md`](../ARCHITECTURE.md) and
+[`IMPLEMENTATION.md`](../IMPLEMENTATION.md).
+
+## The short version
+
+oonfeeWRT is a self-hosted controller for stock OpenWrt. One Go process:
+
+- serves an embedded React interface;
+- stores controller state in SQLite;
+- polls routers through OpenWrt's existing `rpcd`/ubus interface;
+- turns a site-level network model into per-device UCI changes; and
+- previews, applies, verifies, and confirms those changes.
+
+The controller runs on a Linux or macOS computer, NAS, mini-PC, or server. No
+oonfeeWRT executable runs on a managed router.
+
+```text
+Browser
+  │ HTTP or reverse-proxied HTTPS
+  ▼
+oonfeewrtd
+  ├─ embedded React UI
+  ├─ REST API and WebSocket
+  ├─ site model, renderer, and apply engine
+  ├─ collector, topology inference, and event processing
+  ├─ capability registry
+  └─ SQLite + keyring.json
+          │
+          ├─ steady state: OpenWrt /ubus JSON-RPC
+          └─ bounded bootstrap/cleanup: SSH
+                    │
+                    ▼
+          stock OpenWrt routers, APs, and switches
+```
+
+## Components and responsibilities
+
+### Controller process
+
+`oonfeewrtd` owns the HTTP listener, database, keyring, router sessions,
+collection loops, background maintenance, and embedded UI. It is deliberately a
+single process: there is no separate database service or UI server to operate.
+
+The release binary is static and the container image is built from `scratch`.
+The container contains no shell or package manager and runs as a non-root user
+by default.
+
+### Web interface
+
+The React/TypeScript interface is built into `ui/dist` and embedded in the Go
+binary. It talks to the controller over same-origin REST and WebSocket
+connections, so a normal deployment has no cross-origin configuration.
+
+The main workspaces are Dashboard, Topology, Radios, Devices, Client Devices,
+Policy Engine, Settings, Adopt a device, and Logs. What appears in those
+workspaces depends on measured device capabilities; unavailable evidence is not
+silently replaced with zeroes.
+
+### Store and keyring
+
+Controller state lives in a WAL-mode SQLite database named `oonfeewrt.db`.
+Router and Wi-Fi credentials are sealed with a random data key held by the
+adjacent `keyring.json`; the runtime passphrase unwraps that key.
+
+These three items have different jobs:
+
+| Item | Purpose | Can another item recreate it? |
+|---|---|---|
+| `oonfeewrt.db` | Inventory, desired state, accounts, events, audit history, rollups, sealed credential records | No |
+| `keyring.json` | Wrapped random controller data key | No; neither the database nor passphrase can regenerate it |
+| Runtime passphrase or passphrase file | Unlocks the keyring | No; it is not stored in the database or keyring |
+
+Back up the database and matching keyring as one unit, and protect the runtime
+passphrase separately. See [Data retention](./data-retention.md) and the
+[installation and recovery guide](../INSTALL.md).
+
+## Router communication
+
+### Steady-state transport: ubus
+
+Normal polling, capability reads, and configuration use OpenWrt's JSON-RPC ubus
+endpoint, usually `/ubus` through `uhttpd`. A dedicated, scoped `oonfeewrt`
+login is used instead of the router's administrator account.
+
+The controller relies on stock OpenWrt objects such as `session`, `uci`,
+`network`, `network.interface`, `network.device`, wireless/hostapd objects, and
+capability-dependent `iwinfo` or `luci-rpc` methods. A missing object, method, or
+driver fact becomes an explicit capability gap.
+
+### Bounded exception: SSH
+
+Stock rpcd cannot create its own scoped login or write an ACL file even when a
+caller signs in to ubus as root. After explicit operator approval, adoption
+therefore uses SSH to create at most:
+
+- one scoped `oonfeewrt` login in rpcd configuration; and
+- `/usr/share/rpcd/acl.d/oonfeewrt.json`.
+
+The supplied device-administrator credential is used for that transaction and
+is not stored. SSH is also used for approved cleanup, ACL refresh, and the
+separately authorized optional-package workflow. It is not the polling or Apply
+transport. See [Safety model](./safety.md).
+
+## Capability-driven behavior
+
+OpenWrt is a distribution across many kernels, drivers, switch designs, and
+package sets. oonfeeWRT does not assume that two devices expose the same facts.
+Adoption probes and stores evidence per device, including model, firmware,
+radio, interface, package-manager, topology, and supported-method information.
+
+The important state distinction is:
+
+- **observed:** the source answered with usable evidence;
+- **empty:** the source answered successfully and reported no entries;
+- **unavailable/unsupported:** the source could not provide the fact;
+- **stale:** older evidence exists, but a current read did not refresh it; or
+- **unknown:** the controller has not established the fact.
+
+This prevents an unsupported driver counter from looking like a real `0`, or a
+failed topology read from looking like an empty network. The exact v0.1.1
+feature and evidence boundary is in [Capabilities](../reference/capabilities.md).
+
+## Site model and ownership
+
+Configuration is authored as site intent—WLANs, groups, networks, zones,
+policies, device functions, uplinks, meshes, and bounded per-device overrides.
+The renderer turns that model into deterministic UCI sections for each selected
+device.
+
+oonfeeWRT coexists with LuCI by owning only the sections it creates. Managed
+sections have an `oowrt_` name and/or an `oonfeewrt=1` marker, and the database
+also records ownership. Existing human-managed sections remain visible but are
+not silently rewritten or deleted. A foreign section that conflicts with the
+desired result is a blocking conflict, not permission to take it over.
+
+## Preview and Apply pipeline
+
+Saving desired state changes the controller database only. It does not write a
+router. Router changes follow a separate workflow:
+
+1. **Render:** build the complete per-device desired documents.
+2. **Diff:** compare desired state with current, owned router sections.
+3. **Preview:** show exact creates, updates, deletes, gaps, and required
+   acknowledgements.
+4. **Fleet preflight:** verify every selected device before the first write.
+5. **Apply:** stage owned UCI changes with OpenWrt rollback enabled.
+6. **Health verification:** reconnect and read the expected runtime state.
+7. **Confirm:** cancel OpenWrt's rollback timer only after verification passes.
+8. **Receipt:** preserve the operation and per-device outcomes so a page reload
+   does not retry the write.
+
+Polling is quiesced around a write so collection cannot race the change. The
+engine stops before later devices after the first failure. If connectivity is
+lost, OpenWrt's own timer is the recovery mechanism. See
+[Safety model](./safety.md) for operator recovery steps.
+
+## Collection and live updates
+
+The collector batches router reads and uses a baseline cadence of about one
+poll per minute. A focused device view may temporarily use the six-per-minute
+focused cadence. Per-device overrides can make full-state polling slower, up to
+15 minutes; lightweight router-log collection remains once per minute.
+
+Raw metric samples stay in memory until a complete five-minute window can be
+written as one SQLite transaction. Older data is folded into hourly rollups.
+The WebSocket carries bounded live `device.stats` frames; durable history still
+comes from SQLite. See [Data retention](./data-retention.md) for the exact
+limits.
+
+## Deployment boundary
+
+The default container mapping publishes `127.0.0.1:8080`. Bridge networking
+supports normal L3 management and add-by-address adoption, but does not carry
+LAN ARP or mDNS discovery. Linux host networking can enable full local
+discovery, but exposes the listener according to the host's network and
+firewall configuration.
+
+The v0.1.1 HTTP listener has no native TLS. Keep it on loopback or a trusted,
+isolated management network and use a trusted reverse proxy for remote browser
+access. Review [Requirements](../reference/requirements.md) before deployment.
+
+## Deliberate non-components
+
+The architecture excludes:
+
+- controller-authored agents, daemons, services, firmware, or package feeds on
+  routers;
+- a cloud relay, NAT traversal service, or multi-site broker;
+- a separate database server;
+- automatic package installation during adoption; and
+- silent takeover of LuCI-managed configuration.
+
+Those exclusions define the trust and support boundary; they are not missing
+boxes in the diagram.
+
+## Continue reading
+
+- [Safety model](./safety.md)
+- [Permissions and sessions](./permissions.md)
+- [Data retention](./data-retention.md)
+- [Requirements](../reference/requirements.md)
+- [Capabilities and limits](../reference/capabilities.md)

--- a/docs/concepts/data-retention.md
+++ b/docs/concepts/data-retention.md
@@ -1,0 +1,170 @@
+---
+title: Data and retention
+description: What oonfeeWRT stores, for how long, and what must be backed up together.
+---
+
+# Data and retention
+
+oonfeeWRT v0.1.1 keeps configuration, evidence, and audit history locally. It
+does not require a cloud account or external database.
+
+## Storage locations
+
+The data directory is selected by `-data-dir` or `OONFEE_DATA_DIR`. It must be
+an absolute path; the container default is `/data`.
+
+Important contents include:
+
+| Path | Contents | Persistence |
+|---|---|---|
+| `oonfeewrt.db` | SQLite database: accounts, site intent, device inventory, sealed credential records, rollups, events, audit history, operations | Persistent |
+| `keyring.json` | Wrapped random data key used to seal credentials | Persistent and inseparable from the database |
+| `diagnostics/` | Temporary generated diagnostics ZIPs | Terminal artifact expires after 15 minutes |
+| `backups/` | Temporary portable export jobs and downloads | Terminal artifact expires after 15 minutes |
+| `restores/` | Uploaded backup and disposable preview state | Expires after 30 minutes |
+| `.oonfeewrt-recovery/` | Encrypted pre-restore safety artifacts and restore recovery records | Persistent, bounded after restore acknowledgement |
+| controller log files | Bounded structured controller logs used by diagnostics | Persistent within the controller's log policy; not included in `.oowrtbak` |
+
+All controller data is sensitive. Keep the data directory private and do not
+serve it as static content.
+
+## Metric retention
+
+Raw samples are not inserted into SQLite one at a time. They stay in an
+in-memory ring until a complete five-minute window is ready, then the completed
+rollups are written in one transaction. A shutdown flushes complete buckets and
+discards an incomplete bucket rather than presenting partial data as canonical.
+
+The shipped policy is:
+
+| Data | Retention | Detail |
+|---|---:|---|
+| Raw telemetry samples | Memory only | Lost on restart before the current window completes |
+| Five-minute rollups | 14 days | High-resolution recent metrics |
+| Hourly rollups | 396 days | The code's 13-month retention value |
+
+Series queries choose resolution from the requested range. Requests beginning
+more than 14 days ago, or spanning more than seven days, use hourly data. This
+keeps responses bounded and avoids implying that old five-minute points still
+exist.
+
+## Event and topology retention
+
+| Data | Shipped bound |
+|---|---:|
+| OpenWrt `logd` events | 24 hours |
+| OpenWrt events per device | Newest 50,000 |
+| OpenWrt events across the controller | Newest 100,000 |
+| Controller and audit events | Newest 100,000, independent of router-log caps |
+| Encoded event text/detail | 64 KiB per row |
+| Closed topology intervals | 31 days |
+| Current topology intervals | Kept while active; they have no expiry timestamp |
+
+When per-device or global row-count caps truncate router-log evidence, the
+controller records a continuity gap rather than making the remaining history
+look complete. The ordinary 24-hour age prune does not add that marker.
+Repeated exact OpenWrt IPv6 router-advertisement/no-default-route warnings may
+be condensed per producer epoch while retaining counts and source boundaries.
+
+## Bounded operational history
+
+| Surface | Retention |
+|---|---|
+| RF scans | Newest terminal result for each stable device/radio identity; pending/running work is preserved |
+| Controller-host speed tests | Newest three completed or failed attempts; an active attempt is separate |
+| Diagnostics jobs | Up to 20 job records; completed ZIP available for 15 minutes |
+| Portable backup exports | Up to five job records; completed download available for 15 minutes |
+| Restore uploads/previews | Up to five uploads and five previews; 30-minute working retention |
+
+On the first v0.1.1 start, older completed/failed speed-test rows beyond the
+newest three are permanently pruned. Back up v0.1.0 data before upgrading if
+that history matters.
+
+## Diagnostics content and limits
+
+Diagnostics are generated from stored controller evidence only. Generation
+makes no router management call and changes no router.
+
+The bundle can contain controller version/schema/health, stored device
+model/firmware/capability facts, coverage state, bounded events, and a redacted
+controller-log tail. It excludes controller passphrases, password hashes,
+session/CSRF tokens, router credentials, Wi-Fi keys, private keys/certificates,
+the raw database/keyring, client notes, and fixed-address assignments.
+
+The generator caps input and output, including 256 devices, 1,024 source rows,
+1,000 event rows, a 2 MiB output log tail, 4 MiB per archive member, and 16 MiB
+total uncompressed member data. These are safety ceilings, not promised bundle
+sizes.
+
+## Portable backups and safety artifacts
+
+An owner can export an encrypted `.oowrtbak` containing a transactionally
+consistent database snapshot and portable wrapped key material. It includes
+controller accounts/password hashes, settings, desired state, inventory,
+telemetry/events, and saved credentials in encrypted form. It excludes active
+sessions, the runtime passphrase, router firmware/files, controller logs, and
+other backup/diagnostic artifacts.
+
+The export passphrase is separate from the runtime passphrase, is never stored
+by the controller, and cannot be recovered. Keep the artifact and its
+passphrase in separate protected locations.
+
+Before a confirmed restore replaces live state, the controller writes an
+encrypted safety artifact at:
+
+```text
+<data-dir>/.oonfeewrt-recovery/safety-<restore-id>.oowrtbak
+```
+
+After the applied-restore audit receipt is cleared, retention targets the three
+newest recognized safety artifacts. Files referenced by an active restore
+marker, receipt, or suppression record are preserved even if that temporarily
+exceeds three. Copy any safety artifact needed for long-term retention before
+it becomes eligible for pruning.
+
+## What a valid filesystem backup contains
+
+`oonfeewrt.db` and its matching `keyring.json` are one recovery pair. The
+passphrase is required to open the keyring but cannot reconstruct a lost
+keyring. A keyring from another controller cannot open the sealed credential
+records in the database.
+
+Because SQLite uses WAL mode, copying only a live `oonfeewrt.db` can omit
+committed data. Use one of these methods:
+
+- SQLite's online `.backup`, followed by a copy of the matching keyring; or
+- a clean controller shutdown, then copy the database and keyring together.
+
+For the container, stop it cleanly before copying the persistent volume. Keep
+the passphrase file separately.
+
+Verify an isolated pair with the release helper:
+
+```sh
+OONFEE_PASSPHRASE_FILE=/absolute/path/to/mode-600-passphrase \
+  oonfeewrt-recoverycheck /absolute/path/to/backup/oonfeewrt.db
+```
+
+The sibling `keyring.json` must be beside the database. The helper is read-only,
+makes no network call, requires current schema, rejects symlinks, and rejects a
+non-empty `-wal` or `-journal` sidecar. See [CLI reference](../reference/cli.md).
+
+## Deletion and un-adoption
+
+Removing a device deletes its controller inventory and eventually sweeps metric
+series that no longer have a device. Un-adoption is not merely database
+deletion: it first attempts the reviewed router cleanup, and optional-capability
+rollback can block it. Export diagnostics or evidence before removal if the
+history is needed.
+
+The controller does not claim that every deletion is recoverable. Treat
+account deletion, device removal, retention pruning, and restore replacement as
+material operations and preserve a verified backup first.
+
+## Related pages
+
+- [Architecture](./architecture.md)
+- [Safety model](./safety.md)
+- [CLI reference](../reference/cli.md)
+- [Troubleshooting recovery problems](../reference/troubleshooting.md)
+- [Installation, backup, upgrade, and restore](../INSTALL.md)

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -1,0 +1,149 @@
+---
+title: Permissions and sessions
+description: Controller roles, step-up authentication, sessions, and the separate router credential boundary.
+---
+
+# Permissions and sessions
+
+oonfeeWRT v0.1.1 has local controller accounts with four enforced roles. These
+are not OpenWrt accounts: controller authorization and router access are
+separate boundaries.
+
+## Role hierarchy
+
+Higher roles include the permissions of lower roles.
+
+| UI role | Stored value | Intended access |
+|---|---|---|
+| **Owner** | `owner` | Full controller access, account/session administration, portable backup and restore |
+| **Administrator** | `admin` | Configure the controller, adopt/manage devices, edit site intent, Preview/Apply, and generate diagnostics; cannot manage accounts or controller backups/restores |
+| **Operator** | `operator` | Read state and run approved operational actions such as RF scans, on-air verification, and controller-host speed tests; cannot edit configuration or accounts |
+| **Read-only** | `viewer` | View controller state without configuration/account mutations |
+
+Some sensitive event details require Administrator or Owner even though the
+general event stream is readable by lower roles.
+
+## Practical permission matrix
+
+| Task | Read-only | Operator | Administrator | Owner |
+|---|:---:|:---:|:---:|:---:|
+| View dashboard, devices, clients, topology, radios, and general events | Yes | Yes | Yes | Yes |
+| View site desired state and policies | Yes | Yes | Yes | Yes |
+| Run controller-host speed test or cancel one | No | Yes | Yes | Yes |
+| Run an acknowledged RF scan or on-air verification | No | Yes | Yes | Yes |
+| Discover, inspect, adopt, re-probe, rename, or un-adopt a device | No | No | Yes | Yes |
+| Edit WLANs, networks, zones, policies, groups, meshes, uplinks, or overrides | No | No | Yes | Yes |
+| Preview and Apply configuration | No | No | Yes | Yes |
+| Generate/download diagnostics | No | No | Yes | Yes |
+| Install or roll back optional LLDP capability | No | No | Yes | Yes |
+| List/manage controller accounts and their sessions | No | No | No | Yes |
+| Export or restore portable controller backup | No | No | No | Yes |
+| Resume router writes after restore | No | No | No | Yes |
+
+The server enforces this matrix; hiding a control in the UI is not the security
+boundary.
+
+## First account and owner protection
+
+The unauthenticated setup endpoint works only while no account record exists.
+The first account is always an enabled Owner. Deleting accounts does not reopen
+first-run setup because deleted usernames remain reserved.
+
+The controller refuses to disable, demote, or delete the last enabled Owner.
+This prevents an apparently valid account edit from leaving the controller
+without anyone who can manage accounts or restore operations.
+
+## Account rules
+
+- Usernames are 1–64 ASCII characters.
+- A username starts with a letter or digit and may then contain letters,
+  digits, `.`, `_`, or `-`.
+- Username comparison is case-insensitive; a deleted username remains reserved.
+- Passwords are at least 12 Unicode characters and at most 1,024 bytes.
+- Passwords use Argon2id hashes. The controller does not impose predictable
+  composition rules such as “one symbol and one digit.”
+
+Changing an account's password ends all sessions for that account. Disabling,
+deleting, or changing a role also updates/revokes affected sessions rather than
+letting old authorization continue.
+
+## Sessions
+
+Sessions exist only in controller memory. A controller restart signs everyone
+out, including a restart performed during restore.
+
+| Control | v0.1.1 behavior |
+|---|---|
+| Idle expiry | 12 hours after last use |
+| Absolute expiry | 7 days after creation, even when active |
+| Session cookie | `HttpOnly`, `SameSite=Strict`; `Secure` when TLS or `X-Forwarded-Proto: https` is present |
+| CSRF defense | Separate same-site token cookie echoed as `X-Oonfee-CSRF` on mutations |
+| Session management | Every user can view/revoke their own sessions; Owners can view/revoke another account's sessions |
+| Live requests | Revocation closes the account's live channel and cancels protected in-flight requests tied to that session |
+
+The UI displays creation time, last use, expiry, peer address, and which session
+is current. Peer addresses come from the socket, not an untrusted
+`X-Forwarded-For` header.
+
+## Recent-password confirmation
+
+Sensitive Owner actions require recent password authentication. Sign-in starts
+the five-minute recent-authentication window; entering the current password
+again refreshes that window when it has expired.
+
+Step-up is required for:
+
+- creating, deleting, enabling/disabling, or changing the role of accounts;
+- resetting another account's password;
+- revoking another account's session(s);
+- starting, cancelling, or downloading a portable backup export;
+- uploading and previewing a restore;
+- confirming a restore; and
+- resuming router writes after restore.
+
+Step-up confirms the controller account. Restore confirmation separately asks
+for the destination controller's runtime passphrase and the backup's export
+passphrase because those secrets protect different keys.
+
+## Login and credential throttling
+
+Sign-in failures are throttled per socket peer address. Ten failures within five
+minutes cause a five-minute lockout for that address. Password work is limited
+to two concurrent Argon2id derivations to bound unauthenticated memory use.
+
+Within an authenticated session, repeated current-password failures for
+credential confirmation are separately bounded: five failures within five
+minutes cause a five-minute delay. Unknown usernames still incur password-hash
+work so response timing does not trivially reveal account existence.
+
+## Router credentials are not controller roles
+
+An Administrator or Owner may be allowed to initiate adoption, but the device
+administrator credential is still required for the approved SSH transaction.
+That credential:
+
+- belongs to the OpenWrt device, not the oonfeeWRT account;
+- is used for read-only pre-adoption inspection and/or the explicitly approved
+  bootstrap/cleanup transaction;
+- is not stored by the controller; and
+- does not become the steady-state polling credential.
+
+After adoption, the controller stores its scoped `oonfeewrt` credential sealed
+in SQLite. The matching keyring and runtime passphrase are required to open it.
+See [Architecture](./architecture.md) and [Safety model](./safety.md).
+
+## Deployment implications
+
+The v0.1.1 listener is plain HTTP. Cookies are marked `Secure` only when the
+request is TLS or the reverse proxy supplies `X-Forwarded-Proto: https`.
+Therefore:
+
+- bind directly to loopback for local use;
+- use a trusted reverse proxy for remote browser access;
+- preserve WebSocket upgrades and `X-Forwarded-Proto`;
+- do not expose port 8080 directly to the Internet; and
+- do not treat account roles as protection for an untrusted host or stolen data
+  directory.
+
+For deployment details, see [Requirements](../reference/requirements.md) and
+[`INSTALL.md`](../INSTALL.md).

--- a/docs/concepts/safety.md
+++ b/docs/concepts/safety.md
@@ -1,0 +1,181 @@
+---
+title: Safety model
+description: Which oonfeeWRT actions can affect routers, how Apply rollback works, and how to recover safely.
+---
+
+# Safety model
+
+oonfeeWRT v0.1.1 separates observation, controller desired state, and router
+mutation. A device appearing in the UI is never permission to change it.
+
+## Know what an action can change
+
+| Action | Router management calls | Persistent router change | Operational effect |
+|---|---:|---:|---|
+| Start the controller | Yes, read-only polling after startup | No | Opens controller data, starts HTTP service, and resumes collection for adopted devices |
+| Discovery scan or add by address | Network probe only | No | Discovery coverage depends on container networking |
+| Pre-adoption Inspect | Read-only authenticated calls | No | Uses the supplied device credential only for the inspection |
+| Save site settings | No | No | Changes desired state in the controller database |
+| Preview | Read-only calls | No | Computes exact per-device differences and gates |
+| Diagnostics bundle | No live router calls | No | Packages bounded, redacted stored controller evidence |
+| Portable backup/restore preview | No | No | Reads, authenticates, and stages controller data |
+| Controller-host speed test | No router API/SSH call | No | Sends about 15 MiB through the normal WAN path; may saturate it for up to 30 seconds |
+| Adoption with access payload accepted | Yes, over SSH | Yes | Creates/replaces the scoped login and ACL only |
+| Apply | Yes, over ubus | Yes | Changes only reviewed, controller-owned UCI sections |
+| RF scan | Yes | No intended persistent change | Serving radio leaves channel temporarily; clients may be disrupted |
+| Verify on air | Yes | No intended persistent change | Uses disruptive scans and therefore requires acknowledgement |
+| Optional LLDP workflow | Yes, over SSH | Yes | May refresh package indexes, install official-feed packages, configure interfaces, and start a service after separate approvals |
+| Un-adopt | Yes | Yes | Reverts/removes controller-owned configuration, then removes scoped access |
+| Confirmed controller restore | No router call during restore | Controller data changes only | Restarts the controller, revokes sessions, and suppresses future router writes pending review |
+
+## Three separate permissions
+
+Treat these as different decisions:
+
+1. **Observe a router.** Inspection and polling establish facts. Missing facts
+   remain unavailable.
+2. **Save desired state.** Editing a WLAN or network records intent in SQLite.
+   It does not Apply it.
+3. **Change routers.** Apply, adoption payloads, RF scans, and optional
+   capabilities each have their own review and acknowledgement.
+
+Accepting the adoption payload does not authorize a later WLAN, network,
+firewall, DHCP, or package change.
+
+## The access payload
+
+When accepted during adoption, the controller may install or replace one rpcd
+ACL JSON file and create one scoped login named `oonfeewrt`. This payload:
+
+- grants only the documented OpenWrt object, method, path, and executable
+  surface;
+- installs no package, binary, daemon, service, firmware, or custom device
+  code;
+- does not itself change WLAN, network, firewall, or DHCP configuration; and
+- uses the device administrator credential only for the SSH transaction.
+
+Normal polling and Apply use the stored scoped credential. Refreshing the ACL
+later again requires an ephemeral device-administrator credential and explicit
+approval.
+
+## Ownership prevents silent takeover
+
+The controller renders named/marked UCI sections and records their ownership.
+It writes and cleans up only those sections. Foreign sections created through
+LuCI, SSH, another controller, or a package stay outside that boundary.
+
+If a foreign section conflicts with desired state, stop and decide which system
+should own it. Do not delete or rename the foreign section merely to make a
+Preview green without first understanding its role.
+
+## How Apply protects connectivity
+
+Every Apply has two layers of protection.
+
+### Before the first write
+
+- Preview is generated for a particular desired state and fleet.
+- Required acknowledgements are bound to that plan.
+- Every selected device is preflighted before any selected device is changed.
+- Dirty or foreign configuration, missing capabilities, management-path risk,
+  and other gates can block the operation.
+- The operation and actor are recorded durably.
+
+If preflight fails, nothing should be written. Fix the named condition and
+generate a fresh Preview; do not reuse a stale plan.
+
+### After staging
+
+The apply engine stages owned UCI changes and calls OpenWrt Apply with a 90-second
+rollback timer, followed by a 15-second revert-verification grace period. It then
+reconnects and verifies the expected configuration and runtime
+health. Only a successful verification is confirmed. If connectivity is lost
+or verification fails, the OpenWrt rollback timer is left active so it can
+restore the previous state. A fresh read then distinguishes a proved
+`reverted` outcome from `unknown`; an unknown or stranded operation may still
+have the change live and must be inspected before retrying.
+
+The operation continues independently of the browser request. Reloading the
+page reads the durable status; it does not submit the write again. A fleet
+operation stops before later devices after the first failed device.
+
+## Safe operating procedure
+
+For a change that could affect connectivity:
+
+1. Back up the router configuration using OpenWrt's normal backup facility.
+2. Back up the controller database/keyring pair or export a portable backup.
+3. Start with one non-critical device.
+4. Save the smallest useful desired-state change.
+5. Read every Preview row, capability gap, and acknowledgement.
+6. Confirm that the controller's path to the device is not being removed.
+7. Apply and keep independent access to the management network available.
+8. Wait for the durable operation to become terminal.
+9. Verify connectivity, expected SSIDs/interfaces, DHCP, DNS, and Internet
+   access as appropriate.
+10. Re-run Preview. A successful rollout should report no unexplained drift.
+11. Continue to the next device only after the first result is understood.
+
+## Recovery after an uncertain Apply
+
+If the UI reports a failed, unknown, interrupted, or stranded result:
+
+1. **Do not immediately retry.** A second plan can hide the first operation's
+   real state.
+2. Wait through the displayed OpenWrt rollback window.
+3. Test the device's management address from the controller host.
+4. Check the durable Apply receipt after reconnecting or restarting the UI.
+5. Use LuCI or SSH from an independent management path to inspect pending UCI
+   state and the affected owned sections.
+6. Confirm whether OpenWrt restored the pre-change configuration before making
+   another change.
+7. Generate a new Preview. Never assume an old preview token still describes
+   the router.
+8. Download a diagnostics bundle if the state remains unclear; it uses stored
+   evidence and makes no router call.
+
+If you must repair manually, change only the sections named by the Preview and
+operation receipt. Preserve foreign sections and collect the event/audit detail
+before clearing anything.
+
+## Optional packages require a second boundary
+
+v0.1.1's optional LLDP workflow is not part of adoption. The controller first
+resolves an exact `apk` or `opkg` plan. Package-index refresh, installation,
+service configuration, and rollback have explicit review/consent steps.
+
+The capability ledger records package manager, prior package/service state,
+packages actually added, and rollback outcome. Un-adoption is blocked while an
+LLDP capability record still requires rollback, preventing silent package
+residue. Rollback removes only recorded additions and restores the prior
+service/configuration state.
+
+## Restore is fenced from routers
+
+A confirmed `.oowrtbak` restore changes controller state and restarts the
+process; it does not Apply restored desired state to routers. Successful restore:
+
+- revokes every controller session;
+- retains an encrypted pre-restore safety artifact;
+- records the restore outcome; and
+- activates a durable router-write suppression gate.
+
+Read-only monitoring may resume with restored credentials while the gate is
+active. An owner must review inventory and desired state, reauthenticate, and
+type `RESUME ROUTER WRITES` to remove it. Removing the gate also permits
+automatic 802.11k neighbour maintenance, so review roaming intent first.
+
+## Security limits to keep visible
+
+- The controller has no native TLS listener in v0.1.1. Use loopback or a
+  trusted management LAN and a trusted reverse proxy.
+- No independent security audit or penetration test has been completed.
+- Hardware support is capability-driven; validation on two devices is not a
+  guarantee for every OpenWrt target.
+- Rollback protects UCI changes, not unrelated physical, firmware, upstream,
+  or power failures.
+- A portable backup contains sensitive controller state and saved credentials.
+  Anyone with the file and export passphrase can recover that content.
+
+See [Permissions](./permissions.md), [Troubleshooting](../reference/troubleshooting.md),
+and [Requirements](../reference/requirements.md).

--- a/docs/getting-started/first-adoption.md
+++ b/docs/getting-started/first-adoption.md
@@ -1,0 +1,206 @@
+# Adopt the first OpenWrt device
+
+Adoption gives the controller a scoped OpenWrt login and records what the device can actually do. It does not apply your desired WLAN, network, DHCP, or firewall configuration.
+
+> **Outcome:** One router appears as a managed device, polls successfully with its generated scoped credential, and has an explicit Gateway, AP, and/or Switch responsibility.
+
+## Before you begin
+
+You need:
+
+- an owner or administrator controller account;
+- the router's management address;
+- an existing OpenWrt administrator username and password for ubus;
+- SSH password access, or an OpenSSH private key if Dropbear disables password authentication;
+- controller-to-router reachability for HTTP or HTTPS and SSH;
+- a current router backup and physical access for your first trial.
+
+Set a root password first if the router does not already have one:
+
+```sh
+ROUTER_ADDRESS=192.0.2.1
+ssh -t root@"$ROUTER_ADDRESS" passwd
+```
+
+oonfeeWRT warns rather than blocks an explicitly trusted passwordless lab router. Do not leave a production or normal LAN router passwordless.
+
+## Router write impact
+
+Read-only discovery and **Inspect capabilities** do not change the router.
+
+Adoption requires a separate acknowledgement and then:
+
+- writes `/usr/share/rpcd/acl.d/oonfeewrt.json`;
+- creates the scoped `rpcd.oonfeewrt` login with a generated password;
+- verifies that login and records device capabilities;
+- records the router's SSH host key and, for HTTPS, its certificate fingerprint.
+
+Adoption installs no package, binary, daemon, service, or firmware. It does not change network, WLAN, DHCP, or firewall settings. Those require a later Preview and Apply.
+
+The administrator password and optional SSH private key exist only for this request and are not stored.
+
+## 1. Open the adoption screen
+
+Sign in and select **Adopt a device** in the left navigation.
+
+The page always provides add-by-address. Its discovery scan is only a convenience:
+
+- bridge-mode Docker can use routed TCP probing but cannot see LAN ARP or mDNS;
+- Docker Desktop users should normally add by address;
+- discovery is IPv4-only, on demand, and refuses networks wider than `/22`.
+
+If a scan lists the correct router, select **Adopt this**. Otherwise enter its management address directly.
+
+## 2. Enter the existing router login
+
+Fill in:
+
+- **Address:** a router hostname or management IP;
+- **Name:** optional; when blank, the device model can supply the name;
+- **Protocol:** `http` or `https`, matching the router's uhttpd service;
+- **Device username:** commonly `root` on a stock installation;
+- **Device password (for ubus):** the router's existing password;
+- **SSH private key:** only when SSH password authentication is disabled.
+
+The ubus sign-in still needs the password even when an SSH key is supplied. The key is only for the one-time SSH bootstrap.
+
+For HTTPS, adoption records the observed device certificate fingerprint. Later certificate changes are refused until explicitly reviewed rather than silently trusted.
+
+## 3. Inspect before adopting
+
+Select **Inspect capabilities**.
+
+Inspection uses authenticated, read-only ubus calls. It creates no inventory row, login, ACL, package, or configuration. Review:
+
+- model and firmware;
+- radios;
+- observed LAN layout and WAN port;
+- active WAN default-route evidence;
+- LAN DHCP-server evidence;
+- switch mode;
+- recommended device functions;
+- unobservable items and notes.
+
+An **Unknown** result means the credential, ACL, rpcd module, or driver did not supply enough evidence. It does not mean the feature is absent.
+
+## 4. Select device functions
+
+Select at least one function:
+
+- **Gateway:** routes between managed networks and toward the Internet; receives addressing, DHCP, and firewall intent.
+- **AP:** publishes managed WLANs and carries their networks; does not imply routing or DHCP.
+- **Switch:** records wired responsibility and available port/topology visibility; it does not promise universal per-port or VLAN configuration.
+
+Select every responsibility the router should perform. A combined OpenWrt router may be Gateway, AP, and Switch. An AP-only router should not receive Gateway just because it has a default route through its management LAN.
+
+If oonfeeWRT will manage the network's gateway, adopt that device first. Only one managed Gateway is supported. AP-only adoption remains valid when routing is intentionally managed elsewhere.
+
+Switch behavior is capability-dependent:
+
+- `dsa-conditional` can manage VLAN carriage only when the existing LAN bridge is already VLAN-aware;
+- `observe-only` exposes legacy switch telemetry/topology without promising writes;
+- `unknown` retains the uncertainty;
+- `none` means no switch capability was observed.
+
+## 5. Review the controller access payload
+
+Open **Review exact router changes** and read the displayed plan. The scoped ACL grants:
+
+- supported inventory, topology, radio/scan, OpenWrt log, and fixed-target `1.1.1.1` ICMP observations;
+- UCI writes only for controller-owned network, wireless, firewall, and DHCP sections after a separate Preview and Apply;
+- runtime 802.11k neighbour-list updates for managed WLANs that request them.
+
+It does not grant client disconnection or steering. The client keeps the roaming decision.
+
+Select **Install the oonfeeWRT controller access payload?** only after you accept those exact changes. Leaving it unchecked keeps Adopt unavailable; cancelling leaves the router unchanged.
+
+## 6. Adopt and wait for verification
+
+Select **Adopt**.
+
+The controller:
+
+1. pins the resolved target for the operation;
+2. verifies the administrator access and device identity;
+3. writes and hashes the ACL file over SSH;
+4. creates the scoped login;
+5. signs in again using the new controller credential;
+6. probes capabilities through the same access the controller will use later;
+7. stores the device only after the safety checks succeed.
+
+The radio survey is deliberately sampled twice, so adoption may take several seconds.
+
+## Verify adoption
+
+After completion:
+
+1. Review **What the capability probe found**. Available, undetermined, driver-quirk, and note lists should agree with the hardware evidence.
+2. Open **Devices** and select the device.
+3. Confirm its address, MAC, firmware, functions, class, and poll status.
+4. Wait for a successful poll and confirm **Last seen** advances.
+5. Review the **Management overhead** section and unavailable sources.
+6. Open **Dashboard** and confirm the device count changes.
+
+Do not expect new SSIDs or network changes yet. Adoption and provisioning are separate.
+
+## Make the first desired-state change safely
+
+When you are ready:
+
+1. Open **Settings → Network**.
+2. Create or edit only the intended network, AP group, or WLAN.
+3. Save. This changes controller desired state only.
+4. Select **Preview changes**.
+5. Read the per-device diff, source gaps, conflicts, and safety cautions.
+6. Supply every acknowledgement requested by the current preview.
+7. Select **Apply**.
+
+Apply stages the UCI delta and invokes OpenWrt's rollback-protected apply. The controller confirms only after it reconnects and verifies expected interface, WLAN, and uplink health. A lost connection or failed health check leaves the rollback timer active so it can restore the previous configuration. Wait for a fresh read: an `unknown` or stranded outcome is not proof of rollback and may still have the change live.
+
+## Troubleshooting and recovery
+
+### Inspection cannot reach `/ubus`
+
+Verify the protocol, address, and management route. The router needs `rpcd` and `uhttpd` with the ubus handler enabled. The expected uhttpd setting is:
+
+```text
+config uhttpd 'main'
+    option ubus_prefix '/ubus'
+```
+
+Do not install packages blindly. First verify the existing OpenWrt service and configuration through LuCI or SSH.
+
+### Discovery is empty
+
+Enter the IP address directly. Docker bridge mode and Docker Desktop do not provide the layer-2 view needed for full discovery.
+
+### The login fails
+
+Confirm that the password works for ubus as well as SSH. An SSH private key does not replace the ubus password. If the router has no root password, set one before continuing.
+
+### SSH bootstrap fails
+
+Confirm TCP/22 reachability, the administrator username, and whether Dropbear permits password authentication. Supply an OpenSSH private key when password authentication is disabled. A changed SSH host key requires explicit review; do not bypass it without verifying the physical device.
+
+### Gateway selection is refused
+
+The controller permits only one managed Gateway. Review the existing device functions before changing which router owns site routing.
+
+### Adoption stops partway through
+
+Read the returned rollback report. It includes exact cleanup commands if the controller cannot prove that its ACL or login was removed. Do not repeatedly Adopt until you know whether the prior scoped footprint remains.
+
+### Data is unavailable after adoption
+
+Review the device capability report. Missing rpcd access, optional modules, or driver support is shown as a source gap. If the release offers **Refresh controller access**, review and explicitly approve that ACL-only transaction; polling never widens the ACL silently.
+
+### Remove the device later
+
+Use **Devices → Remove from controller**. Normal un-adoption first reverts controller-owned configuration, then asks for the router administrator credential to remove the scoped login and ACL. It is blocked while an optional LLDP rollback ledger remains. If the router is gone, the force path records that configuration or controller footprint may remain.
+
+## Next steps
+
+- [Configure accounts and roles](../operations/accounts.md)
+- [Create and verify backups](../operations/backups.md)
+- [Put TLS in front of the controller](../installation/reverse-proxy.md)
+- [Review routine maintenance](../operations/maintenance.md)

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,107 @@
+# Getting started
+
+oonfeeWRT is a self-hosted controller for stock OpenWrt devices. It gives one browser interface for device health, clients, radios, topology, logs, reviewed network configuration, and safe multi-device changes.
+
+It is **not firmware**. The controller runs on a Linux or macOS computer, NAS, mini-PC, or server. Your routers continue running stock OpenWrt and remain usable through LuCI and SSH.
+
+> **Outcome:** This section takes you from an empty controller to one adopted OpenWrt device without applying an unreviewed network change.
+
+## Choose your path
+
+| If you want… | Start here |
+|---|---|
+| The shortest supported setup | [Quick start](quick-start.md) |
+| A standalone Linux or macOS executable | [Install the binary](../installation/binary.md) |
+| A container on a NAS, server, or Docker Desktop | [Install with Docker](../installation/docker.md) |
+| HTTPS access through an existing host | [Put a reverse proxy in front](../installation/reverse-proxy.md) |
+| To connect the first router | [First adoption](first-adoption.md) |
+
+## What you need
+
+### Controller host
+
+Choose a host that stays on and can reach every router's management address.
+
+- Standalone binaries: `linux/amd64`, `linux/arm64`, `darwin/amd64`, or `darwin/arm64`.
+- Container images: `linux/amd64` or `linux/arm64`.
+- Practical starting point: a 64-bit host with 1 GB RAM and 2 GB free storage.
+- Default browser address in the guides: `http://127.0.0.1:8080`.
+
+Remote routers need an existing routed management network or VPN. oonfeeWRT does not provide cloud brokering or automatic NAT traversal.
+
+### Managed router
+
+The documented minimum is OpenWrt 21.02 or newer with:
+
+- SSH;
+- `rpcd`;
+- `uhttpd` with its ubus handler available at `/ubus`;
+- network reachability from the controller host.
+
+Radio, switch, topology, and policy features depend on the router, driver, installed rpcd modules, and OpenWrt release. oonfeeWRT records those differences instead of treating missing evidence as zero.
+
+For your first run, use a non-critical router that you can reach physically. Back up the router before testing configuration changes.
+
+## Understand the two credentials
+
+oonfeeWRT uses two unrelated kinds of secret:
+
+1. The **controller runtime passphrase** unlocks `keyring.json` when the daemon starts. It protects saved router credentials and wireless keys. It is not a browser account password.
+2. A **controller account password** signs a person into the web interface. The first account is an owner.
+
+For unattended startup, the runtime passphrase is stored in a private mode-`0600` file. Back up that file separately from, but together with, the controller database and `keyring.json`. Losing the runtime passphrase or the matching keyring cannot be repaired from the database alone.
+
+## Know when a router changes
+
+On a new controller, starting it, opening the dashboard, scanning the LAN, adding an address, inspecting a device, generating diagnostics, exporting a controller backup, and running the controller-host speed test do **not** change a router. On later starts, adopted devices resume read-only polling; if managed WLANs request 802.11k neighbour reports and router writes are not suppressed, the automatic reconciler may also update runtime hostapd neighbour lists.
+
+Router-changing actions are explicit:
+
+- **Adoption** installs one scoped `oonfeewrt` rpcd login and `/usr/share/rpcd/acl.d/oonfeewrt.json` after you acknowledge the displayed plan. It installs no package, executable, service, daemon, or firmware.
+- **Apply** changes controller-owned network, wireless, DHCP, and firewall UCI sections only after Preview and safety acknowledgements.
+- **RF scan** takes the selected serving radio off-channel temporarily and requires disruption acknowledgement.
+- **Optional LLDP** may install the official OpenWrt `lldpd` package after separate plan and installation approvals.
+- **Un-adoption** reverts controller-owned state and removes the scoped login and ACL after review.
+
+Existing human-managed UCI sections remain foreign and read-only. A conflict blocks Preview or Apply instead of being silently overwritten.
+
+## The safe first-run sequence
+
+1. Install the controller by [binary](../installation/binary.md) or [Docker](../installation/docker.md).
+2. Keep the HTTP listener on loopback. Add [reverse-proxy TLS](../installation/reverse-proxy.md) before remote browser access.
+3. Create the first owner account.
+4. In **Adopt a device**, enter the router address and existing administrator login.
+5. Run **Inspect capabilities**. This is a read-only ubus operation.
+6. Review and select the device's Gateway, AP, and/or Switch functions.
+7. Review and acknowledge the controller access payload, then Adopt.
+8. Confirm that the device is online and review unavailable capability sources.
+9. Make desired-state changes only when ready. **Preview** first, read every warning, then **Apply**.
+
+## What the interface covers
+
+- **Dashboard:** fleet state, clients, Internet reachability and traffic history, topology summary, warnings, and controller-host speed tests.
+- **Topology:** current and historical links with source and confidence information.
+- **Radios:** radio inventory, channel plans, utilization evidence, and explicit RF scans.
+- **Devices:** health, capabilities, collection overhead, polling, ACL refresh, optional LLDP, and un-adoption.
+- **Client Devices:** client inventory, filters, and a time-aligned observability workspace.
+- **Policy Engine:** objects, firewall/NAT/route records, whole-zone forwarding, and inspectable desired state.
+- **Settings:** networks, DHCP, WLANs, AP groups, roaming, mesh backhauls, wireless uplinks, accounts, diagnostics, and backup/restore.
+- **Logs:** General and Audit events with provenance and coverage information.
+
+Unavailable features are capability-gated. For example, a legacy `swconfig` device may provide port observations without supporting managed per-port VLAN changes.
+
+## Current limits to keep in mind
+
+- The stable release's published physical record covers a Linksys WRT3200ACM and TP-Link Archer C6 v2 on OpenWrt 25.12.5. That record came from the pre-stable/RC workflow underlying v0.1.1; the patch release did not rerun the complete procedure. Other targets may work but do not have the same published evidence.
+- Only one managed Gateway is supported.
+- Docker bridge mode cannot perform layer-2 discovery; add the router by address.
+- The controller has no native TLS listener.
+- The speed test runs on the controller host through Cloudflare, not on the router. It transfers about 15 MiB and is bounded to 30 seconds.
+- Cloud remote access, automatic NAT traversal, native mobile apps, gateway-run speed tests, DPI/application identification, and universal PoE or switch control are not included in v0.1.1.
+
+## Next steps
+
+- [Run the quick start](quick-start.md)
+- [Adopt your first device](first-adoption.md)
+- [Learn the backup and recovery workflow](../operations/backups.md)
+- [Review routine maintenance](../operations/maintenance.md)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,143 @@
+# Quick start
+
+This page starts oonfeeWRT v0.1.1 on one host and creates the first owner account. It offers a standalone-binary path and a Docker Compose path; use only one.
+
+> **Outcome:** The controller answers at `http://127.0.0.1:8080`, `/healthz` returns `ok`, and you can sign in as the first owner.
+
+## Before you begin
+
+You need:
+
+- a supported 64-bit Linux or macOS host;
+- network reachability from that host to the OpenWrt management address;
+- either Docker with Compose support or the v0.1.1 release archive;
+- a private place to retain the controller runtime passphrase and data.
+
+**Write impact:** With a new data directory or volume, these steps write only to the controller host and do not contact a router. Reusing existing controller state resumes adopted-device polling and may resume automatic runtime 802.11k neighbour maintenance. Router access on a fresh controller begins when you explicitly inspect or adopt a device.
+
+## Option A: standalone binary
+
+Follow [Install the binary](../installation/binary.md) to download and checksum-verify the correct release. Then start it with a private data directory:
+
+```sh
+install -d -m 0700 "$PWD/data"
+./oonfeewrtd -data-dir "$PWD/data" -listen 127.0.0.1:8080
+```
+
+On the first interactive start, the daemon asks twice for a new runtime passphrase. There is no recovery if it is lost.
+
+Keep this terminal open while completing the browser setup. For unattended startup, stop the daemon with `Ctrl-C` and configure the mode-`0600` passphrase file described in the [binary installation guide](../installation/binary.md).
+
+## Option B: Docker Compose
+
+Create a private working directory, download the exact v0.1.1 Compose file, and create the runtime passphrase:
+
+```sh
+mkdir -p oonfeewrt
+cd oonfeewrt
+
+curl --fail --location \
+  --output docker-compose.yml \
+  https://raw.githubusercontent.com/aiden0rchad/oonfeeWRT/v0.1.1/deploy/docker-compose.yml
+
+umask 077
+head -c 32 /dev/urandom | base64 > passphrase
+sudo chown 65532:65532 passphrase
+sudo chmod 600 passphrase
+
+OONFEE_VERSION=v0.1.1 docker compose up -d
+```
+
+The supplied Compose file:
+
+- publishes the controller only on `127.0.0.1:8080`;
+- runs as UID/GID 65532;
+- uses a read-only root filesystem;
+- drops all Linux capabilities and disables privilege gain;
+- stores controller state in the named volume `oonfee-data`;
+- reads the runtime passphrase from `./passphrase`.
+
+Do not run `docker compose down -v` unless you intend to delete the named controller-data volume.
+
+## Create the first owner
+
+1. On the controller host, open [http://127.0.0.1:8080](http://127.0.0.1:8080).
+2. Enter a username. Controller usernames are 1–64 ASCII characters, must start with a letter or digit, and may contain letters, digits, `.`, `_`, or `-`.
+3. Enter a password of at least 12 characters and confirm it.
+4. Complete setup. The first account becomes the owner and is signed in.
+
+The account password is not the runtime passphrase. Keep both in your password-management and recovery plan.
+
+## Verify the controller
+
+From the controller host:
+
+```sh
+curl --fail http://127.0.0.1:8080/healthz
+```
+
+Expected output:
+
+```text
+ok
+```
+
+For Docker, also check:
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose ps
+OONFEE_VERSION=v0.1.1 docker compose logs --tail=100 oonfeewrt
+```
+
+In the browser, confirm that the left navigation shows **Dashboard**, **Topology**, **Radios**, **Devices**, **Client Devices**, **Policy Engine**, **Settings**, **Adopt a device**, and **Logs**.
+
+## If it does not start
+
+### The daemon says no passphrase is available
+
+An unattended process has no terminal from which to prompt. Configure `-passphrase-file` or `OONFEE_PASSPHRASE_FILE` with a regular file that is not readable by group or other users.
+
+### The passphrase file is rejected
+
+For a standalone install:
+
+```sh
+chmod 600 /absolute/path/to/passphrase
+```
+
+For the supplied Compose file, it must also be readable by UID 65532:
+
+```sh
+sudo chown 65532:65532 passphrase
+sudo chmod 600 passphrase
+```
+
+### The keyring cannot be unlocked
+
+The runtime passphrase is wrong, or `keyring.json` is corrupt or truncated. Do not delete it and restart: a replacement keyring cannot decrypt the existing database. Restore the matching database, keyring, and passphrase backup.
+
+### The database exists but `keyring.json` does not
+
+Startup intentionally refuses this state. Restore the matching keyring. Move the database aside only if you deliberately want a new, empty controller and accept re-adopting every device.
+
+### Port 8080 is already in use
+
+Choose another loopback port for a standalone process, for example:
+
+```sh
+./oonfeewrtd -data-dir "$PWD/data" -listen 127.0.0.1:8081
+```
+
+Then open `http://127.0.0.1:8081`. If using Compose, change the host side of `127.0.0.1:8080:8080` and keep the container side at `8080`.
+
+### The browser is on another computer
+
+`127.0.0.1` is reachable only on the controller host. Do not expose raw port 8080 to the Internet. Configure [reverse-proxy TLS](../installation/reverse-proxy.md), or use a deliberate isolated management network.
+
+## Next steps
+
+- [Adopt the first OpenWrt device](first-adoption.md)
+- [Install with the binary in detail](../installation/binary.md)
+- [Install with Docker in detail](../installation/docker.md)
+- [Protect access with a reverse proxy](../installation/reverse-proxy.md)
+- [Create a recovery backup](../operations/backups.md)

--- a/docs/guide/clients-topology.md
+++ b/docs/guide/clients-topology.md
@@ -1,0 +1,155 @@
+# Clients and topology
+
+The Clients and Topology workspaces connect endpoint presence with the
+infrastructure path used to observe it. Both preserve evidence confidence and
+coverage gaps so an inferred link never looks like a measured cable.
+
+<div class="write-impact"><strong>Router write impact</strong><span>Viewing, filtering, and investigating clients or topology is read-only. Optional LLDP is a separate reviewed package/configuration workflow.</span></div>
+
+## Client Devices
+
+The Client Devices table is scoped to managed LANs and excludes adopted
+infrastructure from the client count without deleting it from inventory.
+
+### Use the filters
+
+Filters operate on the complete matching result before pagination:
+
+- network scope (**This network**, **Upstream**, **Unknown**, or all);
+- presence (**Online**, **Offline**, or all);
+- connection evidence (**Wireless**, **Unknown**, or all).
+
+The current table does not claim that an endpoint is wired merely because no
+managed AP reports it, and v0.1.1 has no client text-search or source-coverage
+filter.
+
+The count above the table is the filtered total, not merely the number of rows
+on the current page.
+
+### Read presence carefully
+
+Presence is based on fresh fleet evidence, not on the fact that a MAC once
+appeared in inventory. A historical neighbour or stale station entry must not
+keep a client “online” after its live evidence expires.
+
+Possible explanations for a missing or partial row include:
+
+- the responsible device is offline or has not completed a poll;
+- the client is outside the managed network scope;
+- station or neighbour evidence is stale;
+- AP attribution is incomplete;
+- the client uses a randomized MAC and has a second inventory identity;
+- the source is unavailable on this hardware/driver.
+
+## Open Client Observability
+
+Select a client row to open the joined investigation workspace. It keeps a
+shared time cursor across the evidence it can correlate, including:
+
+- current identity and presence;
+- network and AP/path attribution;
+- client, AP, and site health context;
+- an event spine around the selected time;
+- wireless/traffic metrics and accessible tables when present;
+- explicit source and freshness gaps.
+
+Use the same time cursor when comparing a client symptom with AP load, radio
+quality, WAN health, and events. Correlation by time is more reliable than
+comparing each screen's latest value after the incident has passed.
+
+### A client investigation sequence
+
+1. Confirm the client identity, including MAC randomization possibility.
+2. Check whether presence is current and which source asserted it.
+3. Identify the managed network and AP/device attribution.
+4. Move the shared cursor to the reported incident time.
+5. Correlate signal/traffic data with AP/device and site health.
+6. Read events immediately before and after the change.
+7. Open Topology at the same time when the infrastructure path may have moved.
+8. Record unavailable evidence as a limitation in the conclusion.
+
+## Current topology
+
+Open **Topology** to view nodes and active link intervals. Sources can include:
+
+- client wireless associations;
+- bridge forwarding-database observations;
+- neighbour data;
+- default-route/uplink evidence;
+- optional LLDP.
+
+Each edge includes a confidence and medium. Confidence describes the evidence,
+not the importance of the device.
+
+### Filter and inspect
+
+Use the controls to filter by:
+
+- confidence;
+- medium;
+- VLAN;
+- current versus historical mode;
+- selected historical time/range.
+
+Zoom changes the visual workspace only. The accessible topology details and
+complete interval table preserve the underlying information for keyboard and
+screen-reader use.
+
+Select a node to open its identity or device workspace. For exact edge source,
+time range, confidence, port, and ambiguity evidence, use the **Accessible
+topology details** table and expand its **Evidence** cell. When duplicate names
+exist, use the stable device/node identity rather than the label alone.
+
+## Historical topology
+
+Historical mode answers **what links did the controller have evidence for at a
+given time?** It does not reconstruct packets or invent missing intervals.
+
+Choose a preset or custom range. The view uses interval semantics: a link is
+present when its evidence interval overlaps the selected time. A last-known
+placement may be shown separately from a currently supported link.
+
+Topology history is retained for 31 days. A request near or beyond that bound
+can be marked retention-truncated. Export or record incident evidence before
+the window expires when it must be kept longer.
+
+## Evidence coverage and LLDP
+
+The coverage indicator accounts for every adopted device relevant to the
+current request. One device with stale/unreadable topology sources makes the
+fleet view incomplete; oonfeeWRT does not hide that by drawing only the easier
+links.
+
+LLDP can strengthen direct infrastructure adjacency evidence. It remains
+optional because enabling it may install the official OpenWrt `lldpd` package
+and configure physical interfaces. Review the exact package and interface
+plans on the device page, and retain the rollback ledger.
+
+LLDP does not replace client association, FDB, neighbour, or route evidence.
+Each source answers a different question.
+
+## Troubleshooting clients
+
+| Symptom | Likely explanation | Action |
+|---|---|---|
+| Client missing from current list | Presence expired, device poll failed, client out of scope, or randomized identity | Clear filters, check source coverage/device state, and compare MAC/hostname evidence |
+| Wireless client attributed to wrong AP | Stale station data or simultaneous/ambiguous evidence | Check timestamp and association history; wait for fresh evidence rather than editing inventory |
+| Wired neighbour appears on uplink | It is on the subnet carrying the default route, not a managed LAN client | Review network scoping and topology source; do not count it as a client merely because ARP saw it |
+| Metrics are blank | Focused source has not flushed or hardware does not expose it | Leave the client/device view focused through the next collection/rollup and read the source note |
+
+## Troubleshooting topology
+
+| Symptom | Likely explanation | Action |
+|---|---|---|
+| No edge between known devices | No shared fresh source proves adjacency | Inspect coverage gaps; add LLDP only if its footprint is justified |
+| Edge confidence is lower than expected | Inference comes from FDB/neighbour/association rather than direct LLDP | Expand the edge's Evidence cell in the accessible table and base the conclusion on the named source |
+| Historical device is unplaced | Device existed but no edge interval supports placement at that time | Use last-known placement as context, not as a historical fact |
+| History ends early | 31-day retention bound or missing collection interval | Read the truncation/gap notice and preserve future incidents earlier |
+| Duplicate node names | Devices share display names or defaults | Rename controller display identities and use stable IDs during review |
+
+## Related guides
+
+- [Discovery, adoption, and devices](./devices.md)
+- [Radios and channel planning](./radios.md)
+- [Telemetry and retention](../concepts/data-retention.md)
+- [Logs and diagnostics](./logs-diagnostics.md)

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -1,0 +1,159 @@
+# Dashboard and Internet health
+
+The Dashboard answers three questions quickly: **is the controller receiving
+fresh evidence, can the managed Gateway reach the Internet, and where should I
+investigate next?** It combines fleet counts, WAN observations, topology,
+speed-test history, and recent warnings without hiding missing sources.
+
+<div class="write-impact"><strong>Router write impact</strong><span>Opening and refreshing the Dashboard is read-only. A controller speed test uses WAN bandwidth from the controller host but makes no router management call.</span></div>
+
+## Before you begin
+
+- Sign in with any controller role, including **Read only**.
+- Adopt at least one device to populate fleet health.
+- Assign the **Gateway** function to the device that carries the default route
+  if you want Internet health. oonfeeWRT supports one managed Gateway.
+- Allow time for the first collection cycle. An empty value before collection
+  is different from an observed zero.
+
+## Read the fleet overview
+
+The overview cards summarize the whole current fleet:
+
+| Card | Meaning | Investigate when |
+|---|---|---|
+| Devices online | Devices with sufficiently recent successful management evidence | The online count falls or a device alternates between states |
+| Wireless clients | Fresh stations attributed to devices with the AP function | The value is marked incomplete or differs from an AP's local view |
+| Devices on the LAN | Client inventory scoped to managed LANs | Infrastructure appears as a client or a neighbour is incorrectly scoped |
+| Devices in focus | Devices temporarily using the fast collection tier because a live detail view is open | The count stays high after viewers leave detail screens |
+| Series collected | Durable metric series currently known to the controller | Charts remain empty after several collection intervals |
+
+Counts carry source-coverage information. A partial wireless-client count is
+not silently presented as a complete fleet total. Follow the adjacent source
+message before treating a number as authoritative.
+
+## Understand Internet health
+
+Internet health is derived from the managed Gateway, not from the browser and
+not from a cloud service.
+
+### Observed Gateway path
+
+The path identifies the default-route device and uplink only when fresh route
+evidence supports that conclusion. If the controller cannot read the route,
+the Dashboard reports the source gap rather than borrowing an older or guessed
+uplink.
+
+### ICMP reachability
+
+The Gateway sends exactly three ICMP probes to `1.1.1.1`, no more than once per
+minute. The displayed latency and loss establish only that this target was
+reachable over ICMP at that time.
+
+They do **not** prove:
+
+- DNS works;
+- HTTP or HTTPS works;
+- every Internet destination is reachable;
+- the ISP has met an uptime target;
+- the router itself has available bandwidth.
+
+ICMP may also be deprioritized by a network. Correlate loss with traffic,
+events, device state, and an independent application test.
+
+### Six-hour trends
+
+The chart and accessible table show five-minute rollups for:
+
+- download traffic;
+- upload traffic;
+- ICMP latency;
+- ICMP loss.
+
+Coverage markers distinguish observed buckets from unavailable ones. A gap is
+not a zero. Use the table when you need exact timestamps and values; use the
+chart to correlate simultaneous changes.
+
+## Run a controller speed test
+
+The speed test measures the path from the **controller host or container** to
+Cloudflare. It is useful when that host shares the WAN path you care about, but
+it is not a router-native test.
+
+Read-only accounts can inspect the plan and history. Starting or cancelling a
+test requires the **Operator**, **Admin**, or **Owner** role.
+
+::: warning Bandwidth and privacy impact
+One completed attempt transfers approximately 15 MiB—10 MiB down and 5 MiB
+up—is bounded to 30 seconds, and can temporarily saturate a slower WAN. The
+controller's public IP and test requests are visible to Cloudflare.
+:::
+
+1. Open **Dashboard**.
+2. Open the impact and consent details and review the exact endpoint, limits,
+   controller-host vantage point, and data-use disclosure.
+3. Select **Run speed test**. In v0.1.1 this action is the explicit,
+   plan-bound acknowledgement and starts the test immediately.
+4. Leave the Dashboard open to watch progress.
+
+The result can include download, upload, idle latency, and idle jitter. Loaded
+latency and loaded jitter are not measured in v0.1.1. The controller retains
+the newest three terminal attempts, including failed or cancelled attempts, so
+a failure does not disappear from history.
+
+### Verify the result
+
+- Confirm the result says **Completed** and has a finish time.
+- Compare the chart bar with the exact result table.
+- Check whether the controller host uses the same uplink, VPN, container
+  network, or traffic policy as the device path you intended to evaluate.
+- Compare against live traffic. A speed test run while the network is busy is
+  evidence of the combined load, not an unloaded line rate.
+
+### Cancel or recover
+
+Use **Cancel** while a test is running. The terminal history should report the
+cancelled outcome. If the UI disconnects, reopen the Dashboard; the controller
+owns the job and exposes its current or terminal state after reconnecting.
+
+## Use topology and event summaries
+
+The Dashboard includes a compact topology view and recent warning/error list.
+
+- Open **Topology** for confidence, medium, VLAN, history, and full source-gap
+  controls.
+- Open **Logs** when a warning needs its complete details or surrounding audit
+  events.
+- Open the named **Device** when the event points to capability, collection,
+  or management overhead.
+
+## A practical investigation sequence
+
+When the Dashboard looks unhealthy:
+
+1. Confirm whether the data is fresh, stale, partial, or unavailable.
+2. Compare the affected device's online state and last-seen time.
+3. Check the Gateway path and WAN source message.
+4. Correlate traffic, latency, and loss across the same time range.
+5. Review recent warnings and errors.
+6. Open **Topology** for a path or placement change.
+7. Run a speed test only if its controller-host vantage and bandwidth impact
+   answer the remaining question.
+
+## Troubleshooting
+
+| Symptom | Likely explanation | What to do |
+|---|---|---|
+| Internet health is unavailable | No managed Gateway, stale route evidence, failed poll, or insufficient ACL/source coverage | Open the Gateway device, review functions and source gaps, then reprobe or refresh the ACL if the UI identifies a missing permission |
+| Wireless count is incomplete | One or more AP-function devices lack fresh station evidence | Open **Devices**, find the named coverage gaps, and wait for or troubleshoot their focused poll |
+| Charts show gaps | The bucket had no valid samples; the controller restarted, device was unreachable, or a source failed | Use the accessible table and Logs; do not interpret the gap as zero |
+| Speed test is much slower than expected | Container/VPN path, concurrent traffic, controller-host limits, or shared WAN saturation | Verify the host path and repeat during a controlled quiet window only if another 15 MiB test is acceptable |
+| Speed test fails immediately | Controller cannot reach the Cloudflare endpoints or the job was refused by current state | Check controller logs, DNS/HTTPS egress, and whether another test is active |
+| A device is online but WAN health is missing | Device management reachability and Gateway Internet evidence are separate | Verify the Gateway function, default route source, and probe result on that device |
+
+## Related guides
+
+- [Clients and topology](./clients-topology.md)
+- [Radios and channel planning](./radios.md)
+- [Logs and diagnostics](./logs-diagnostics.md)
+- [Telemetry and retention](../concepts/data-retention.md)

--- a/docs/guide/devices.md
+++ b/docs/guide/devices.md
@@ -1,0 +1,224 @@
+# Discovery, adoption, and devices
+
+The Devices workflow moves from **unknown address**, to **read-only inspection**,
+to **explicitly adopted functions**. Discovery never equals adoption, and
+adoption never equals applying network configuration.
+
+<div class="write-impact warning"><strong>Router write impact</strong><span>Discovery, add-by-address, inspection, telemetry, rename, and reprobe are read-only to the router. Adoption can create a scoped login and ACL only after review and approval. Optional LLDP and un-adoption have separate change plans.</span></div>
+
+## The device lifecycle
+
+1. **Discover or add** an address.
+2. **Inspect** model, firmware, interfaces, functions, and source gaps without
+   saving a management credential.
+3. **Adopt** selected Gateway, AP, or Switch functions and approve scoped
+   controller access.
+4. **Observe and configure** through the device and site views.
+5. **Reprobe or refresh access** when firmware or capabilities change.
+6. **Un-adopt** through a reviewed cleanup plan when the device leaves the
+   controller.
+
+## Find a device
+
+Open **Adopt a device** or use the adoption action from **Devices**.
+
+### Add by address
+
+Add-by-address is the reliable path in every supported deployment. Enter the
+router's management hostname or IPv4 address and continue to inspection.
+
+Use it when:
+
+- the controller runs in Docker bridge mode;
+- the router is across a routed management VLAN or VPN;
+- local discovery does not cover the subnet;
+- you already know the management address.
+
+### Scan the local subnet
+
+Discovery is an explicit, on-demand IPv4 scan. The scan will not accept a
+network wider than `/22`. It probes each eligible address over TCP for an
+unauthenticated OpenWrt `/ubus` endpoint; it does not implement ARP or mDNS
+discovery. A bridged container may not expose the LAN subnets to this scan.
+
+Discovery only lists candidates. It does not create a router login, change UCI,
+install a package, or begin continuous management.
+
+## Inspect before adoption
+
+Provide the router administrator credential only in the inspection/adoption
+flow. The controller can use it to establish facts such as:
+
+- model, board, and firmware;
+- management address and device MAC;
+- radio and interface evidence;
+- LAN, WAN, default-route, and switch-mode evidence;
+- recommended Gateway, AP, or Switch functions;
+- capability features, unobservable sources, driver notes, and source gaps.
+
+Unknown is not the same as absent. If the controller could not read a source,
+the inspection should say so. Fix the source or accept the limitation; do not
+convert the gap into a capability claim.
+
+::: danger Identity pins begin at adoption
+Read-only inspection uses ubus and does not open SSH. Adoption records the SSH
+host key and, for HTTPS management, the rpcd certificate fingerprint. Later
+unexpected changes are refused. They can indicate a factory reset,
+reinstallation, address reuse, or interception; verify the device out of band
+before force-un-adopting and adopting it again.
+:::
+
+## Choose device functions
+
+Functions describe what the controller may expect from the device:
+
+| Function | Use it for | Important boundary |
+|---|---|---|
+| Gateway | Default route, WAN observation, routed networks, DHCP, and firewall behavior | Only one managed Gateway is supported |
+| AP | WLAN broadcast, associated stations, radio metrics, roaming, and RF tools | A device can be AP-only or combine functions |
+| Switch | Infrastructure placement and switch observations | Per-port VLAN writing depends on hardware; legacy swconfig remains observe-only |
+
+Select only functions the device actually performs. You can combine functions
+on an all-in-one router. A wrong function choice creates misleading
+expectations and can block a later preview when required capabilities are not
+present.
+
+## Review the controller access payload
+
+Stock rpcd cannot create its own scoped management identity. Adoption can use
+SSH once to create:
+
+- one `oonfeewrt` login; and
+- one reviewable rpcd ACL JSON file.
+
+The router administrator credential is used for that bounded bootstrap and is
+not stored. Normal collection and configuration use rpcd/ubus with the scoped
+credential. Adoption does not install a package, executable, daemon, service,
+or firmware.
+
+1. Expand the displayed access plan.
+2. Review the destination paths and ACL operations.
+3. Confirm the inspected MAC/model evidence and selected functions.
+4. Approve the controller access payload only if the scope is acceptable.
+5. Wait for the post-adoption capability report before configuring the site.
+
+See [Adopt your first device](../getting-started/first-adoption.md) for the full
+first-device runbook.
+
+## Read the Devices list
+
+The list is the fleet-level view. Use status and last-seen time together:
+
+- **Online** means management evidence is fresh enough for the current
+  collection cadence.
+- **Offline** means the freshness threshold was crossed; it does not prove the
+  router itself is powered off.
+- **Unavailable** or a source gap means a specific value could not be
+  established.
+
+Open a row for the detail workspace.
+
+## Use device detail
+
+The detail view can include:
+
+- name, address, MAC, firmware, class, and selected functions;
+- load, memory, client count, and poll duration;
+- traffic and radio time series;
+- radio inventory and broadcast provenance;
+- capability states and actionable source gaps;
+- current collection tier and adjustable slower interval;
+- controller requests, bytes, polls, and router CPU attributed to management;
+- controller-installed package accounting;
+- ownership state and reviewed change or un-adoption actions.
+
+### Focused collection
+
+Opening a live device workspace can move it from the baseline collection tier
+to a faster focused tier. The verified defaults are approximately 60 seconds
+at baseline and 10 seconds while focused. Slow or overloaded devices can back
+off, up to 10 minutes, and Apply temporarily quiesces collection.
+
+Use **poll less often** when management overhead matters more than freshness.
+Check the overhead card afterward rather than assuming the interval change had
+the intended effect.
+
+### Rename
+
+Renaming changes the controller's display identity only. It does not rename
+the OpenWrt hostname. Use distinct names when two devices share the same model
+or default hostname.
+
+### Reprobe capabilities
+
+Reprobe after a firmware upgrade, package change, ACL refresh, or when the UI
+says an older capability record has no answer for a new feature. Reprobe reads
+sources; it does not Apply site configuration.
+
+Compare the new report with the earlier one. A newly missing source can be an
+ACL regression or package/module change, not necessarily lost hardware.
+
+### Refresh the ACL
+
+Use ACL refresh only when the controller identifies that the adopted scoped
+identity lacks a currently required permission. This uses the device
+administrator credential for a bounded update. Review the exact payload again;
+do not treat it as a generic repair step for transport failures.
+
+## Optional LLDP
+
+LLDP can improve physical topology evidence, but it is not part of adoption.
+The separate workflow can:
+
+1. refresh the OpenWrt package index after acknowledgement;
+2. show the exact official-feed package plan;
+3. install `lldpd` and recorded feed dependencies after acknowledgement;
+4. show the exact physical-interface configuration plan;
+5. record before-state, added packages, and service ownership for rollback.
+
+::: warning Router package change
+LLDP is the only shipped optional package workflow. Do not approve it merely
+to remove an “unavailable” label. Install it only when improved topology
+evidence is worth the storage, service, and change footprint on that device.
+:::
+
+Rollback restores the recorded configuration and service state and removes
+only packages recorded as additions. A live LLDP ownership record blocks
+un-adoption until rollback is resolved.
+
+## Un-adopt safely
+
+Un-adoption first plans restoration/removal of controller-owned configuration,
+then removes the scoped login and ACL. It must not rewrite human-owned UCI.
+
+Before starting:
+
+- export a controller backup;
+- make a router configuration backup;
+- resolve any in-progress Apply;
+- roll back optional LLDP;
+- ensure the administrator credential and management path still work.
+
+If the device is unreachable, the force path can remove the controller record
+but cannot prove router cleanup. Save the displayed residue report and manual
+commands. Do not assume a lost device is clean merely because it disappeared
+from the controller.
+
+## Troubleshooting
+
+| Symptom | Check | Action |
+|---|---|---|
+| Scan finds no device | Bridged-container subnet visibility, routed subnet, subnet size, or controller reachability | Add the router by hostname or IPv4 address; verify the controller can route to its management endpoint |
+| Inspection cannot connect | Address, administrator password, selected HTTP/HTTPS protocol, `rpcd`, `uhttpd` ubus handler, or firewall | Verify the ubus management endpoint from the controller host; SSH is not used by inspection |
+| Adoption refuses Gateway | Another adopted device already has the Gateway function | Review and un-adopt the existing Gateway before adopting a replacement; functions cannot be reassigned in place in v0.1.1 |
+| Host key or certificate changed | Factory reset, firmware reinstall, address reuse, interception | Verify identity out of band before force-un-adopting and adopting the device again |
+| Metrics say unavailable | Source not readable, driver lacks metric, ACL gap, or no completed poll | Read the source explanation; reprobe or refresh ACL only when it names a repairable cause |
+| Device flips offline/online | Slow polls, unstable transport, adaptive backoff, overloaded router | Review poll duration, overhead, controller logs, and network path before shortening intervals |
+| Un-adoption is blocked | Active LLDP ledger or another conflicting operation | Roll back LLDP and allow active operations to finish |
+
+## Related guides
+
+- [Adopt your first device](../getting-started/first-adoption.md)
+- [Safety and ownership model](../concepts/safety.md)
+- [Requirements and compatibility](../reference/requirements.md)
+- [Clients and topology](./clients-topology.md)

--- a/docs/guide/logs-diagnostics.md
+++ b/docs/guide/logs-diagnostics.md
@@ -1,0 +1,137 @@
+# Logs and diagnostics
+
+Logs explain controller and network events; diagnostics package a bounded,
+redacted subset of stored controller evidence for support. Diagnostics do not
+poll or change routers while generating a bundle.
+
+<div class="write-impact"><strong>Router write impact</strong><span>Reading logs and generating/downloading diagnostics are router-read-free operations. A diagnostics bundle is built from stored controller evidence and makes no router management call.</span></div>
+
+## General and Audit logs
+
+Open **Logs** and choose the appropriate view:
+
+- **General** — device health, collection, topology, RF, controller operations,
+  and other operational events.
+- **Audit** — authenticated administrative and security-relevant actions, such
+  as account changes, adoption, Apply, backup/restore, or session operations.
+
+The exact detail panel preserves source provenance and fields that would be too
+dense for the table.
+
+## Filter effectively
+
+Use filters/facets before paging. The event store applies the filter before the
+limit and uses keyset pagination, so a page is a stable slice of the matching
+history rather than an unfiltered batch trimmed in the browser.
+
+A useful incident filter sequence:
+
+1. choose General or Audit;
+2. set severity and category facets when available;
+3. page backward to the time around the first symptom;
+4. use the Device column to locate events for the affected router;
+5. open exact details rather than inferring from the short message;
+6. note source gaps and timestamps;
+7. correlate with Dashboard, Client Observability, or Topology at the same time.
+
+v0.1.1 does not provide a device or free-text search filter on the Logs page.
+
+## Retention boundaries
+
+- OpenWrt-origin logs: 24 hours, bounded to 50,000 per device and 100,000
+  globally.
+- Controller/audit history: bounded to 100,000 records.
+
+Retention is deliberately bounded. Export a diagnostics bundle or record the
+needed evidence before a long investigation exceeds the window. A bundle is a
+support snapshot, not a replacement for a dedicated long-term log platform.
+
+## Generate a diagnostics bundle
+
+Users with the required administrative permission can open **Settings →
+Diagnostics**.
+
+1. Read the descriptor before generation. It lists included sections, excluded
+   secret classes, and size limits.
+2. Confirm it reports `router_management_calls=false` and
+   `router_changes=false`.
+3. Select **Generate**.
+4. Watch the job state. Only one active generation is accepted at a time.
+5. Download the completed ZIP.
+6. Store and share it as private network metadata, even though it is redacted.
+
+The bundle content is bounded to 16 MiB plus 1 MiB of archive overhead. Job
+history exposes completed, failed, and cancelled outcomes instead of hiding a
+failed collection.
+
+## What diagnostics include
+
+The UI's descriptor is authoritative for the current build. Typical stored
+evidence categories can include:
+
+- controller version, schema, platform, uptime, health, migration, and
+  integrity metadata;
+- adopted device model, target, firmware, kernel, package-manager, and
+  capability records;
+- bounded events/audit evidence;
+- stored topology-source/edge, radio-scan, event-source, and source-gap
+  summaries;
+- sanitized controller log material;
+- a manifest describing sections, limits, and router-call/write assertions.
+
+Generation uses the database/log evidence already on the controller. It does
+not contact Fleet or fetch a fresh secret-bearing router configuration.
+
+## What diagnostics exclude
+
+Redaction and exclusion cover secret-bearing classes such as:
+
+- router credentials;
+- WLAN and mesh keys;
+- private keys and keyring material;
+- session cookies/tokens and CSRF material;
+- controller runtime/export passphrases;
+- account password hashes and authentication secrets.
+
+The generator also sanitizes sensitive key names and patterns in stored text.
+No automatic redactor is a reason to publish internal diagnostics publicly.
+Review distribution and delete third-party copies when the support need ends.
+
+## Verify a downloaded bundle
+
+1. Confirm the ZIP size is within the descriptor limit.
+2. Open the manifest first.
+3. Check controller version and generation time.
+4. Confirm included/excluded sections match the UI disclosure.
+5. Search the extracted copy for known local secret canaries only in a private
+   environment if you maintain a formal validation procedure.
+6. Share through an access-controlled channel.
+
+Do not edit the bundle and then present it as controller-generated evidence;
+keep the original hash/file when chain of custody matters.
+
+## Troubleshooting logs
+
+| Symptom | Explanation | Action |
+|---|---|---|
+| Expected event is absent | Wrong view/filter, retention expired, operation never crossed its audit boundary, or storage error | Clear filters, check both views, inspect controller logs and durable operation receipt |
+| Device log stream stops | Device/source unavailable or log retention/collection gap | Open device capability/source state and correlate last successful poll |
+| Many repeated warnings | Persistent source failure or unstable device rather than separate incidents | Group by device/type/time; fix the root source instead of acknowledging each row |
+| Timestamps appear surprising | Browser locale versus stored epoch/UTC context | Use exact detail and compare with controller host time |
+
+## Troubleshooting diagnostics
+
+| Symptom | Explanation | Action |
+|---|---|---|
+| Generate is unavailable | Role does not permit diagnostics or another exclusive operation is active | Sign in with the required admin role and let backup/restore/other conflicting work finish |
+| Job fails on size | Stored evidence exceeded a bounded section/archive limit | Read the terminal detail; reduce unrelated retained evidence only through supported maintenance, never delete DB files manually |
+| Download is refused | Job expired, state changed, or artifact validation failed | Generate a new bundle and preserve the terminal error for support |
+| Bundle lacks a live router value | Diagnostics intentionally use stored evidence only | Reproduce/collect the source through normal controller polling first, then generate a new bundle |
+| You suspect failed redaction | A local name/value resembles an uncovered secret pattern | Do not share the file; report the issue privately with a synthetic reproducer rather than the real secret |
+
+## Related guides
+
+- [Dashboard and Internet health](./dashboard.md)
+- [Routine maintenance](../operations/maintenance.md)
+- [Backup and staged restore](../operations/backups.md)
+- [Troubleshooting reference](../reference/troubleshooting.md)

--- a/docs/guide/networks.md
+++ b/docs/guide/networks.md
@@ -1,0 +1,180 @@
+# Networks, VLANs, and DHCP
+
+Network settings describe the site you want: IPv4 networks, optional VLANs,
+DHCP service, and firewall zones. Saving a model records intent in the
+controller. **Preview and Apply are separate actions.**
+
+<div class="write-impact warning"><strong>Router write impact</strong><span>Editing and saving desired state changes only the controller database. Apply can change controller-owned `network`, `dhcp`, `firewall`, and related wireless UCI sections after preview, preflight, and acknowledgement.</span></div>
+
+## Before you configure a network
+
+Have all of these ready:
+
+- a tested controller backup and router configuration backup;
+- one adopted non-critical device for the first rollout;
+- an IPv4 CIDR and, when applicable, VLAN ID;
+- the intended firewall zone and forwarding behavior;
+- a DHCP pool that fits inside the subnet and does not include infrastructure
+  addresses you plan to configure statically;
+- capability evidence for DSA versus legacy swconfig and for the relevant
+  network/firewall rpcd modules;
+- physical switch and trunk configuration outside oonfeeWRT, if traffic must
+  traverse unmanaged infrastructure.
+
+::: danger Keep a recovery path
+An incorrect management VLAN, bridge, firewall input policy, or DHCP plan can
+disconnect the controller and clients. Start with one non-critical device,
+stay on a known management path, and rely on the rollback timer—not on an
+untested assumption that another path will work.
+:::
+
+## Understand the model
+
+### Network
+
+A network gives a named IPv4 segment its CIDR, optional VLAN ID, DHCP behavior,
+and firewall-zone membership. Networks are site-wide; device functions and
+capability evidence determine what each Preview can safely render.
+
+### VLAN
+
+A VLAN ID labels traffic; it does not configure every switch between the
+controller and the client. oonfeeWRT will not silently convert a bridge that is
+not already VLAN-aware. Legacy swconfig port writes remain observe-only in
+v0.1.1 because port topology and safe mutation are hardware-specific.
+
+### DHCP
+
+DHCP settings must stay within the network CIDR. The editor validates missing,
+inverted, or out-of-range pool values before Apply. Plan the router address,
+static infrastructure, reservations, and dynamic range together.
+
+### Firewall zone
+
+The zone anchors forwarded traffic policy and explicit firewall-rule scope. A
+zone name is not cosmetic: moving a network can change effective policy. The
+Zone Matrix edits whole-zone forwarding; router-local input rules are separate
+explicit policies. oonfeeWRT previews controller-owned firewall sections and
+blocks or warns on conflicts it cannot safely reconcile.
+
+## Create a network
+
+1. Open **Settings → Network**.
+2. Find **Networks** and choose **Add network**.
+3. Enter a unique, descriptive name.
+4. Enter the IPv4 CIDR, such as `192.168.20.1/24`, using the router address in
+   the prefix where the editor expects the interface address.
+5. If the segment is tagged, enter its VLAN ID and confirm the upstream trunks
+   already carry it.
+6. Choose or create the firewall zone.
+7. Enable DHCP only if this managed Gateway should provide it.
+8. Set the DHCP pool and lease options shown by the editor.
+9. Save desired state.
+
+At this point no router Apply has happened.
+
+## Review zone behavior
+
+Before Apply, open the **Policy Engine → Zone Matrix** and **Master Table** and
+answer:
+
+- Is forwarding to WAN allowed or denied as intended?
+- Which other managed zones can this zone initiate connections toward?
+- Are inbound port forwards or explicit gateway-input rules required?
+- Does foreign firewall configuration already cover or conflict with this
+  path?
+
+The Zone Matrix does not model DHCP/DNS access to the Gateway itself. Review
+the network's DHCP settings and any explicit gateway-input rules separately.
+
+Use explicit policy rules for exceptions. Avoid broad forwarding merely to
+make a test pass.
+
+## Preview the fleet change
+
+Open the review action in Settings and generate a fresh Preview. A preview is
+bound to the current desired state and fleet; if either changes, generate it
+again.
+
+Inspect every device bucket:
+
+- **Changes** — owned UCI sections/options that would be staged;
+- **No change** — desired state already matches observed owned state;
+- **Omissions** — capability or device-function rules intentionally skip work;
+- **Conflicts/blockers** — foreign state, missing sources, unsupported bridge
+  shape, driver defects, or invalid intent;
+- **Acknowledgements** — traversal or hardware risks you must explicitly
+  accept.
+
+The preview redacts WLAN and mesh keys. A preview should never be used as a way
+to reveal stored secrets.
+
+## Apply and verify
+
+1. Resolve blockers rather than bypassing them on the router.
+2. Read every acknowledgement and select only those you understand.
+3. Start Apply once. The operation is durable; do not create a second attempt
+   merely because the browser disconnects.
+4. oonfeeWRT preflights the fleet, applies non-Gateway devices first, and the
+   Gateway last.
+5. Each device stages a bounded UCI batch and starts OpenWrt's rollback window.
+6. The controller reconnects, reads the expected state, runs the health checks,
+   and confirms only on success.
+
+After completion:
+
+- confirm the operation receipt reports a known outcome for every device;
+- verify the management path still works;
+- connect a test client to the segment;
+- verify address, gateway, DNS, and intended Internet/inter-zone reachability;
+- inspect **Logs → Audit** for the Apply record;
+- compare the device's owned-state/capability view with the preview.
+
+## If connectivity fails
+
+Do not immediately repeat Apply. OpenWrt should revert an unconfirmed change
+when the rollback window expires.
+
+1. Keep the router powered and avoid restarting it during the window.
+2. Wait for the durable operation status to settle.
+3. Reconnect through the original management path.
+4. Confirm the prior configuration returned in LuCI or with read-only UCI
+   inspection.
+5. Read the controller receipt and logs for the device boundary it crossed.
+6. Correct desired state, generate a new preview, and try again only after the
+   outcome is known.
+
+If the outcome is reported as **unknown** or **possible write**, treat the
+router as changed until independently inspected.
+
+## Coexist with LuCI and existing UCI
+
+oonfeeWRT owns only sections it created and recorded. Human-managed sections
+remain visible but are not silently rewritten. This has two consequences:
+
+- foreign configuration can block a requested intent when both would control
+  the same effective behavior;
+- renaming or manually removing an owned section outside the controller can
+  break ownership evidence and requires investigation, not automatic takeover.
+
+Make a deliberate ownership choice. Do not repeatedly edit the same logical
+network in both LuCI and oonfeeWRT.
+
+## Common problems
+
+| Preview finding | Meaning | Safe response |
+|---|---|---|
+| Bridge is not VLAN-aware | The live bridge cannot accept the requested safe rendering | Convert it manually with a tested OpenWrt-specific plan, or use an untagged design; oonfeeWRT will not convert it silently |
+| Legacy swconfig device | Per-port VLAN writes are not safely generalized | Keep port configuration outside oonfeeWRT and use supported observation/site features |
+| Foreign firewall conflict | A human-owned rule/zone affects the requested traffic path | Inspect the exact UCI/nft behavior, then remove or redesign one owner intentionally |
+| Missing `firewall4` capability | The controller cannot establish the required firewall backend | Install/enable the supported OpenWrt component outside adoption, then reprobe |
+| DHCP range invalid | Pool is incomplete, outside the subnet, or conflicts with the interface plan | Correct the CIDR/pool before preview |
+| Stale preview | Desired state or fleet changed after preview | Generate and review a new preview |
+| Apply interrupted | Browser or controller connection ended during a durable operation | Reopen the operation status; never assume failure means no write |
+
+## Related guides
+
+- [Policy Engine and firewall](./policy-engine.md)
+- [Wi-Fi, roaming, and overrides](./wifi.md)
+- [Safety and ownership model](../concepts/safety.md)
+- [Backup and staged restore](../operations/backups.md)

--- a/docs/guide/policy-engine.md
+++ b/docs/guide/policy-engine.md
@@ -1,0 +1,181 @@
+# Policy Engine and firewall
+
+The Policy Engine turns explicit intent into reviewable firewall, forwarding,
+route, and client-policy objects. It exposes both the high-level relationship
+and the concrete draft so broad access is not hidden behind friendly labels.
+
+<div class="write-impact warning"><strong>Router write impact</strong><span>Editing and saving policies changes controller desired state. Router firewall, DHCP, or route state changes only through a fresh Preview and acknowledged Apply.</span></div>
+
+## Before you create policy
+
+- Define the networks and firewall zones first.
+- Confirm the managed Gateway has current firewall/backend capability evidence.
+- Document the source, destination, protocol, ports, and business reason.
+- Back up controller and Gateway configuration.
+- Begin with a narrow test rule and a known client.
+- Know how you will retain management access if the rule is wrong.
+
+The Policy Engine is IPv4-focused in v0.1.1. QoS, application/DPI identity,
+proved priority semantics, switch ACLs, device/group routing, and advanced
+traffic classification remain unavailable or gated.
+
+## The three views
+
+### Master Table
+
+The Master Table combines saved rules with synthesized zone-forwarding and
+client-policy rows. Use it to see which policies exist, their types, display
+order, enabled state, origin, deployability, and editable source.
+
+Rows in this view include:
+
+- explicit firewall rules;
+- port forwards;
+- static routes;
+- client block/fixed-address/group intent;
+- whole-zone forwarding relationships.
+
+Display order helps reviewers understand intent, but do not assume a numeric
+priority has packet-processing semantics unless the preview/concrete backend
+proves it.
+
+### Zone Matrix
+
+The matrix shows effective relationships from each managed source zone to
+other zones and WAN. Same-zone cells are informational. Editable cells open the
+source policy rather than mutating the router immediately.
+
+Use it to spot broad forwarding before reading the exception rules:
+
+- Which zones may initiate toward WAN?
+- Which managed zones may reach each other?
+- Which directions are read-only or derived?
+- Does an allowed relationship exceed the narrow service actually needed?
+
+### Object Manager
+
+Object Manager compiles selected networks/clients and an intended action into a
+visible **unsaved draft**. Read the concrete result before saving it.
+
+The client inventory can be partial. A selector built from incomplete current
+inventory is not proof that every intended endpoint is covered. Prefer stable
+network or explicit address objects when identity must survive MAC
+randomization or an offline client.
+
+## Create an explicit firewall rule
+
+1. Open **Policy Engine → Master Table**.
+2. Add a rule and choose **Firewall rule**.
+3. Give it a descriptive name and display order.
+4. Choose `accept`, `drop`, or `reject` deliberately.
+5. Select the source zone.
+6. Select a destination zone, or leave it router-local only when that is the
+   intended model.
+7. Choose protocols.
+8. Add source/destination IPv4 CIDRs, ports/ranges, or source MACs only as
+   needed.
+9. Save desired state.
+10. Review the Zone Matrix and generate a fresh Preview.
+
+Avoid `0.0.0.0/0`, all protocols, and all ports unless the zone relationship is
+intentionally broad and documented.
+
+## Create a port forward
+
+A port forward exposes a service through the managed Gateway.
+
+Required intent includes:
+
+- destination zone;
+- protocol;
+- external port;
+- destination IPv4 address;
+- destination port;
+- optional allowed source IPv4 CIDR.
+
+::: danger Internet exposure
+A correct port-forward rendering can still expose an insecure service. Patch
+the destination, restrict source CIDRs when possible, use application-level
+authentication/TLS, and verify the service from an external test path.
+:::
+
+After Apply, test both an allowed and a denied source. Review Gateway logs and
+the exact rendered preview; a successful Apply proves configuration state, not
+that the application is safe.
+
+## Create a static route
+
+Specify:
+
+- target IPv4 network;
+- next-hop IPv4 address;
+- egress network;
+- optional metric.
+
+Verify the next hop is reachable on the selected network and that the return
+route exists. A forward route without a return path can look like a firewall
+failure.
+
+After Apply, test from the Gateway and a representative client, then confirm
+that the route does not capture management or default traffic unexpectedly.
+
+## Manage client intent
+
+Client desired policy can record a fixed IPv4 address, group, or block intent.
+The inventory identity and DHCP/firewall backend still determine how that
+intent is realized.
+
+Before using a fixed address:
+
+- keep it inside the intended subnet;
+- keep it outside the dynamic pool or reserve it intentionally;
+- account for randomized MAC addresses;
+- verify there is no existing static assignment.
+
+## Review the concrete preview
+
+The Preview is the decision boundary. Expand the Gateway and check:
+
+- exact controller-owned UCI additions/updates/removals;
+- protocol and port normalization;
+- source/destination zones and router-local versus forwarded behavior;
+- route target, next hop, network, and metric;
+- foreign rule/route conflicts;
+- capability omissions or backend gaps;
+- acknowledgement requirements;
+- redaction of any unrelated secret values.
+
+If a foreign rule already rejects or redirects the same path, resolve ownership
+explicitly. oonfeeWRT must not reorder or rewrite human-owned firewall state to
+make its preview converge.
+
+## Apply and validate
+
+1. Generate a fresh preview after the final edit.
+2. Start Apply once and follow the durable receipt.
+3. Confirm management access remains available.
+4. Test the intended allowed path.
+5. Test at least one intended denied path.
+6. For port forwards, test from outside the Gateway rather than hairpinning
+   unless hairpin behavior is itself the requirement.
+7. For routes, test the return path and traceroute/route evidence.
+8. Check **Logs → Audit** and the Gateway device state.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| Rule saves but is not on the router | Saving desired state is not Apply | Generate a Preview and use the acknowledged Apply workflow |
+| Preview blocks on firewall capability | `firewall4`/rpcd source is absent or unknown | Read the capability report, repair the supported OpenWrt source, and reprobe |
+| Preview reports a foreign conflict | Human-owned UCI/nft rule controls the same path | Inspect exact order/effect; redesign or remove one owner intentionally |
+| Port forward applies but service is unreachable | Application down, destination firewall, wrong route, ISP/CGNAT, or source restriction | Test each hop and service locally before changing the rule |
+| Static route works one way | Missing return route or stateful firewall path | Correct the remote network and zone policy; do not add an unrelated broad allow |
+| Object Manager list is incomplete | Client inventory/source coverage is partial | Use network/stable explicit selectors and fix coverage before relying on it |
+| Management is lost | Policy affected router input or management path | Let OpenWrt rollback unconfirmed Apply; inspect the durable outcome before retrying |
+
+## Related guides
+
+- [Networks, VLANs, and DHCP](./networks.md)
+- [Safety and ownership model](../concepts/safety.md)
+- [Logs and diagnostics](./logs-diagnostics.md)
+- [Capability and support matrix](../reference/capabilities.md)

--- a/docs/guide/radios.md
+++ b/docs/guide/radios.md
@@ -1,0 +1,122 @@
+# Radios and channel planning
+
+The Radios workspace combines inventory, measured RF data, source gaps, and an
+evidence-aware channel plan. It helps you decide what to investigate; it does
+not claim spectrum knowledge the hardware did not report.
+
+<div class="write-impact warning"><strong>Router write impact</strong><span>Viewing radio inventory, metrics, and the channel plan is read-only. Starting an RF scan is disruptive to clients on the serving radio and requires an explicit acknowledgement.</span></div>
+
+## What the workspace contains
+
+### Channel Plan
+
+The channel plan lays out known radios, bands, current channels, and evidence
+that can support a placement decision. The per-radio table adds utilization,
+interference, airtime, retry/failure, signal, and a scan-derived channel score
+when those sources are available. The latest scan row shows its outcome and BSS
+count; v0.1.1 does not display the raw BSS inventory.
+
+Treat it as a plan, not an automatic optimizer:
+
+- a missing scan does not mean the channel is clear;
+- channel width changes the overlap picture;
+- 2.4 GHz, 5 GHz, and 6 GHz rules differ by regulatory domain and hardware;
+- DFS channels can require radar handling and availability checks;
+- client compatibility can matter more than the cleanest measured channel;
+- observations from one AP do not describe the exact RF environment at
+  another AP.
+
+### Per-radio observability
+
+Each radio row identifies the device, stable radio key, band, channel,
+utilization/interference and related metrics, scan capability, and source state
+that the controller can establish.
+
+Values can be:
+
+- **Observed** — a valid recent sample exists;
+- **Stale** — earlier evidence exists but has crossed its freshness window;
+- **Refresh failed** — an older sample is shown with a failed latest attempt;
+- **Unavailable** — the required source or capability is not available;
+- **Not measured yet** — no successful collection/scan has produced a value.
+
+Do not compare an observed value with an unavailable one as though both were
+numbers.
+
+## Plan a channel change
+
+1. Confirm every intended AP appears and has the AP function.
+2. Separate radios by band and channel width.
+3. Review current-channel reuse among APs that can hear each other.
+4. Check utilization, interference, and scan timestamps, not only their values.
+5. Review the scan-derived suggestion and its evidence limits.
+6. Consider the physical floor plan, wall materials, transmit power, and client
+   density that controller telemetry cannot infer reliably.
+7. Make one approved channel change at a time in LuCI or through an audited
+   device-specific OpenWrt workflow.
+8. Refresh oonfeeWRT and compare client experience and new measurements after
+   the change.
+
+oonfeeWRT v0.1.1 does not include spectrum analysis or an automatic channel
+change loop, and it has no radio-channel editor or Apply path. Its planner is
+read-only; only the separately acknowledged RF scan can disrupt a serving
+radio.
+
+## Run an RF scan
+
+::: danger Client disruption
+An active scan can take the serving radio off-channel. Associated clients may
+pause, roam, or disconnect. Do not scan a sole production AP or a wireless
+backhaul radio without a recovery and timing plan.
+:::
+
+1. Open **Radios**.
+2. Find a row whose scan capability is **Present** and whose radio interface is
+   known.
+3. Select **Scan**.
+4. Verify the device and radio key in the dialog.
+5. Read and accept the disruption acknowledgement.
+6. Start the scan once and wait for its terminal state.
+
+The controller persists the latest terminal scan result for each radio. It
+does not build an unlimited scan archive. Record a before/after comparison
+outside the controller when a long-term RF study matters.
+
+### Verify the result
+
+- Confirm the terminal result belongs to the intended device and radio.
+- Check its timestamp and outcome.
+- Inspect the terminal outcome, BSS count, scan-derived suggestion/basis, and
+  any explicit source gaps.
+- Confirm clients returned and the radio resumed its expected channel.
+- Review Logs if the scan failed or the AP became unreachable.
+
+## Interpret common metrics
+
+| Metric | What it can indicate | What it cannot establish alone |
+|---|---|---|
+| Channel utilization | How busy the radio reports the channel during the sample | Which transmitter caused the activity or whether user traffic was harmed |
+| Interference | Controller-derived airtime not explained by its tracked TX/RX split | Complete interference spectrum or non-Wi-Fi source identity |
+| Scan BSS count and suggestion | How many BSS rows a terminal scan returned and the transparent overlap score derived from them | Raw BSS details, hidden transmitters, client-side visibility, or continuous occupancy |
+| Client RSSI | Signal at the AP for a client sample | Downlink signal at the client, throughput, or roaming readiness |
+| Retry-related values | Link quality when the driver exposes a trustworthy source | A complete fleet retry rate when the focused source is absent |
+
+Correlate RF metrics with client path, traffic, latency, events, and the time of
+the observation.
+
+## Troubleshooting
+
+| Symptom | Explanation | Action |
+|---|---|---|
+| Scan button is unavailable | Capability is absent/unknown, interface name is missing, or driver source is not exposed | Reprobe the device and read the capability reason; do not install unrelated packages blindly |
+| Utilization or interference is unavailable | Driver/rpcd source is missing, required counters disagree, or no valid poll has completed | Focus the device workspace, wait for collection, and check source gaps |
+| Scan completes with few results | Quiet environment, band/channel visibility, driver behavior, or scan limitations | Compare from another AP and time; do not infer full-spectrum cleanliness |
+| Clients disconnect | Expected scan disruption or unstable radio recovery | Let the scan finish, verify radio state, review OpenWrt/controller logs, and avoid scanning that production path again |
+| Channel plan looks inconsistent | Mixed widths/bands, stale samples, or one AP lacks evidence | Align the time/source coverage before comparing rows |
+
+## Related guides
+
+- [Wi-Fi, roaming, and overrides](./wifi.md)
+- [Clients and topology](./clients-topology.md)
+- [Dashboard and Internet health](./dashboard.md)
+- [Capability and support matrix](../reference/capabilities.md)

--- a/docs/guide/wifi.md
+++ b/docs/guide/wifi.md
@@ -1,0 +1,183 @@
+# Wi-Fi, roaming, and overrides
+
+oonfeeWRT models a WLAN once and fans it out to the selected APs. AP groups and
+bounded per-device overrides let a mixed fleet share intent without pretending
+every radio and driver behaves identically.
+
+<div class="write-impact warning"><strong>Router write impact</strong><span>Editing and saving WLAN intent is controller-only. Apply can create or update controller-owned `wireless` sections and related network/firewall state. RF scans are a separate disruptive action.</span></div>
+
+## Before you change Wi-Fi
+
+- Back up the controller and the OpenWrt configuration on a test AP.
+- Confirm each target has the **AP** function and fresh radio capability data.
+- Record the existing SSID, security mode, passphrase, bands, channels, and
+  management path.
+- Use a wired management path for the first change when possible.
+- Check whether the AP is using a wireless uplink; changing its serving radio
+  can disconnect both clients and controller management.
+- Decide which radios/APs belong together before creating groups.
+
+## Build the site structure
+
+### AP groups
+
+An AP group selects where a WLAN is eligible to broadcast. Use groups for real
+placement or policy boundaries, such as `All APs`, `Downstairs`, or `Guest
+areas`. Avoid one group per device unless the intent is genuinely unique.
+
+The effective target is the intersection of:
+
+- devices with the AP function;
+- group membership;
+- detected radio/band capabilities;
+- WLAN settings and any bounded override;
+- safety/capability gates in the preview.
+
+### WLANs
+
+A WLAN describes the shared intent:
+
+- SSID and enabled state;
+- security mode and passphrase when required;
+- target AP group;
+- network attachment;
+- band/radio eligibility;
+- protected management frames (PMF);
+- 802.11r fast transition;
+- 802.11k neighbour reports and 802.11v steering-related options exposed by
+  the current UI.
+
+The API and preview do not reveal stored WLAN or mesh keys, including legacy
+reveal query patterns. Replace a forgotten passphrase; do not expect the
+controller to display it.
+
+## Create or update a WLAN
+
+1. Open **Settings → Network** and find the Wi-Fi/WLAN section.
+2. Choose **Add WLAN**, or open the WLAN you intend to change.
+3. Enter the SSID exactly as clients should see it.
+4. Select a security mode supported by every target AP/client combination.
+5. Enter a passphrase when the mode requires one.
+6. Choose the client network and AP group.
+7. Set band and roaming options conservatively for a mixed fleet.
+8. Save desired state.
+9. Generate a fresh Preview and expand every target device.
+
+Check that the preview fans out to the intended APs and does not silently omit
+a radio. An omission should include a reason, such as missing capability,
+incompatible band, device function, or unreadable source.
+
+## Security modes and PMF
+
+Use a mode supported by the oldest required client and the target OpenWrt
+driver. PMF requirements must agree with the selected security mode; the UI
+clamps combinations that cannot be valid, but capability evidence still
+matters at Apply time.
+
+Roll out stricter security in stages:
+
+1. create a test WLAN or target one AP;
+2. verify representative clients can associate and obtain DHCP;
+3. verify DNS, Internet, and required local services;
+4. expand to the remaining group;
+5. retire the older WLAN only after observing the migration.
+
+## 802.11k, 802.11v, and 802.11r
+
+These features help clients make roaming decisions; they do not force a client
+to roam well.
+
+- **802.11k** provides neighbour information. oonfeeWRT can maintain managed
+  neighbour state when capabilities and complete observations support it.
+- **802.11v** can provide transition guidance where the driver and client
+  support it.
+- **802.11r** reduces authentication handoff cost but requires compatible
+  security and consistent configuration across participating APs.
+
+Keep SSID, security, passphrase, and roaming identifiers consistent across the
+roaming domain. Start with two APs and a known client. Observe actual
+association changes in Clients/Topology rather than assuming an enabled toggle
+proves roaming.
+
+The automatic 802.11k neighbour reconciler is a router-write path. It runs only
+when router writes are not globally suppressed, and uses the managed evidence
+and ownership rules. After a controller restore, review neighbour intent before
+entering `RESUME ROUTER WRITES`.
+
+## Mesh backhauls
+
+Mesh settings describe a shared backhaul and SAE key across participating
+devices. An empty key creates an open mesh, which permits any compatible nearby
+node to join and reach the network behind it.
+
+::: danger Secure mesh backhauls
+Use a strong mesh passphrase unless the deployment is an isolated lab. Treat a
+mesh key change as a management-path change when APs rely on that backhaul.
+:::
+
+Mesh support is capability-gated. Real mesh-backhaul behavior remains outside
+the published live-hardware evidence for v0.1.1, so validate on non-critical
+devices and keep a wired recovery path.
+
+## Wireless uplinks
+
+A wireless uplink makes an infrastructure device a client of another WLAN.
+Changing its band, SSID, key, or upstream AP can sever controller reachability.
+The UI exposes both the network intent and traversal hazards; read each preview
+acknowledgement.
+
+Wireless-uplink scenarios are implemented but not part of the published live
+hardware validation set. Do not roll them across a remote fleet without local
+recovery.
+
+## Per-device overrides
+
+Overrides are for bounded hardware differences. They must not fork the WLAN's
+identity or security contract across APs. The v0.1.1 UI permits per-device
+publication, hidden-SSID, and client-isolation overrides. It does not permit
+SSID, passphrase, security-mode, roaming, band, or radio-channel overrides.
+
+If many devices need the same override, change the group or shared WLAN intent
+instead. Repeated one-off overrides make preview review and future hardware
+replacement harder.
+
+## Existing broadcasts and takeover
+
+Pre-adoption inspection may find human-managed wireless sections. oonfeeWRT
+does not silently claim them. The device detail can present a takeover brief
+that identifies the broadcast and the consequences of leaving it unmanaged or
+disabling it.
+
+Review provenance by section, not only by SSID: two sections can broadcast the
+same SSID while having different owners or purposes. A takeover brief never
+includes the passphrase.
+
+## Apply and test
+
+1. Apply to one test AP or the smallest practical group.
+2. Keep the device powered while the OpenWrt rollback window is active.
+3. Confirm the durable receipt reports success and expected state.
+4. From a test client, forget stale credentials if appropriate and associate.
+5. Verify DHCP, DNS, Internet, and intended local-zone access.
+6. Check the Clients page for AP/radio attribution and source freshness.
+7. Walk between two APs and correlate association history before declaring
+   roaming successful.
+8. Expand the group only after the result is repeatable.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| WLAN omitted from one AP | Band/radio capability, AP function, group membership, or unreadable source | Expand that device's preview and capability report; do not force the section manually |
+| Client sees SSID but cannot join | Security/PMF/client incompatibility or wrong key | Test a known client, verify mode, replace rather than reveal the passphrase, and review OpenWrt logs |
+| Client joins but gets no address | Network attachment, VLAN path, DHCP, or firewall input | Follow [Networks, VLANs, and DHCP](./networks.md) from AP through Gateway |
+| Roaming does not occur | Client decision, inconsistent domain settings, missing 802.11k/v/r support, or RF design | Verify configuration consistency, capability evidence, signal/channel design, and actual association history |
+| AP becomes unreachable after Apply | Wireless management/uplink path changed | Wait for rollback; use wired/local recovery if it cannot reconnect; inspect the durable Apply outcome before retrying |
+| Preview reports foreign wireless conflict | Existing human-owned section overlaps the requested intent | Choose explicit manual ownership or a distinct WLAN; do not delete the foreign section blindly |
+
+## Related guides
+
+- [Radios and channel planning](./radios.md)
+- [Networks, VLANs, and DHCP](./networks.md)
+- [Clients and topology](./clients-topology.md)
+- [Safety and ownership model](../concepts/safety.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,187 @@
+---
+layout: home
+title: oonfeeWRT Documentation
+titleTemplate: false
+
+hero:
+  name: oonfeeWRT
+  text: OpenWrt management without replacing OpenWrt
+  tagline: One self-hosted controller for visibility, adoption, safe configuration, radio planning, policy, backups, and operations across stock OpenWrt devices.
+  image:
+    src: /logo-light.svg
+    alt: oonfeeWRT signal mark
+  actions:
+    - theme: brand
+      text: Get started
+      link: /getting-started/
+    - theme: alt
+      text: Explore capabilities
+      link: /reference/capabilities
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/aiden0rchad/oonfeeWRT
+
+features:
+  - title: Stock OpenWrt stays in control
+    details: The controller runs on your server, NAS, mini-PC, or Mac. Routers keep their existing firmware, LuCI, and human-managed configuration.
+  - title: Evidence before assumptions
+    details: Every screen separates measured values, unavailable sources, stale data, and unsupported capabilities instead of filling gaps with guesses.
+  - title: Preview, rollback, confirm
+    details: Configuration is reviewed first, staged through UCI, protected by OpenWrt's rollback timer, and confirmed only after the controller reads the expected state.
+  - title: Useful fleet visibility
+    details: See Internet health, clients, device telemetry, topology history, radios, events, management overhead, and controller-host speed tests.
+  - title: Local security boundaries
+    details: Local accounts and roles, scoped router access, encrypted stored secrets, redacted diagnostics, and no cloud broker or controller-authored router package.
+  - title: Recovery designed in
+    details: Export encrypted portable backups, validate them in staging, restore through a controlled restart, and keep router writes suppressed until an owner reviews the result.
+---
+
+<p class="doc-kicker">Documentation for v0.1.1</p>
+
+## One control plane, explicit boundaries
+
+oonfeeWRT is a self-hosted controller for small OpenWrt networks. It gives a
+single, UniFi-inspired interface to devices that still run stock OpenWrt. The
+controller observes the fleet, keeps desired configuration, and makes only the
+changes you review and approve.
+
+It is **not firmware**. Nothing is installed on a router when you start the
+controller, discover a device, or add an address. Adoption can create one
+scoped `oonfeewrt` login and one reviewable rpcd ACL after consent. The only
+optional package workflow in v0.1.1 is LLDP, with a separate plan and rollback.
+
+<div class="status-strip">
+  <span class="status-pill">OpenWrt 21.02+</span>
+  <span class="status-pill">Linux and macOS hosts</span>
+  <span class="status-pill">Docker optional</span>
+  <span class="status-pill">Local accounts</span>
+  <span class="status-pill">SQLite persistence</span>
+  <span class="status-pill">No cloud broker</span>
+</div>
+
+## Choose your path
+
+<div class="path-grid">
+  <a class="path-card" href="./getting-started/">
+    <h3>I am evaluating oonfeeWRT</h3>
+    <p>Understand the fit, requirements, hardware evidence, security model, and current limitations before installing anything.</p>
+  </a>
+  <a class="path-card" href="./getting-started/quick-start">
+    <h3>I want to install it</h3>
+    <p>Choose a standalone binary or Docker Compose, preserve the data directory, create the first owner, and verify the controller.</p>
+  </a>
+  <a class="path-card" href="./getting-started/first-adoption">
+    <h3>I am ready to add a router</h3>
+    <p>Inspect capabilities first, review the scoped access payload, adopt with the minimum functions, then verify the capability report.</p>
+  </a>
+  <a class="path-card" href="./concepts/safety">
+    <h3>I need to understand router writes</h3>
+    <p>See which actions are read-only, which require acknowledgement, how ownership works, and what happens during rollback or recovery.</p>
+  </a>
+</div>
+
+## Capabilities at a glance
+
+<div class="capability-grid">
+  <div class="capability-card">
+    <h3>Fleet and Internet health</h3>
+    <p>Online state, WAN route evidence, ICMP reachability, six-hour trends, recent warnings, topology summary, and bounded Cloudflare speed tests from the controller host.</p>
+  </div>
+  <div class="capability-card">
+    <h3>Discovery and adoption</h3>
+    <p>On-demand IPv4 discovery, add-by-address, read-only pre-adoption inspection, independently selected Gateway/AP/Switch functions, and pinned device identity.</p>
+  </div>
+  <div class="capability-card">
+    <h3>Devices and clients</h3>
+    <p>Firmware, load, memory, throughput, radio series, management overhead, adjustable polling, client presence and attribution, and a joined observability workspace.</p>
+  </div>
+  <div class="capability-card">
+    <h3>Topology and RF</h3>
+    <p>Current and historical topology with evidence confidence, VLAN and medium filters, radio inventory, channel plans, utilization, interference, and acknowledged RF scans.</p>
+  </div>
+  <div class="capability-card">
+    <h3>Site configuration</h3>
+    <p>Networks, VLANs, IPv4 CIDRs, DHCP, firewall zones, WLANs, AP groups, 802.11k/v/r, mesh backhauls, wireless uplinks, and bounded per-device overrides.</p>
+  </div>
+  <div class="capability-card">
+    <h3>Policy Engine</h3>
+    <p>Zone matrix, explicit firewall rules, port forwards, static routes, fixed client addresses, client groups, and visible compiled drafts before they enter desired state.</p>
+  </div>
+  <div class="capability-card">
+    <h3>Safe operations</h3>
+    <p>Redacted preview, fleet preflight, acknowledged Apply, Gateway-last ordering, OpenWrt rollback, durable operation status, ownership records, and careful un-adoption.</p>
+  </div>
+  <div class="capability-card">
+    <h3>Administration and recovery</h3>
+    <p>Owner, administrator, operator, and read-only roles; session control; audit history; stored-only redacted diagnostics; encrypted portable backups; compatibility preview; and staged restore.</p>
+  </div>
+</div>
+
+[See the complete capability and support matrix →](/reference/capabilities)
+
+## See the controller
+
+<figure class="docs-screenshot">
+  <img src="./images/dashboard-overview.jpg" alt="oonfeeWRT dashboard showing Internet health, speed tests, fleet status, topology, and recent events" loading="lazy">
+  <figcaption>The live dashboard keeps health, provenance, trends, and gaps together instead of reducing the network to a single status color.</figcaption>
+</figure>
+
+<figure class="docs-screenshot">
+  <img src="./images/radios-channel-plan.jpg" alt="oonfeeWRT radio inventory and channel planning screen" loading="lazy">
+  <figcaption>Radio inventory and evidence-aware channel planning. Disruptive scans stay explicit and acknowledged.</figcaption>
+</figure>
+
+## What runs where
+
+| Component | Location | Responsibility |
+|---|---|---|
+| `oonfeewrtd` | Your 64-bit Linux or macOS host | UI, API, collection, desired state, encrypted secrets, SQLite history |
+| Web browser | A trusted management client | Local sign-in, review, configuration, and operations |
+| Stock OpenWrt | Each managed router or AP | Networking, wireless, firewall, DHCP, ubus/rpcd, rollback |
+| Optional reverse proxy | Usually the controller host | Trusted TLS and secure remote access over an existing routed network or VPN |
+
+The controller does not provide cloud access, NAT traversal, firmware, or a
+router-hosted agent. Remote sites need an existing management route or VPN.
+
+## A workflow designed for safe changes
+
+1. **Observe.** Discover or add a device and read what the controller can
+   establish without making a router change.
+2. **Adopt deliberately.** Select the device functions and approve the scoped
+   access payload. The administrator credential is used for that action and is
+   not stored.
+3. **Describe intent.** Define site networks, WLANs, policy, or overrides in the
+   controller. Saving desired state does not silently Apply it.
+4. **Preview.** Review per-device changes, omissions, conflicts, source gaps,
+   and acknowledgements.
+5. **Apply with rollback.** The controller stages owned UCI changes, uses the
+   OpenWrt rollback window, reconnects, and confirms only after reading the
+   expected state.
+6. **Keep evidence.** Events, audit history, rollups, and durable operation
+   receipts explain what happened later.
+
+## Current boundaries
+
+oonfeeWRT v0.1.1 deliberately does not claim capabilities it cannot prove.
+
+- One managed Gateway; no controller high availability.
+- No native TLS, SSO, cloud broker, mobile app, DPI, application identity,
+  PoE control, switch ACL management, or gateway-run speed test.
+- IPv4 on-demand discovery probes eligible local subnets no wider than `/22`
+  for an unauthenticated `/ubus` endpoint. A bridged container may not see the
+  LAN subnets to scan, so add devices by address.
+- Hardware and driver support varies. Live evidence currently covers a Linksys
+  WRT3200ACM and TP-Link Archer C6 v2 on OpenWrt 25.12.5; several mesh,
+  wireless-uplink, and newer-platform scenarios remain unverified.
+- The project has not received an independent security audit or penetration
+  test. Begin with non-critical hardware and keep tested recovery material.
+
+[Review requirements and compatibility →](/reference/requirements)
+
+## Start with one device
+
+The shortest safe path is to install the controller on a host that can reach
+your router, create the first owner, add one non-critical OpenWrt device by
+address, inspect it, and adopt only the functions you need.
+
+[Start the guided setup →](/getting-started/)

--- a/docs/installation/binary.md
+++ b/docs/installation/binary.md
@@ -1,0 +1,214 @@
+# Install the standalone binary
+
+The standalone release contains one static controller executable with the web UI embedded. Docker is not required.
+
+> **Outcome:** A checksum-verified oonfeeWRT v0.1.1 binary runs on a supported Linux or macOS host, stores private state outside the program directory, and answers only on loopback.
+
+## Prerequisites
+
+- A 64-bit `linux/amd64`, `linux/arm64`, `darwin/amd64`, or `darwin/arm64` host.
+- `curl`, `tar`, and either `sha256sum` or `shasum`.
+- Network reachability to each router's management address.
+- A private directory for controller state and a separate private passphrase file.
+
+The release is built with Go 1.26.6 and includes the UI; the host does not need Go or Node.js.
+
+**Write impact:** Installing the executable writes files on the controller host only. A first start with new state does not contact a router. Starting with existing adopted-device state resumes polling and may resume automatic runtime 802.11k neighbour maintenance.
+
+## 1. Select and download the correct archive
+
+Run the following in a clean download directory:
+
+```sh
+VERSION=v0.1.1
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$(uname -m)" in
+  x86_64) ARCH=amd64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+NAME="oonfeewrt_${VERSION#v}_${OS}_${ARCH}"
+BASE="https://github.com/aiden0rchad/oonfeeWRT/releases/download/$VERSION"
+
+curl --fail --location --remote-name "$BASE/$NAME.tar.gz"
+curl --fail --location --remote-name "$BASE/SHA256SUMS"
+```
+
+This normalizes macOS `x86_64` to the release archive's `amd64` name.
+
+## 2. Verify the checksum before extracting
+
+```sh
+grep "  $NAME.tar.gz\$" SHA256SUMS > "$NAME.sha256"
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum --check "$NAME.sha256"
+else
+  shasum -a 256 --check "$NAME.sha256"
+fi
+```
+
+Continue only when the command reports that the archive is valid. Do not bypass a mismatch or use an archive whose filename is absent from the release checksum file.
+
+The macOS binaries are not Developer ID signed or notarized. The checksum-verified GitHub release is the authenticity path documented for v0.1.1.
+
+## 3. Extract and inspect the version
+
+```sh
+tar -xzf "$NAME.tar.gz"
+"$NAME/oonfeewrtd" -version
+```
+
+Expected output:
+
+```text
+v0.1.1
+```
+
+The archive also includes `oonfeewrt-recoverycheck`, installation/validation documentation, notices, and the release Compose file.
+
+## 4. Install the executables
+
+You may run from the extracted directory. To put both supported executables on `PATH`:
+
+```sh
+sudo install -m 0755 "$NAME/oonfeewrtd" /usr/local/bin/oonfeewrtd
+sudo install -m 0755 "$NAME/oonfeewrt-recoverycheck" \
+  /usr/local/bin/oonfeewrt-recoverycheck
+```
+
+Verify the installed daemon:
+
+```sh
+oonfeewrtd -version
+```
+
+## 5. Create private state and passphrase paths
+
+```sh
+install -d -m 0700 "$HOME/.local/share/oonfeewrt" "$HOME/.config/oonfeewrt"
+umask 077
+head -c 32 /dev/urandom | base64 > "$HOME/.config/oonfeewrt/passphrase"
+chmod 600 "$HOME/.config/oonfeewrt/passphrase"
+```
+
+The generated file unlocks the controller keyring on unattended restarts. It is not a browser password. Because the daemon can read it without a person, host file permissions become the protection boundary.
+
+Back up this passphrase, the data directory's `oonfeewrt.db`, and its matching `keyring.json`. The passphrase cannot recreate a lost keyring, and a keyring from another controller cannot open this database.
+
+## 6. Start the controller on loopback
+
+```sh
+oonfeewrtd \
+  -data-dir "$HOME/.local/share/oonfeewrt" \
+  -passphrase-file "$HOME/.config/oonfeewrt/passphrase" \
+  -listen 127.0.0.1:8080
+```
+
+Keep it in the foreground for the first setup so startup errors remain visible. The daemon logs to standard error and also maintains a private bounded `controller.jsonl` log family inside the data directory.
+
+For an interactive passphrase instead, omit `-passphrase-file`. First run prompts twice; later starts prompt once. Interactive startup requires a terminal.
+
+Do not set `OONFEE_PASSPHRASE`. The daemon rejects a passphrase in the environment because environment values can leak through process inspection, child processes, crash reports, and container metadata.
+
+## 7. Verify and create the first owner
+
+In another terminal:
+
+```sh
+curl --fail http://127.0.0.1:8080/healthz
+```
+
+Expected output:
+
+```text
+ok
+```
+
+Open [http://127.0.0.1:8080](http://127.0.0.1:8080), create the first owner account, and sign in.
+
+## Supported flags and environment
+
+```text
+-data-dir PATH
+-listen ADDRESS
+-passphrase-file PATH
+-log-level debug|info|warn|error
+-version
+-healthcheck
+```
+
+The equivalent non-secret environment variables are:
+
+```text
+OONFEE_DATA_DIR
+OONFEE_LISTEN
+OONFEE_PASSPHRASE_FILE
+```
+
+`-data-dir` must be absolute. Its default is `/data`; the documented standalone command overrides it deliberately. The default listener is `:8080`, which is not loopback-only, so always pass the intended bind address.
+
+## Troubleshooting and recovery
+
+### `data directory ... must be an absolute path`
+
+Pass an absolute path. `$PWD/data` is acceptable because the shell expands it before starting the daemon.
+
+### `stdin is not a terminal` and no passphrase is available
+
+The process is unattended. Add:
+
+```sh
+-passphrase-file /absolute/path/to/passphrase
+```
+
+or set `OONFEE_PASSPHRASE_FILE` to that absolute path.
+
+### The passphrase file is not accepted
+
+It must be a non-empty regular file with no group or world permission bits:
+
+```sh
+chmod 600 "$HOME/.config/oonfeewrt/passphrase"
+```
+
+Only one final newline is stripped. Other leading or trailing spaces are part of the passphrase.
+
+### The key cannot be unwrapped
+
+The passphrase is wrong, or `keyring.json` is corrupt or truncated. Restore the matching database, keyring, and passphrase backup. There is no reset that preserves sealed router credentials.
+
+### `keyring.json` is missing beside an existing database
+
+Startup refuses to create an unrelated keyring. Restore the matching keyring. Moving the database aside starts an empty controller and requires re-adoption; do that only as a deliberate reset.
+
+### The database is newer than the daemon
+
+The daemon refuses an unsupported downgrade. Restore a backup made for the older schema or run the compatible newer release. See [Upgrades and rollback](upgrades.md).
+
+### The UI says the binary was built without it
+
+Official release binaries embed the UI. For a local source build, run:
+
+```sh
+make build
+```
+
+The `make build` target installs UI dependencies, builds the embedded UI, and then builds the daemon.
+
+### Another program uses port 8080
+
+Choose a different loopback port:
+
+```sh
+oonfeewrtd \
+  -data-dir "$HOME/.local/share/oonfeewrt" \
+  -passphrase-file "$HOME/.config/oonfeewrt/passphrase" \
+  -listen 127.0.0.1:8081
+```
+
+## Next steps
+
+- [Adopt the first device](../getting-started/first-adoption.md)
+- [Add trusted HTTPS](reverse-proxy.md)
+- [Create and verify a backup](../operations/backups.md)
+- [Plan upgrades and rollback](upgrades.md)

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -1,0 +1,223 @@
+# Install with Docker
+
+The v0.1.1 container is a multi-platform Linux image containing one static controller binary, CA roots, licenses, and release material. The final image has no shell or package manager.
+
+> **Outcome:** oonfeeWRT runs as non-root in a hardened container, publishes HTTP only on host loopback, and persists state in a named Docker volume.
+
+## Prerequisites
+
+- Docker with Compose support.
+- A Linux amd64/arm64 host or Docker Desktop capable of running the Linux image.
+- Permission to run Docker as a non-root host user.
+- Controller-host network reachability to each router.
+- `curl`, `/dev/urandom`, `base64`, `sudo`, and a private working directory.
+
+**Write impact:** With a new named volume, these steps create host/container state and do not contact a router. Reusing an existing controller volume resumes adopted-device polling and may resume automatic runtime 802.11k neighbour maintenance.
+
+## 1. Create the deployment directory
+
+```sh
+mkdir -p oonfeewrt
+cd oonfeewrt
+```
+
+Keep `docker-compose.yml` and `passphrase` in this private directory. The controller database itself lives in Docker's named `oonfee-data` volume.
+
+## 2. Download the release Compose file
+
+```sh
+curl --fail --location \
+  --output docker-compose.yml \
+  https://raw.githubusercontent.com/aiden0rchad/oonfeeWRT/v0.1.1/deploy/docker-compose.yml
+```
+
+The file pins the image version through the required `OONFEE_VERSION` value instead of silently following `latest`.
+
+## 3. Create the runtime passphrase
+
+```sh
+umask 077
+head -c 32 /dev/urandom | base64 > passphrase
+sudo chown 65532:65532 passphrase
+sudo chmod 600 passphrase
+```
+
+The Compose service runs as UID/GID 65532, so the bind-mounted mode-`0600` file must belong to that UID. A missing source path is an error; Compose is configured not to create an empty directory in its place.
+
+This is the controller runtime/boot passphrase, not an owner account password. Store a protected recovery copy separately.
+
+## 4. Start v0.1.1
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose up -d
+```
+
+The release image is:
+
+```text
+ghcr.io/aiden0rchad/oonfeewrt:v0.1.1
+```
+
+The supplied service hardening includes:
+
+- process UID/GID 65532;
+- read-only root filesystem;
+- all Linux capabilities dropped;
+- `no-new-privileges:true`;
+- private `noexec,nosuid,nodev` tmpfs;
+- state mounted at `/data`;
+- host-loopback mapping `127.0.0.1:8080:8080`;
+- 150-second stop grace period for an in-flight rollback/confirm cycle.
+
+## 5. Verify the service
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose ps
+OONFEE_VERSION=v0.1.1 docker compose logs --tail=100 oonfeewrt
+curl --fail http://127.0.0.1:8080/healthz
+```
+
+The health request should print:
+
+```text
+ok
+```
+
+Open [http://127.0.0.1:8080](http://127.0.0.1:8080) on the controller host and create the first owner.
+
+## Container networking and discovery
+
+The default bridge mode is the safe portable choice. Polling, adoption, and Apply are normal outbound layer-3 connections and work when the container can route to the router.
+
+What bridge mode does not provide is the controller host's LAN layer-2 view:
+
+- add-by-address works;
+- routed TCP subnet probing may work;
+- ARP and mDNS discovery do not cross the bridge.
+
+On Linux, full layer-2 discovery is an explicit host-network opt-in. In `docker-compose.yml`, remove `ports:`, add:
+
+```yaml
+network_mode: host
+```
+
+and set:
+
+```yaml
+OONFEE_LISTEN: "127.0.0.1:8080"
+```
+
+Host mode exposes the daemon directly according to its listen address. Review host firewall and TLS policy before using a non-loopback bind. Docker Desktop users should use add-by-address.
+
+## Optional: verify the published image signature
+
+Install `cosign` using Sigstore's official instructions, then verify the v0.1.1 GitHub Actions identity:
+
+```sh
+cosign verify \
+  --certificate-identity "https://github.com/aiden0rchad/oonfeeWRT/.github/workflows/release.yml@refs/tags/v0.1.1" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ghcr.io/aiden0rchad/oonfeewrt:v0.1.1
+```
+
+Deployments should pin `v0.1.1` or the reported digest. The `0.1.1`, `0.1`, and `latest` aliases may resolve to the same manifest but are not immutable deployment intent.
+
+## Optional: run without Compose
+
+This uses bind-mounted state owned by your non-root host user:
+
+```sh
+[ "$(id -u)" -ne 0 ] || { echo "run Docker as a non-root user" >&2; exit 1; }
+install -d -m 0700 \
+  "$HOME/.config/oonfeewrt" \
+  "$HOME/.local/share/oonfeewrt-container"
+umask 077
+head -c 32 /dev/urandom | base64 > "$HOME/.config/oonfeewrt/passphrase"
+chmod 600 "$HOME/.config/oonfeewrt/passphrase"
+
+docker run -d \
+  --name oonfeewrt \
+  --restart unless-stopped \
+  --read-only \
+  --user "$(id -u):$(id -g)" \
+  --cap-drop ALL \
+  --security-opt no-new-privileges:true \
+  --stop-timeout 150 \
+  --tmpfs "/tmp:rw,noexec,nosuid,nodev,uid=$(id -u),gid=$(id -g),mode=0700" \
+  -p 127.0.0.1:8080:8080 \
+  --mount "type=bind,source=$HOME/.local/share/oonfeewrt-container,target=/data" \
+  --mount "type=bind,source=$HOME/.config/oonfeewrt/passphrase,target=/run/secrets/oonfee-passphrase,readonly" \
+  -e OONFEE_DATA_DIR=/data \
+  -e OONFEE_LISTEN=:8080 \
+  -e OONFEE_PASSPHRASE_FILE=/run/secrets/oonfee-passphrase \
+  ghcr.io/aiden0rchad/oonfeewrt:v0.1.1
+```
+
+## Stop and restart safely
+
+Compose sends SIGTERM and allows 150 seconds for shutdown:
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose stop
+OONFEE_VERSION=v0.1.1 docker compose start
+```
+
+The longer grace period lets an Apply that reached OpenWrt's rollback-protected stage finish its confirm decision. Do not force-kill the container during an Apply unless the host itself is failing.
+
+## Troubleshooting and recovery
+
+### The passphrase mount is denied
+
+For the supplied Compose service:
+
+```sh
+sudo chown 65532:65532 passphrase
+sudo chmod 600 passphrase
+```
+
+Confirm that `passphrase` is a file, not a directory.
+
+### The container repeatedly restarts
+
+Inspect the startup error:
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose logs --tail=200 oonfeewrt
+```
+
+Common causes are a missing/unreadable passphrase, the wrong passphrase for the volume's keyring, a missing keyring beside an existing database, an unsupported database downgrade, or port 8080 already in use.
+
+### Discovery finds no router
+
+Use **Adopt a device** and enter the router IP. Empty layer-2 discovery is expected in bridge mode and on Docker Desktop.
+
+### The controller appears empty after recreating the service
+
+Check that the same `oonfee-data` volume is mounted at `/data`. A new volume creates a new controller. Do not copy only `oonfeewrt.db`; restore its matching `keyring.json` and use a consistent snapshot.
+
+### The browser cannot connect from another computer
+
+The default mapping is intentionally loopback-only. Add [trusted reverse-proxy TLS](reverse-proxy.md) or deliberately bind on an isolated management LAN. Do not publish raw port 8080 to the Internet.
+
+### Avoid accidental deletion
+
+This removes the container but preserves the named volume:
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose down
+```
+
+This also deletes the named volume and controller state:
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose down -v
+```
+
+Use `-v` only after a verified backup and only when deletion is intentional.
+
+## Next steps
+
+- [Adopt the first device](../getting-started/first-adoption.md)
+- [Add trusted HTTPS](reverse-proxy.md)
+- [Back up and restore the controller](../operations/backups.md)
+- [Upgrade or roll back](upgrades.md)

--- a/docs/installation/reverse-proxy.md
+++ b/docs/installation/reverse-proxy.md
@@ -1,0 +1,134 @@
+# Put TLS in front of the controller
+
+oonfeeWRT v0.1.1 serves HTTP and WebSocket traffic but has no native TLS listener. Keep it on loopback and let a trusted reverse proxy terminate HTTPS.
+
+> **Outcome:** Browsers connect to a trusted `https://` address while the controller remains reachable only as `127.0.0.1:8080` on its host.
+
+## Prerequisites
+
+- A working oonfeeWRT controller bound to `127.0.0.1:8080`.
+- A reverse proxy on the same host, or another host that reaches a deliberately isolated controller listener.
+- An internal DNS name and certificate trusted by every administrator browser.
+- Proxy support for WebSocket upgrades and `X-Forwarded-Proto`.
+
+**Write impact:** This changes only controller-host proxy and DNS/certificate configuration. It does not contact or change a router.
+
+## Why TLS matters
+
+At-rest encryption protects saved credentials in the controller database. It does not protect:
+
+- a password or WLAN key while a browser submits it;
+- an authenticated session cookie in transit;
+- data in daemon memory;
+- topology, client, or configuration details crossing the network.
+
+Use direct HTTP only on host loopback or a deliberately trusted, isolated management network. Never expose port 8080 directly to the Internet.
+
+## 1. Confirm the backend is loopback-only
+
+For a standalone process, use:
+
+```sh
+oonfeewrtd \
+  -data-dir /absolute/path/to/data \
+  -passphrase-file /absolute/path/to/passphrase \
+  -listen 127.0.0.1:8080
+```
+
+The supplied Compose file already maps:
+
+```text
+127.0.0.1:8080:8080
+```
+
+Verify locally:
+
+```sh
+curl --fail http://127.0.0.1:8080/healthz
+```
+
+## 2. Configure Caddy
+
+A minimal Caddy site is:
+
+```text
+oonfeewrt.example.internal {
+    reverse_proxy 127.0.0.1:8080
+}
+```
+
+Replace `oonfeewrt.example.internal` with the DNS name in your trusted certificate. Caddy preserves WebSocket upgrades and supplies `X-Forwarded-Proto: https` by default.
+
+Reload Caddy through the installation method you already use. oonfeeWRT does not install or manage the proxy.
+
+## 3. Verify HTTPS
+
+From a client that trusts the certificate:
+
+```sh
+curl --fail https://oonfeewrt.example.internal/healthz
+```
+
+Expected output:
+
+```text
+ok
+```
+
+Then:
+
+1. Open `https://oonfeewrt.example.internal`.
+2. Sign in.
+3. Open a device detail screen and leave it open long enough to receive live updates. This verifies the `/api/v1/live` WebSocket path as well as ordinary REST requests.
+4. Confirm the browser reports a trusted certificate and no mixed-content warning.
+
+When `X-Forwarded-Proto` is `https`, oonfeeWRT marks both session and CSRF cookies `Secure`. The session cookie is also `HttpOnly` and `SameSite=Strict`.
+
+## Proxy requirements
+
+If you use a proxy other than Caddy, preserve:
+
+- the original `Host` value;
+- WebSocket `Upgrade` and `Connection` behavior;
+- `X-Forwarded-Proto: https`;
+- request and response bodies without caching authenticated API responses.
+
+The API sends `Cache-Control: no-store`. Do not override it with a shared cache. Hashed UI assets may be cached; `index.html` must remain revalidated so upgrades do not leave browsers referencing deleted asset names.
+
+## Troubleshooting and recovery
+
+### Sign-in succeeds over HTTP but fails over HTTPS
+
+Confirm the proxy sends `X-Forwarded-Proto: https` and does not rewrite or strip `Set-Cookie` headers. Clear stale cookies for the controller origin after correcting the proxy.
+
+### Pages load but live device data stops
+
+The REST path works but the WebSocket upgrade likely does not. Verify proxy WebSocket support for `/api/v1/live`. Caddy's `reverse_proxy` handles this without extra directives.
+
+### The proxy returns 502 or connection refused
+
+When the proxy and controller share a host, run:
+
+```sh
+curl --fail http://127.0.0.1:8080/healthz
+```
+
+For a proxy on another host, probe the controller's deliberately isolated address instead of `127.0.0.1`. If the backend probe fails, fix the controller route first. If it succeeds, check that the proxy targets the correct network namespace. A proxy in another container cannot use its own `127.0.0.1` to reach the oonfeeWRT container; connect them through a deliberate private container network or proxy the host mapping.
+
+### The browser reports an untrusted certificate
+
+Install a certificate issued by a CA trusted by the administrator devices. Do not train users to bypass certificate warnings for a controller that receives router and account credentials.
+
+### The controller is intentionally on a management LAN
+
+Bind only to the specific trusted interface address, protect port 8080 with host/network firewall policy, and proxy it over a route you control. A wildcard `:8080` listener exposes every host interface and is not the recommended default.
+
+## Recovery
+
+If the proxy configuration fails, the loopback backend is unchanged. Access it locally at `http://127.0.0.1:8080`, repair the proxy, and verify HTTPS again. Do not broaden the controller bind merely to work around a proxy routing error.
+
+## Next steps
+
+- [Configure controller accounts and roles](../operations/accounts.md)
+- [Back up and restore the controller](../operations/backups.md)
+- [Review routine maintenance](../operations/maintenance.md)

--- a/docs/installation/upgrades.md
+++ b/docs/installation/upgrades.md
@@ -1,0 +1,160 @@
+# Upgrade and roll back
+
+oonfeeWRT keeps controller state in SQLite plus a separate keyring. Upgrade safety depends on preserving a matching database/keyring/passphrase set before replacing a binary or image.
+
+> **Outcome:** The controller runs v0.1.1 with its existing state intact, and you retain a verified recovery point suitable for the version you may need to restore.
+
+## Before you begin
+
+- Read the release notes for the version you are installing.
+- Know whether the current install is a standalone binary or container.
+- Locate the data directory or volume and the runtime passphrase file.
+- Schedule a clean stop; do not upgrade during Apply, backup, restore, diagnostics generation, RF scan, or optional-package work.
+- Preserve enough downtime to verify the new process before resuming changes.
+
+**Router write impact:** Replacing the binary/image and migrating the database do not themselves contact or configure routers. After startup, read-only polling resumes and, when the write gate is open, automatic 802.11k neighbour reconciliation may update runtime hostapd neighbour lists. A restore, unlike an ordinary upgrade, activates a persistent router-write safety gate.
+
+## Version facts for v0.1.1
+
+- v0.1.1 uses controller database schema 19.
+- v0.1.0 also uses schema 19, so v0.1.0 → v0.1.1 requires no schema migration.
+- On first v0.1.1 startup, completed or failed speed-test rows older than the newest three are permanently removed.
+- A clean v0.1.1 → v0.1.0 rollback is schema-compatible, though you should still retain the v0.1.1 recovery pair.
+- Historical v0.1.0-rc.1 uses schema 17. Moving from that RC to a stable schema-19 daemon migrates forward; returning to the RC requires restoring the untouched schema-17 backup, not merely replacing the executable or image.
+
+## 1. Create a verified pre-upgrade backup
+
+The recommended operator path is **Settings → Backup & Restore**. Export an encrypted `.oowrtbak`, download it before it expires, record its separate export passphrase, and verify that the job completed.
+
+For a standalone filesystem recovery pair while the controller is live, use SQLite's backup API:
+
+```sh
+install -d -m 0700 /path/to/private-backup
+sqlite3 "$HOME/.local/share/oonfeewrt/oonfeewrt.db" \
+  ".backup '/path/to/private-backup/oonfeewrt.db'"
+cp -p "$HOME/.local/share/oonfeewrt/keyring.json" \
+  /path/to/private-backup/keyring.json
+```
+
+Verify it:
+
+```sh
+OONFEE_PASSPHRASE_FILE="$HOME/.config/oonfeewrt/passphrase" \
+  oonfeewrt-recoverycheck /path/to/private-backup/oonfeewrt.db
+```
+
+For the documented bind-mounted `docker run` layout, stop cleanly before copying:
+
+```sh
+docker stop --time 150 oonfeewrt
+install -d -m 0700 /path/to/private-backup
+cp -p "$HOME/.local/share/oonfeewrt-container/oonfeewrt.db" \
+  "$HOME/.local/share/oonfeewrt-container/keyring.json" \
+  /path/to/private-backup/
+docker start oonfeewrt
+```
+
+For a Compose named volume, the portable `.oowrtbak` workflow avoids unsafe ad hoc copying. If you use volume-level backup tooling instead, stop the container first and preserve the whole database/keyring unit.
+
+Never copy only the main SQLite file while WAL is active. It may omit committed state.
+
+## 2A. Upgrade a standalone binary
+
+1. Download, checksum-verify, and extract v0.1.1 using [Install the binary](binary.md).
+2. Stop the old daemon using the same process manager or foreground terminal that started it. Give it time to finish a graceful shutdown.
+3. Replace the executable:
+
+   ```sh
+   sudo install -m 0755 "$NAME/oonfeewrtd" /usr/local/bin/oonfeewrtd
+   sudo install -m 0755 "$NAME/oonfeewrt-recoverycheck" \
+     /usr/local/bin/oonfeewrt-recoverycheck
+   ```
+
+4. Confirm the installed version:
+
+   ```sh
+   oonfeewrtd -version
+   ```
+
+5. Start it with the unchanged absolute data directory and unchanged runtime passphrase source.
+
+Do not point a new process at a copied database while leaving the old process running against the same files.
+
+## 2B. Upgrade Docker Compose
+
+From the directory containing the release Compose file and passphrase:
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose pull
+OONFEE_VERSION=v0.1.1 docker compose up -d
+```
+
+The service keeps the existing `oonfee-data` volume and passphrase bind mount. Confirm that you did not add `-v` to any `down` command.
+
+## 3. Verify the upgraded controller
+
+```sh
+curl --fail http://127.0.0.1:8080/healthz
+```
+
+For Compose:
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose ps
+OONFEE_VERSION=v0.1.1 docker compose logs --tail=200 oonfeewrt
+```
+
+In the browser:
+
+1. Sign in again; sessions are process-local and do not survive restart.
+2. Confirm the expected devices, site settings, accounts, and event history.
+3. Confirm devices resume read-only polling.
+4. Open **Settings → Backup & Restore** and confirm no restore-based router-write suppression is active after an ordinary upgrade.
+5. Run Preview before the next Apply; do not assume desired and observed state still match after downtime.
+
+## Roll back v0.1.1 to v0.1.0
+
+v0.1.0 and v0.1.1 both use schema 19. Retain the current v0.1.1 data pair first, stop v0.1.1 cleanly, replace the binary or image with v0.1.0, and start it against the schema-19 data.
+
+The v0.1.1 startup pruning of older speed-test rows cannot be reversed unless those rows exist in a pre-upgrade backup.
+
+## Roll back to v0.1.0-rc.1
+
+Do not point the RC daemon at a schema-19 database. Rollback is a data restore:
+
+1. Stop the stable controller.
+2. Retain its schema-19 database/keyring pair separately.
+3. Restore the untouched schema-17 database and matching `keyring.json` captured before migration.
+4. Use the prior runtime passphrase file.
+5. Install the v0.1.0-rc.1 binary or image.
+6. Start and verify the RC.
+
+Controller rollback does not roll back router configuration.
+
+## Troubleshooting and recovery
+
+### Startup refuses to downgrade the database
+
+The database schema is newer than the daemon understands. Stop. Install the compatible newer daemon or restore the older version's matching pre-upgrade database/keyring pair.
+
+### The new daemon cannot unlock the keyring
+
+Verify that the unchanged runtime passphrase file and the keyring from the same data pair are present. Do not create a new keyring over the existing database.
+
+### The controller is empty after upgrade
+
+It is probably using a new path or volume. Stop it before making changes. Reconnect the original data directory/volume and matching passphrase source, then restart.
+
+### The UI loads old or missing assets
+
+Reload the page. Official binaries embed content-hashed assets and serve `index.html` without persistent caching. Confirm the proxy does not cache `index.html` or override API `no-store` headers.
+
+### A migration fails
+
+Leave the failed data pair untouched for diagnosis. Restore the verified pre-upgrade pair and old version instead of manually editing `schema_version` or database tables.
+
+## Next steps
+
+- [Back up and restore the controller](../operations/backups.md)
+- [Review routine maintenance](../operations/maintenance.md)
+- [Verify reverse-proxy TLS](reverse-proxy.md)

--- a/docs/operations/accounts.md
+++ b/docs/operations/accounts.md
@@ -1,0 +1,190 @@
+# Accounts, roles, and sessions
+
+Controller accounts are local to oonfeeWRT. They are separate from router logins and from the runtime passphrase that unlocks `keyring.json` at startup.
+
+> **Outcome:** Each person has an individual account with the least role needed, and owners can review or revoke active sessions without sharing credentials.
+
+## Prerequisites and impact
+
+- The first owner account must already exist.
+- Only an owner can create, change, disable, delete, or reset another controller account.
+- Sensitive owner actions require the owner's current password again when the last password confirmation is more than five minutes old.
+
+**Write impact:** Account and session administration changes the controller database and audit log only. It does not contact or change a router. The assigned role controls what that person may later ask the controller to do.
+
+## Role matrix
+
+Roles are hierarchical: each higher role includes the lower role's permissions.
+
+| Role | Intended use | Important permissions |
+|---|---|---|
+| **Read-only** (`viewer` internally) | Read-only monitoring | Read dashboards, devices, clients, topology, radios, policy/site state, General events, and own account/sessions. May request focused polling while viewing a device. |
+| **Operator** | Day-to-day transient operations | Read-only access plus acknowledged RF scans, on-air verification, and controller-host speed-test start/cancel. |
+| **Administrator** | Device and network management | Operator access plus discovery/inspection, adoption/un-adoption, ACL refresh, optional LLDP, reprobe, desired-state editing, Preview/Apply, policy and client intent, polling settings, and diagnostics bundles. |
+| **Owner** | Controller custody | Administrator access plus controller-account administration and encrypted backup/restore, including the post-restore write gate. |
+
+Audit events are more sensitive than ordinary General events. The API applies additional authorization after it knows an event's scope.
+
+## Account rules
+
+### Usernames
+
+A username must:
+
+- contain 1–64 ASCII characters;
+- start with a letter or digit;
+- use only letters, digits, `.`, `_`, or `-`.
+
+Usernames are ASCII case-insensitive for uniqueness. A soft-deleted username remains reserved and cannot be recreated under different capitalization.
+
+### Passwords
+
+- Minimum: 12 Unicode characters.
+- Maximum encoded input: 1024 bytes.
+- Passwords are stored as Argon2id verifiers, not plaintext.
+- Account passwords are not router passwords and are not the controller runtime passphrase.
+
+Use a unique password for each person. Do not create one shared “admin” account when individual accountability matters.
+
+## Create an account
+
+1. Sign in as an owner.
+2. Open **Settings → Accounts**.
+3. In **Create account**, enter the username.
+4. Choose **Read-only**, **Operator**, **Administrator**, or **Owner**.
+5. Enter and repeat a password of at least 12 characters.
+6. Select **Create account**.
+7. If prompted, enter your current owner password to establish a new five-minute reauthentication window, then run the pending action.
+
+The account mutation and its audit event are committed together. If the mutation fails, it is not presented as an audited success.
+
+## Verify a new account
+
+Use a separate private browser window so you do not disturb the owner session:
+
+1. Sign in as the new user.
+2. Confirm the header shows the correct username.
+3. Open **Settings → My account** and verify the role.
+4. Confirm the navigation and controls match the role matrix. A forbidden API operation remains forbidden even if stale UI state displayed a control.
+5. Sign out of the test window.
+
+## Change an account's role
+
+1. Open **Settings → Accounts** as an owner.
+2. Find the account and select **Role**.
+3. Choose the new role.
+4. Review the privilege change, reauthenticate if requested, and confirm.
+
+Role-bearing sessions are checked by the API. Do not rely solely on hiding controls in the browser.
+
+The last enabled owner cannot be demoted. Create and verify another owner first if ownership must move.
+
+## Disable or enable an account
+
+Disabling preserves the account and audit identity while preventing authentication.
+
+1. Open **Settings → Accounts**.
+2. Select **Disable** or **Enable** beside the account.
+3. Review and confirm after any required reauthentication.
+
+The last enabled owner cannot be disabled. Disabled and deleted accounts deliberately authenticate like an unknown username so the login response does not reveal account existence.
+
+## Reset another account's password
+
+1. Open **Settings → Accounts**.
+2. Select **Reset password** for the account.
+3. Enter and repeat the new password.
+4. Reauthenticate as the owner if requested.
+5. Confirm the reset.
+6. Give the password to the user through a protected channel and have them change it after sign-in when appropriate.
+
+Password changes revoke that account's sessions so an old session cannot outlive the credential reset.
+
+## Change your own password
+
+1. Open **Settings → My account**.
+2. Enter the current password.
+3. Enter and repeat the new password.
+4. Select **Change password**.
+
+All of your sessions, including the current one, are revoked. Sign in again with the new password. This is intentional: a password change that leaves an existing borrowed session active would not fully remove access.
+
+## Review and revoke sessions
+
+Sessions live only in controller memory; they do not survive a daemon restart.
+
+Current limits:
+
+- idle expiry: 12 hours;
+- absolute expiry: 7 days;
+- password reauthentication window: 5 minutes.
+
+### Your own sessions
+
+1. Open **Settings → My account**.
+2. Review peer address, creation, last use, expiry, and the current-session marker.
+3. Select **Revoke** for an unfamiliar or no-longer-needed session.
+4. Confirm. Revoking the current session signs this browser out.
+
+### Another user's sessions
+
+1. Open **Settings → Accounts** as an owner.
+2. Select **Sessions** for the account.
+3. Revoke one session or all sessions.
+4. Reauthenticate and confirm when requested.
+
+Session revocation cancels requests associated with that session, including its live WebSocket.
+
+## Delete an account
+
+Deletion is soft: it disables the row, removes its password verifier, retains its username for audit identity, and prevents reuse.
+
+1. Open **Settings → Accounts**.
+2. Select **Delete**.
+3. Review the username carefully.
+4. Reauthenticate and confirm.
+
+The last enabled owner cannot be deleted.
+
+## Authentication protections
+
+- Session cookie: `HttpOnly`, `SameSite=Strict`, and `Secure` when the request is HTTPS or the trusted proxy reports `X-Forwarded-Proto: https`.
+- CSRF: mutating authenticated requests require the matching `X-Oonfee-CSRF` token.
+- Setup and login: same-origin browser checks protect the unauthenticated endpoints.
+- Login throttling: ten failures from one socket peer address within five minutes produce a five-minute lockout.
+- Account-specific password confirmation: five failures within five minutes produce a five-minute lockout for that session.
+- Unknown-user login spends the same Argon2id work as a known-user failure to reduce username timing disclosure.
+
+The login limiter uses the socket peer, not untrusted `X-Forwarded-For`. When every request arrives from one reverse proxy, failed attempts share that proxy peer for throttling.
+
+## Troubleshooting and recovery
+
+### `recent password confirmation is required`
+
+Complete the **Confirm owner identity** form with the current account password. The resulting step-up lasts five minutes for that session.
+
+### `last_owner`
+
+The operation would disable, demote, or delete the final enabled owner. Create and verify a second owner, then repeat the transfer.
+
+### A username is unavailable after deletion
+
+This is expected. Soft deletion reserves the identity so audit history cannot later refer to a different person with the same username.
+
+### A user is unexpectedly signed out
+
+Check whether their password changed, an owner revoked their sessions, the account was disabled/deleted, the 12-hour idle or seven-day absolute lifetime elapsed, or the controller restarted.
+
+### Login is temporarily locked
+
+Wait for the five-minute window instead of retrying continuously. Verify the correct password in your password manager before the next attempt.
+
+### No owner can sign in
+
+Do not edit the SQLite database by hand; account, secret, schema, and audit invariants are transactional. Restore a verified controller backup containing an enabled owner, or recover through a separately tested controller recovery plan.
+
+## Next steps
+
+- [Back up account and controller state](backups.md)
+- [Protect sessions with reverse-proxy TLS](../installation/reverse-proxy.md)
+- [Review routine maintenance](maintenance.md)

--- a/docs/operations/backups.md
+++ b/docs/operations/backups.md
@@ -1,0 +1,231 @@
+# Backup and restore
+
+oonfeeWRT state is not one interchangeable database file. `oonfeewrt.db` and its matching `keyring.json` are a recovery unit, and the runtime passphrase is required to unlock that keyring.
+
+The recommended v0.1.1 workflow packages the consistent database snapshot and matching wrapped key material into one encrypted `.oowrtbak` file.
+
+> **Outcome:** You have an encrypted off-host controller backup, its separately recorded export passphrase, and a tested understanding of the preview-first restore safety gate.
+
+## Prerequisites and impact
+
+- Backup export and restore require an owner account.
+- Start/download and restore mutations require recent account-password reauthentication.
+- Use direct loopback or trusted reverse-proxy TLS; do not send backup secrets over an untrusted HTTP path.
+- Keep the controller's runtime passphrase available during restore confirmation.
+- Store the backup file and export passphrase separately.
+
+**Router write impact:** Export, upload, preview, and controller-state replacement make no router management call and do not automatically Apply configuration. After a successful restore, router writes are persistently suppressed until an owner reviews the restored state and explicitly resumes them.
+
+## What the portable backup contains
+
+The `.oowrtbak` contains:
+
+- a transactionally consistent snapshot of the live WAL-mode controller database;
+- matching wrapped key material needed to open sealed credentials;
+- an authenticated manifest with controller version, schema, sizes, and hashes.
+
+It contains sensitive controller state, including account password hashes, configuration, inventory, and encrypted saved credentials. It does not back up foreign/unmanaged router UCI, router firmware, or arbitrary router files.
+
+The export passphrase:
+
+- is separate from the controller runtime passphrase and account password;
+- must contain at least 16 Unicode characters;
+- may be at most 4096 UTF-8 bytes;
+- is never retained by the controller;
+- cannot be recovered if lost.
+
+## Export an encrypted backup
+
+1. Sign in as an owner over loopback or trusted HTTPS.
+2. Open **Settings → Backup & Restore**.
+3. Under **Controller backup export**, select **Review encrypted export**.
+4. Read the current plan, format, includes, excludes, snapshot method, encryption method, and `plan_id`.
+5. If prompted, enter your current account password under **Confirm owner identity**.
+6. Enter and repeat a separate export passphrase.
+7. Acknowledge that the file contains account password hashes, controller settings, and encrypted saved credentials, and that the export passphrase is unrecoverable.
+8. Select **Create encrypted backup**.
+9. Wait for the job to complete. One export can run at a time.
+10. Select **Download .oowrtbak**.
+11. Move the downloaded file to protected off-host storage and record its export passphrase separately.
+
+Completed downloadable artifacts remain on the controller for 15 minutes. The page retains up to five recent job records, but job history is not a substitute for downloading the file.
+
+## Verify an export
+
+Before depending on it:
+
+1. Confirm the job state is **completed**.
+2. Record the displayed file size, SHA-256, controller version, and schema.
+3. Confirm the downloaded file has the `.oowrtbak` extension and a non-zero size.
+4. Store the exact export passphrase in the recovery record.
+5. Perform a restore preview during a maintenance window. Preview authenticates the artifact and validates a disposable copy without replacing live state or contacting routers.
+
+A preview is the built-in portable-artifact validation path. Do not confirm the restore merely to test the file on a production controller.
+
+## Preview a restore
+
+1. Open **Settings → Backup & Restore** as an owner.
+2. Under **Controller restore**, select the `.oowrtbak` file and upload it.
+3. Reauthenticate with the current owner account password if requested.
+4. Enter the backup's export passphrase.
+5. Start the preview.
+6. Wait for the authenticated disposable preview to complete.
+7. Review:
+   - manifest controller version and creation time;
+   - source schema and target schema;
+   - database size;
+   - counts of devices, credentials, owned sections, WLANs, and meshes;
+   - the bound restore `plan_id`;
+   - every compatibility or safety error.
+
+Upload/preview state is temporary and retained for 30 minutes. Uploading and previewing do not replace live state.
+
+Future unsupported schemas, an invalid passphrase, a modified artifact, manifest/database mismatch, corrupt or oversized state, missing usable owner, broken secret records, or failed migration all stop before replacement.
+
+## Confirm a controller restore
+
+Confirmation is destructive to the current controller state, although a safety artifact is made first. Schedule downtime and ensure no Apply or other controller operation is running.
+
+1. From a completed preview, select **Review controller restore**.
+2. Re-enter the backup export passphrase.
+3. Enter the **destination controller runtime passphrase**. This is the boot/keyring secret, not your signed-in account password.
+4. Type exactly:
+
+   ```text
+   RESTORE CONTROLLER
+   ```
+
+5. Independently acknowledge all four consequences:
+   - the controller will restart;
+   - all active controller sessions will be revoked;
+   - router writes remain suppressed until an owner explicitly resumes them;
+   - restored desired configuration will not be applied to routers automatically.
+6. Select **Restore controller**.
+7. Do not interrupt the process. The confirmation creates a prepared pair and safety artifact, records durable intent, cleanly closes the running store, swaps through a controlled in-process restart, and validates the restored state before serving it.
+
+Before replacement, the controller writes a mode-`0600` encrypted safety artifact at:
+
+```text
+<data-dir>/.oonfeewrt-recovery/safety-<restore-id>.oowrtbak
+```
+
+It uses the export passphrase supplied for confirmation. After the applied-restore audit receipt is cleared, retention targets the newest three recognized safety artifacts. Artifacts referenced by active restore state are preserved even when that temporarily exceeds three. Copy a needed safety artifact to protected off-host storage before later pruning.
+
+## Verify restored state
+
+After restart:
+
+1. Reload the controller and sign in with an account from the restored backup. All previous sessions were revoked.
+2. Open **Settings → Backup & Restore**.
+3. Confirm **Router-write status** reports that writes are suppressed.
+4. Review the restored device inventory, site intent, WLANs, networks, policies, accounts, and event history.
+5. Allow read-only monitoring to resume and compare observed device state with restored desired state.
+6. Run Preview. Do not Apply merely because restored state differs.
+7. Decide whether the restored controller should again own router writes.
+
+## Resume router writes after review
+
+Clearing the gate does not start an Apply, but it immediately permits automatic 802.11k neighbour reconciliation. That reconciler may write hostapd RRM neighbour state.
+
+1. Under **Router-write status**, select **Review router-write resumption**.
+2. Acknowledge that resuming may immediately write 802.11k RRM neighbour state.
+3. Type exactly:
+
+   ```text
+   RESUME ROUTER WRITES
+   ```
+
+4. Select **Resume router writes**.
+5. Confirm the suppression status becomes inactive.
+
+Restored desired configuration is still not automatically Applied. Preview and Apply remain separate operator actions.
+
+## Filesystem-level backup
+
+Portable export is preferred because it binds the database and key material in one authenticated file. Filesystem recovery remains useful for host-level operations.
+
+### Live standalone controller
+
+Use SQLite's online backup mechanism, then copy the matching keyring:
+
+```sh
+install -d -m 0700 /path/to/private-backup
+sqlite3 "$HOME/.local/share/oonfeewrt/oonfeewrt.db" \
+  ".backup '/path/to/private-backup/oonfeewrt.db'"
+cp -p "$HOME/.local/share/oonfeewrt/keyring.json" \
+  /path/to/private-backup/keyring.json
+```
+
+Verify the pair:
+
+```sh
+OONFEE_PASSPHRASE_FILE="$HOME/.config/oonfeewrt/passphrase" \
+  oonfeewrt-recoverycheck /path/to/private-backup/oonfeewrt.db
+```
+
+`oonfeewrt-recoverycheck` makes no network call. It expects the exact sibling `keyring.json`, validates sealed records, and reports counts. Run it on an isolated copy.
+
+### Bind-mounted container state
+
+Stop cleanly before copying:
+
+```sh
+docker stop --time 150 oonfeewrt
+install -d -m 0700 /path/to/private-backup
+cp -p "$HOME/.local/share/oonfeewrt-container/oonfeewrt.db" \
+  "$HOME/.local/share/oonfeewrt-container/keyring.json" \
+  /path/to/private-backup/
+docker start oonfeewrt
+```
+
+For a named Compose volume, use portable export or established volume-backup tooling after a clean stop. Do not assume the Compose working directory contains the database.
+
+## Important recovery rules
+
+- Never copy only `oonfeewrt.db` while the controller is running in WAL mode.
+- Always pair the database with its exact `keyring.json`.
+- Preserve the runtime passphrase separately.
+- Do not mix files from two controllers even when their runtime passphrases match; each keyring contains a random data key.
+- Do not delete old pre-schema-14 backups casually. They may contain plaintext WLAN/mesh keys and ownership verifiers that later migration cannot scrub outside the live store.
+- Do not point an older daemon at a newer unsupported schema.
+- Do not manually edit restore markers, suppression records, schema versions, or safety-artifact names.
+
+## Troubleshooting and recovery
+
+### Export asks for recent reauthentication
+
+Enter the current owner account password. It is neither the runtime nor export passphrase.
+
+### Export passphrase is rejected
+
+Use valid UTF-8 containing at least 16 Unicode characters and no more than 4096 UTF-8 bytes. Both entries must match exactly.
+
+### The completed export disappeared
+
+Downloadable artifacts expire after 15 minutes. Start a new reviewed export. Job history does not retain an expired file.
+
+### Preview reports an invalid export passphrase
+
+Verify the passphrase record for that exact artifact. The controller does not retain or recover it.
+
+### Restore confirmation says the plan changed
+
+The artifact, preview, or current controller state no longer matches the bound plan. Cancel, upload again if necessary, and run a new preview. Do not bypass plan binding.
+
+### Restore is blocked by an existing router-review gate
+
+Finish reviewing the prior restored state. Either keep writes suppressed and do not start another restore, or explicitly resume the prior gate after review before beginning a new restore.
+
+### The controller does not reconnect after confirmation
+
+Check daemon/container logs and `/healthz`. Startup applies or rolls back the durable restore intent before serving. Do not delete `.oonfeewrt-recovery` files while investigating.
+
+### Recoverycheck refuses SQLite sidecars
+
+Create a self-contained SQLite backup or stop/checkpoint the controller cleanly. A non-empty `-wal` or `-journal` may contain recoverable pages and cannot be ignored safely.
+
+## Next steps
+
+- [Upgrade and roll back safely](../installation/upgrades.md)
+- [Review routine maintenance](maintenance.md)
+- [Manage owner accounts and sessions](accounts.md)

--- a/docs/operations/maintenance.md
+++ b/docs/operations/maintenance.md
@@ -1,0 +1,263 @@
+# Routine maintenance and health checks
+
+oonfeeWRT is designed as one long-running controller process with bounded storage and adaptive router polling. Routine operation is mainly about preserving recovery material, watching explicit source gaps, and allowing clean shutdown during safety-critical work.
+
+> **Outcome:** You can verify service health, read useful logs, understand automatic retention, adjust polling safely, collect redacted diagnostics, and stop the controller without stranding an Apply.
+
+## Prerequisites and impact
+
+- Read-only access is enough for ordinary health screens.
+- Operator access is needed for transient tests such as RF scan and speed test.
+- Administrator access is needed for device polling changes and diagnostics.
+- Owner access is needed for backup/restore and account custody.
+
+**Router write impact:** Health endpoints, dashboards, logs, diagnostics, and backups are read-only with respect to routers. Polling makes bounded read calls. RF scans, Apply, ACL refresh, optional LLDP, un-adoption, and resuming post-restore 802.11k maintenance have separately displayed write/disruption impact.
+
+## Check controller health
+
+The unauthenticated health endpoint is suitable for local service monitoring:
+
+```sh
+curl --fail http://127.0.0.1:8080/healthz
+```
+
+Expected output:
+
+```text
+ok
+```
+
+The executable also has a healthcheck mode that reads the configured listen address and checks `/healthz`:
+
+```sh
+oonfeewrtd -healthcheck
+```
+
+Docker Compose runs that mode every 30 seconds with a five-second timeout and three retries.
+
+A healthy HTTP endpoint means the process is serving. It does not prove that every router, telemetry source, or optional capability is healthy. Use the Dashboard and device detail views for those layers.
+
+## Read controller logs
+
+### Foreground or service logs
+
+The daemon writes human-readable structured logs to standard error. Read them through the terminal or service manager that starts it.
+
+For Compose:
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose logs --tail=200 oonfeewrt
+```
+
+To follow new Compose output:
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose logs --follow oonfeewrt
+```
+
+### Retained private log
+
+The controller also mirrors accepted records into:
+
+```text
+<data-dir>/controller.jsonl
+```
+
+It rotates at 2 MiB and retains three rotated segments. Each segment is forced to mode `0600`; an individual record larger than 64 KiB is replaced by an omission record.
+
+Do not publish the raw log family casually. Use the diagnostics workflow when sharing support evidence because it bounds and redacts retained content.
+
+## Use the application health views
+
+### Dashboard
+
+Review:
+
+- online versus total devices;
+- wireless and LAN clients;
+- five-minute WAN download/upload/ICMP latency/loss history;
+- route and fixed-probe provenance;
+- missing samples rather than a false zero;
+- recent warnings and errors;
+- topology evidence summary.
+
+The WAN probe runs only through the managed Gateway, sends exactly three ICMP packets to `1.1.1.1`, and runs at most once per minute. It is a fixed reachability observation, not DNS/HTTP validation or a claim of ISP uptime.
+
+### Devices
+
+For each device, review:
+
+- last seen and polling state;
+- firmware and capability record;
+- current load, memory, clients, and throughput when available;
+- degraded/unavailable source explanations;
+- management overhead, request rate, observed device CPU cost, bytes sent, and packages recorded as controller-installed;
+- current poll interval and scheduled tier.
+
+An unavailable value is not zero. Unknown evidence may come from a denied rpcd call, missing module, failed decode, stale observation, or driver limitation.
+
+### Logs
+
+Use **General** for operational events and **Audit** for authorized controller actions. Event details retain producer identity, provenance, severity, and supplied network fields. Coverage gaps are part of the result; the controller does not claim history for a source it did not observe.
+
+## Understand polling behavior
+
+Shipped defaults:
+
+| State | Interval/limit | Meaning |
+|---|---:|---|
+| Baseline | 60 seconds | Always-on device health and history. |
+| Focused | 10 seconds | While at least one UI viewer focuses that device. |
+| Adaptive maximum | 10 minutes | Backoff ceiling for unavailable or struggling devices. |
+| Slow response threshold | 1.5 seconds | Evidence used to widen polling. |
+| Load threshold | 5.0 | High one-minute load widens polling. |
+
+Polls are staggered across devices, batched where supported, and completely quiesced during that device's Apply/confirm cycle.
+
+The per-device poll-interval control can make baseline polling slower, not faster than the controller default. Use it for constrained or remote hardware. After saving, the daemon re-registers the device so the new interval takes effect without restart.
+
+## Automatic retention
+
+The controller holds raw telemetry in memory temporarily and stores completed rollups in SQLite:
+
+| Data | v0.1.1 retention/bound |
+|---|---|
+| Five-minute average/min/max/count | 14 days |
+| Hourly average/min/max/count | 396 days (13 months) |
+| OpenWrt log events | 24 hours; 50,000/device and 100,000 total |
+| Controller and audit events | newest 100,000 |
+| One event's encoded text/detail | 64 KiB aggregate limit |
+| Closed topology intervals | 31 days; active intervals remain |
+| RF scans | newest terminal run per device/radio; active work preserved |
+| Speed tests | newest three terminal attempts, plus any active test |
+| Diagnostic downloads | 15 minutes; up to 20 job records |
+| Backup downloads | 15 minutes; up to five job records |
+| Restore upload/preview state | 30 minutes; up to five uploads and five previews |
+
+Five-minute rows flush only after a bucket closes. Clean shutdown discards an unfinished in-memory bucket instead of writing a partial canonical row. Do not expect second-by-second raw history after restart.
+
+The engineering envelope is:
+
+- final container image at most 40 MB;
+- at most 256 MB steady-state RSS at 25 devices;
+- at most 2% of one modern CPU core for an idle fleet;
+- at most 2 GB disk at the full retention depth;
+- UI bundle at most 1.5 MB gzipped.
+
+These are release engineering bounds, not substitutes for monitoring the host's actual free disk and memory.
+
+## Run a controller-host speed test responsibly
+
+The Dashboard speed test:
+
+- runs from the controller process, not a router;
+- uses Cloudflare's `https://speed.cloudflare.com/__down` and `__up` endpoints;
+- transfers approximately 10 MiB down and 5 MiB up;
+- is bounded to 30 seconds;
+- may temporarily saturate the normal WAN route;
+- exposes the controller host's public IP and test requests to Cloudflare;
+- measures idle latency/jitter and throughput, not loaded latency/jitter.
+
+The Run action is the plan-bound acknowledgement. Do not schedule repeated tests; v0.1.1 exposes an explicit operator action, not an automatic test loop.
+
+## Generate safe diagnostics
+
+Owners and administrators can open **Settings → Diagnostics**.
+
+The bundle:
+
+- uses stored controller evidence only;
+- makes no router management/API/SSH call;
+- includes controller/version/schema/health, stored device model/firmware/capability state, source coverage, bounded events, and a bounded controller log tail;
+- pseudonymizes or redacts sensitive identifiers and known secret values;
+- excludes credentials, WLAN/mesh keys, private keys, session material, runtime/export passphrases, and raw secret values;
+- is bounded to 16 MiB of members plus 1 MiB archive overhead;
+- remains downloadable for 15 minutes.
+
+Procedure:
+
+1. Open **Settings → Diagnostics**.
+2. Read the **Stored evidence only** disclosure.
+3. Select **Generate stored-only bundle**.
+4. Wait for completion and download the ZIP before expiry.
+5. Inspect its manifest and contents before sharing it.
+
+Redaction reduces risk; it does not make arbitrary distribution safe. Controller metadata and network structure may remain sensitive.
+
+## Shut down safely
+
+The daemon handles SIGINT and SIGTERM. A normal shutdown:
+
+- stops accepting new work;
+- waits for admitted requests and controller jobs within bounds;
+- lets an Apply that reached OpenWrt's rollback-protected stage continue toward confirm instead of abandoning its timer;
+- flushes completed telemetry buckets and discards the incomplete one;
+- checkpoints/closes SQLite;
+- closes the private log.
+
+For a foreground binary, press `Ctrl-C` once and wait. A second signal is an emergency termination path, not routine shutdown.
+
+For Compose:
+
+```sh
+OONFEE_VERSION=v0.1.1 docker compose stop
+```
+
+The supplied service grants 150 seconds. Avoid `docker kill` during Apply or restore confirmation.
+
+## Routine operator checklist
+
+Before configuration work:
+
+1. Confirm `/healthz` and controller logs are clean.
+2. Confirm the target device is online and source gaps are understood.
+3. Confirm no restore-based router-write suppression is unexpectedly active.
+4. Take or verify a recent encrypted backup.
+5. Preview and read the complete per-device plan.
+6. Never reuse acknowledgements from an older preview; a changed plan requires new review.
+
+Periodically:
+
+1. Download a fresh `.oowrtbak` to off-host storage.
+2. Keep its export passphrase separately and run a disposable restore preview.
+3. Review owner accounts and active sessions.
+4. Review device firmware/capability freshness and explicit ACL-refresh notices.
+5. Check host disk/RAM and the controller data-volume backup.
+6. Read release notes before changing the daemon or image.
+
+## Troubleshooting and recovery
+
+### `/healthz` fails
+
+Check whether the process/container is running, then inspect startup logs. Common causes include passphrase-file permission, wrong runtime passphrase, missing/mismatched keyring, unsupported schema downgrade, data-directory permission, and address/port collision.
+
+### Health works but the browser says unavailable
+
+Test the browser route from the same host, then check reverse-proxy routing and certificate state. If REST works but live updates do not, check WebSocket forwarding for `/api/v1/live`.
+
+### One device is offline
+
+Verify management routing and the device's uhttpd/rpcd service. Review certificate/SSH pin changes separately; do not silently accept a changed identity. Default adaptive backoff may wait up to ten minutes after repeated hard failures; an explicitly configured 15-minute baseline remains 15 minutes unless a safe explicit action retriggers contact.
+
+### Data is missing or stale
+
+Read the displayed source gap. Do not interpret `Unavailable` as zero. A stored capability may need explicit reprobe after firmware changes; ACL widening is an explicit reviewed refresh, never a polling side effect.
+
+### Apply status is unknown after reload
+
+Use the durable Apply-operation recovery/status view. Do not start a second Apply until the first operation's per-device outcome and possible rollback window are understood.
+
+### Disk backup looks smaller or older than expected
+
+Do not trust a live main-file-only SQLite copy. Use `.backup`, a clean stop, or portable `.oowrtbak`, and always include the matching keyring.
+
+### A container was recreated with an empty controller
+
+Stop before adopting anything. Reattach the original volume and passphrase source. A new empty volume is a separate controller, even when the Compose file is unchanged.
+
+## Next steps
+
+- [Back up and restore](backups.md)
+- [Upgrade and roll back](../installation/upgrades.md)
+- [Review accounts and sessions](accounts.md)
+- [Protect the browser path with TLS](../installation/reverse-proxy.md)

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,2638 @@
+{
+  "name": "oonfeewrt-docs",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "oonfeewrt-docs",
+      "version": "0.0.0",
+      "devDependencies": {
+        "vitepress": "1.6.4"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.23.0.tgz",
+      "integrity": "sha512-j45MBISstltys9QyQ4xf6quRiN1g7vMuwQL9VM4dx8YuRZvCQ173b9royZAx6iAbRX3IB1VnG1z//NuwyQ8jpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.57.0.tgz",
+      "integrity": "sha512-JVFFujiZUCguk5tz3LZr4fTQxqpIrj4/Jw3SI7kMljSqtfLxYn/s/TWH0J2s4iNfsDpxPhgFGMotCpmDI4kZ8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.57.0.tgz",
+      "integrity": "sha512-6KqECK4ED3JJQEoDrQWnGPQzElA828xAD4qK5ceawNNyP/LcSvzAoLHjFkoTPksZ/kxj6VUtCRH+IHZesLltng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.57.0.tgz",
+      "integrity": "sha512-uqpGF3oXYsoCbQq5d7BzNrNTfIfuvJyGP1CKvSW27T9boUg7KOwyxsAw1AX0a3jSW2HrYEJ/NN+Z4MiGivbpeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.57.0.tgz",
+      "integrity": "sha512-u5NboJVJXDEFplvNnqqX4CxkXPYysjJRj47hOSh9329H8kG5gFLKJBIiS5utMQ+GZm8xQl3Te7NInDk6elEADQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.57.0.tgz",
+      "integrity": "sha512-uzc0b2LmHAK9/QID4xeo35OG84AkZl4YewkCqawqAOGLjT2eZpM/OZx45ESygMHG30Ws+ZTSdluPtMJcUnrbWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.57.0.tgz",
+      "integrity": "sha512-dIAhnM6ue/ssa5PjgNfu4g8A4yTojl9ZOUzZU3wIaIKRerL2R/3Emuf9n/D6ICXXP167KC6XCeC7nliSw7cuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.57.0.tgz",
+      "integrity": "sha512-2TTPTTKSJmCptvhCm4Xf3bBYMqZni+Pgc2hVdqc4l9wsBpSJNVTVIKpnd10OubUgkGcmppVDj1XQqYaf6EnPSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.57.0.tgz",
+      "integrity": "sha512-W4JseHKt+pzOxlFV+T3MWEG0h4Z2Se5zjoXUD0ewlw8aOWMG/yjRdopUdLQsXULepB/My2tDuZjkwk2sMfsUrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.57.0.tgz",
+      "integrity": "sha512-BrxJVE0/eLinEPICCD7BKN/2xnt0nkjge70u8zzE2ISP3fuB3tjLgcwpanUycvlHBFLI4gK0l5ol54p6IYuR/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.57.0.tgz",
+      "integrity": "sha512-Gc29jkeiLKlVfHvyrIgyUHHE+aYTdXEeLfK42rjr5/1TTVsYwUJz0XkvoIBIqfMjcDg6gXeHb1jTUZ0H+SYIlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.57.0.tgz",
+      "integrity": "sha512-PIPnPN7MP3fp2VAi01BVXhCWmD366ZB2Hkq5TlYKtThd4KxUtMmaaNDpFgVCTXtSIqWVZLJntOHRvxg/sIPd8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.57.0.tgz",
+      "integrity": "sha512-AX3RlOudXMdTwtwUqdAf5hAVLvXfOZZH1FZh6ALDdrhVLT0TtAIe48N6nYcWcTnwoTxK/wDIQqZ19IMjK8zJAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.57.0.tgz",
+      "integrity": "sha512-cWZc1dKb7wy9/wPpwMtL1y89gK2G7y2A47Coa7zwf1ydtIeJm4+S+XxoQ2b/ZRiQnrC1YHavLjYUPDCdnT7Khg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.93",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.93.tgz",
+      "integrity": "sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.0.tgz",
+      "integrity": "sha512-70TeIFezKKy65LgAVyQh+w94/gjWhvPWaLaGGeMEgVrPkQhuj/M5bAYYZzIFUj9Y69oHyTm5Um/R6gcLh4A8JA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.0.tgz",
+      "integrity": "sha512-YC86tYIHK6M1IV+wbzO+Bxk8RCBr6ZyWYgWxUCzaZD8mc8rrFoIJDNzDrkHBYRc/wKdrsIXmm6/F7NzrAO+OrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.0.tgz",
+      "integrity": "sha512-oI+ECtUcli0y0fi4xpW82GdPIXdTkI8G8DSjG2LRuw09fPAGykaWYH/hXxiKuTxiAjiPSTIIuYUqof5Z2hShWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.0.tgz",
+      "integrity": "sha512-NwV+1s7TiKrMe4owHyKB/dTLD7ZJD0YEBEhIz+hvav1Cu1GReJjF+rsdNwjzENQeIAbE/CoNiaAc5Vz2h5DPAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.0.tgz",
+      "integrity": "sha512-tWtHBTu5gOPK4u4Urtk4qAHW3zZ9rQAmbssO8gp7ELvGTGI3aCiq6NqyTQ0PCIg7KbHJF2UkGDDs77YZGxfjCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.0.tgz",
+      "integrity": "sha512-2qPoJiwTvtHQ27NnYvTnsgk8laXWYuVmNESG8WFZBcEPKLfZ3I27qBJarjVRQtwGeYyRfq5ZowHXih9lm2BItw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.0.tgz",
+      "integrity": "sha512-FQwsTRvLNuHoTdICABJQfbPUSEueISGmnpT06tXTMpfprf5NiKLSXKA0A+w45wJnCmZAnzgqBwbt6ARFuyOi5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.0.tgz",
+      "integrity": "sha512-BBVTXziw8mY1a4ZbWME9tZyfzqXCDPqaC7Z3heQ29p5dkvXzwL0NwelO8zLa8c3RBKvl3YTuSnBgsBhYBtwjIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.0.tgz",
+      "integrity": "sha512-w2Iyy9+RqKwx3d9qWMKsJg0FfRBsY0/pXNv0mCQ3ueRvJI6+QAScfD4nrMlzFLs2HNVW6Ew+mtZfDl9b7Ew5/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.0.tgz",
+      "integrity": "sha512-YK++KtrFRHYE0P6/RtYEAy9t8F37znP+K03RrIuLPYOL6SVlObRumf/0OE4V/h63xL9DwkWbNssZfmA9hawuDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.0.tgz",
+      "integrity": "sha512-aBfOG6fP7YkkPmTqPwufRJeFyz7WPpECv9XNbnsk9+vg7rxdih0lbtEel7jcRng4LZrrmU3FfitCFyEj4BWDWg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.0.tgz",
+      "integrity": "sha512-LGaHEOeHNAag9VuS1Crs5DFg4RrU9MPi2nVnNJk9DTePx/B6RRYKVmrIXt2h7YOJlwjaFJ6lwtFDliZxScTLrQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.0.tgz",
+      "integrity": "sha512-jClvk+J0FC3b7Udvegiw5/4hErbHtmsNsQgENnKXDWtNCJXsJYZH5WURvu7imDOO38xYml24eeh5x3A04ppwCw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.0.tgz",
+      "integrity": "sha512-0OJlaGK+8+B777Ql5okIpD7ua5Ro9+VB9Ve0OKa28OQJZ1RbuUBVNHK/e3pr4BROqsyPl1JrPO1ZxJseCNffcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.0.tgz",
+      "integrity": "sha512-Ygsx+HoNH7afwi1bTIXbnTvVnsO+zurPLSYxybV1hHFVU72OWOCl6v05ql/z0hkpAPx+DK7Kn9Bi7MayCcjLTA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.0.tgz",
+      "integrity": "sha512-pDQxtMGb+OvG3fLwR2OkZlSd47hW+kWg4BYMG/++sR6RqorQccwPTDsxda5hPwiIeIErAnCF9ma3SAU06bdQtQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.0.tgz",
+      "integrity": "sha512-0BnUG9mS8I4SSHr3XsxVhuCMEiu+rX61xxZF5vujso4LaiAGFZFxvDjg6Xn6tLPNTUAfuCvQYas4LMQMVsKRSQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.0.tgz",
+      "integrity": "sha512-Adu/VttB1dpPNW+FEacrZ+xVm9tFty84+RrFzsqlFaPxoJB+9XXyDGtp5dCOoBwGBIEVH0To7lExFXEx0BIF4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.0.tgz",
+      "integrity": "sha512-NQ3bDvjUbFKmP23671xUlXtKmqVsUBd6M4PQCvbmNtOy06hnQIdKHy8oG/6S3R/S6He1JgPk6A5VT+prAJMYEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.0.tgz",
+      "integrity": "sha512-u2eDAl4+0aFvA13GxlGBtTI3SS3sdgwgtV0HyjZ0QaQVCgNE+jqNGey+GtxWiq+wxr/UycAx/OnfJzApCFamvA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.0.tgz",
+      "integrity": "sha512-XvRb5vfW3wAZQ+ZUG21AnHHDKtNcw99eigzEhjr//NZ3u7SoBaPP0seSc7FgP7p1epAEdAoZckMW9WY/+4w70w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.0.tgz",
+      "integrity": "sha512-iZPmniy4kNBf5yo2RezbkYNNK5HPbXE9+g+twnbqSng7dtLEJy1SKoxiE/ni4FDacjyuZpEeb9U054N4EoKHYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.0.tgz",
+      "integrity": "sha512-mFBBd+LF37fnE8JnYUOH+imj0aPFPK30vpar4ehJkgnLj9sZn8ZxiRENmLtgIwxK7TC8klF6N57fxdNBwQoqOA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.0.tgz",
+      "integrity": "sha512-ujeqEY3B+zbGn3Z4Q03cUBG/LGWnBJncVT36WER31LcOsQk9+1dmINKKtvmmfChUvRbK1G0R8OhMWFgHgaZtAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.0.tgz",
+      "integrity": "sha512-hncn90N4sOky0L2LKE5oESKLbxCPeVo4eLA2LSMoDzM+879ml4WSr+Rr4DWknNIVVvS1Hirkc9hx02W6YxS8rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-NoQ2yGlLWj4wpxMs+TYmRKk3thDrQ97agr7sFqfLsAlvoS8SNQuTrlObhFqG9iugdTtgOE9jpJ6FNM4ZGsa5xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.42.tgz",
+      "integrity": "sha512-2Ye1ilMtKXxl8qZUrQ5j0CdgenFp/HFQmta6rfRyfEsTG69L6Wk+tWuNoHYHMx9E8tF2Slvdg1FuwDvAXdy1LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.42",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.42.tgz",
+      "integrity": "sha512-qbhQZEFmycr+ni/qyuccS4sucNN7VAbDfbkvNxWOX2VfgFm90MNs3/UhRNKoPMEIVn0F8gdlYjLPvqxHwHeQOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.42.tgz",
+      "integrity": "sha512-fkCAFB4okcAANGMThboWnScp/gzWjU0ZSkVnjTIiplmMDq2uq0tIB3j+xVu4rhv5rvOgBySCysudmbMd6xRRqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.42",
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/compiler-ssr": "3.5.42",
+        "@vue/shared": "3.5.42",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.42.tgz",
+      "integrity": "sha512-xmLk3wLkbizPAiLyomjgFFosf2ys9b5Ghb+oh/k2tnvipNz8OFrQOiTcWCzyK7MpBp9KkyGtfvgfLUivbmuGYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.10"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.10",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.42.tgz",
+      "integrity": "sha512-TzNNfKpb7hDxbQltwAut8VDQA5YP+BuRlxntHUuRjyKwlMvmAPbs3unhCvieijifY6vFfVBwsS7wG/C7uq+bEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.42.tgz",
+      "integrity": "sha512-9uACtuHs7vJGkm5Bp3xu4xRDLFTIYy5DgxpToVjqGIAhAEKwQfsaLvKINhM6nFVp6bZPRFGdDqd1g52MqKsotA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.42.tgz",
+      "integrity": "sha512-rsCmhiWLaRxGltLwhlCWyYkFn7WAbKRh0q17eZ1A6Dq6eqc2ACQ61IIryxz0LrsvCzHSilLA9JHovVwM8CNE2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.42",
+        "@vue/runtime-core": "3.5.42",
+        "@vue/shared": "3.5.42",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.42.tgz",
+      "integrity": "sha512-2++5dUyYS4gvo7xQXSECUDhB7TS0aOl5SeVfC5qSq1Jgfhjvegw1zqhwTIR3imZ+QYPJQw9gfcFvXGAjGZ7ajQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.42",
+        "@vue/runtime-dom": "3.5.42",
+        "@vue/shared": "3.5.42"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.42.tgz",
+      "integrity": "sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.57.0.tgz",
+      "integrity": "sha512-HpND7MBGctOAkd1GoQoDZCGoCpqNTS5NG1LuhElFet3RdLJkwnyTYZXZhXwtpAQPrI36fqQ3eT6KQrdKDTKu3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.23.0",
+        "@algolia/client-abtesting": "5.57.0",
+        "@algolia/client-analytics": "5.57.0",
+        "@algolia/client-common": "5.57.0",
+        "@algolia/client-insights": "5.57.0",
+        "@algolia/client-personalization": "5.57.0",
+        "@algolia/client-query-suggestions": "5.57.0",
+        "@algolia/client-search": "5.57.0",
+        "@algolia/ingestion": "1.57.0",
+        "@algolia/monitoring": "1.57.0",
+        "@algolia/recommend": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.1.0.tgz",
+      "integrity": "sha512-ufbM3smX/Jbnpk5wcQjzd1MgBpzmqfNETUAyZNrGwU9foRlyHoGzMMBBCRzEhQLBjZfFDE1W2ufPXX2vdWkV8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.0.tgz",
+      "integrity": "sha512-T5vnZ2y4QqC3/4P+w2+JO+Q/OVdnPsv4XcSYJYMEn0R9/jjl5AgLwO9LAZMzP2lN71O6pypn91rB7lDstUkfrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.0",
+        "@rollup/rollup-android-arm64": "4.63.0",
+        "@rollup/rollup-darwin-arm64": "4.63.0",
+        "@rollup/rollup-darwin-x64": "4.63.0",
+        "@rollup/rollup-freebsd-arm64": "4.63.0",
+        "@rollup/rollup-freebsd-x64": "4.63.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.0",
+        "@rollup/rollup-linux-arm64-musl": "4.63.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.0",
+        "@rollup/rollup-linux-loong64-musl": "4.63.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.0",
+        "@rollup/rollup-linux-x64-gnu": "4.63.0",
+        "@rollup/rollup-linux-x64-musl": "4.63.0",
+        "@rollup/rollup-openbsd-x64": "4.63.0",
+        "@rollup/rollup-openharmony-arm64": "4.63.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.0",
+        "@rollup/rollup-win32-x64-gnu": "4.63.0",
+        "@rollup/rollup-win32-x64-msvc": "4.63.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.42.tgz",
+      "integrity": "sha512-4RyHQTbQvOPs3MfvUO1Sg0YRrKNnA0mAVtvpd12Tg1fKDN7OHBUl1IqSn8zGJjK9nI3NkNp8cgTpVrSZC5TTcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/compiler-sfc": "3.5.42",
+        "@vue/runtime-dom": "3.5.42",
+        "@vue/server-renderer": "3.5.42",
+        "@vue/shared": "3.5.42"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "oonfeewrt-docs",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vitepress .",
+    "build": "vitepress build .",
+    "preview": "vitepress preview ."
+  },
+  "devDependencies": {
+    "vitepress": "1.6.4"
+  },
+  "overrides": {
+    "vite": "6.4.3"
+  }
+}

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="oonfeeWRT">
+  <rect width="64" height="64" rx="15" fill="#18569f"/>
+  <path d="M16 39h7v9h-7zm13-13h7v22h-7zm13-10h7v32h-7z" fill="#fff"/>
+  <path d="M13 15h38" stroke="#63d0c7" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/docs/public/logo-dark.svg
+++ b/docs/public/logo-dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="oonfeeWRT">
+  <rect x="1" y="1" width="62" height="62" rx="14" fill="#16181c" stroke="#3987e5" stroke-width="2"/>
+  <path d="M16 39h7v9h-7zm13-13h7v22h-7zm13-10h7v32h-7z" fill="#f2f4f7"/>
+  <path d="M13 15h38" stroke="#54cbc2" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/docs/public/logo-light.svg
+++ b/docs/public/logo-light.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="oonfeeWRT">
+  <rect width="64" height="64" rx="15" fill="#18569f"/>
+  <path d="M16 39h7v9h-7zm13-13h7v22h-7zm13-10h7v32h-7z" fill="#fff"/>
+  <path d="M13 15h38" stroke="#63d0c7" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/docs/public/social-card.svg
+++ b/docs/public/social-card.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-label="oonfeeWRT Documentation">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop stop-color="#0f1114"/>
+      <stop offset="1" stop-color="#182b42"/>
+    </linearGradient>
+    <radialGradient id="glow">
+      <stop stop-color="#3987e5" stop-opacity=".34"/>
+      <stop offset="1" stop-color="#3987e5" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="980" cy="120" r="430" fill="url(#glow)"/>
+  <g transform="translate(86 88)">
+    <rect width="92" height="92" rx="22" fill="#18569f"/>
+    <path d="M23 56h10v14H23zm21-20h10v34H44zm21-15h10v49H65z" fill="#fff"/>
+    <path d="M18 20h58" stroke="#63d0c7" stroke-width="7" stroke-linecap="round"/>
+  </g>
+  <text x="86" y="277" fill="#f2f4f7" font-family="system-ui,sans-serif" font-size="72" font-weight="740">oonfeeWRT</text>
+  <text x="86" y="359" fill="#62a8f6" font-family="system-ui,sans-serif" font-size="48" font-weight="650">Documentation</text>
+  <text x="86" y="432" fill="#aeb4be" font-family="system-ui,sans-serif" font-size="29">Self-hosted management for stock OpenWrt.</text>
+  <text x="86" y="478" fill="#aeb4be" font-family="system-ui,sans-serif" font-size="29">Install. Adopt. Observe. Configure safely.</text>
+  <g fill="none" stroke="#54cbc2" stroke-width="5">
+    <circle cx="885" cy="348" r="24"/>
+    <circle cx="1035" cy="282" r="24"/>
+    <circle cx="1015" cy="444" r="24"/>
+    <path d="m906 337 107-46m-107 70 87 70"/>
+  </g>
+</svg>

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,0 +1,182 @@
+---
+title: Capabilities and limits
+description: What oonfeeWRT v0.1.1 can do, what depends on device evidence, and what is unavailable.
+---
+
+# Capabilities and limits
+
+This is the user-facing capability boundary for **oonfeeWRT v0.1.1**. It is
+intentionally narrower than the long-term roadmap.
+
+## How to read status
+
+| Status | Meaning |
+|---|---|
+| **Shipped** | Present in v0.1.1 source, UI/API, and automated tests |
+| **Hardware-verified** | Exercised on the published physical-router validation setup |
+| **Capability-dependent** | Shipped, but visibility or operation depends on the router, driver, package set, and measured source |
+| **Source-tested only** | Automated contracts exist, but the published hardware run did not execute the disruptive or optional operation |
+| **Unverified** | Intended/shipped path lacks the stated physical topology or hardware proof |
+| **Unavailable** | Not provided by v0.1.1 or deliberately outside the project boundary |
+
+An unavailable measurement is not a zero. The UI distinguishes unknown,
+unsupported, stale, partial, and observed-empty evidence.
+
+## Deployment and controller
+
+| Capability | v0.1.1 status | Important boundary |
+|---|---|---|
+| Standalone Linux/macOS controller | **Shipped** | amd64 and arm64 release archives |
+| Linux container/Compose deployment | **Shipped** | amd64/arm64, non-root scratch image, read-only root filesystem in supplied Compose setup |
+| Embedded web UI | **Shipped** | One process; no separate web server |
+| Local SQLite storage | **Shipped** | WAL mode; database and keyring must be backed up together |
+| Light and dark controller themes | **Shipped** | UI-side switch; v0.1.1 defaults to dark and does not persist the choice across reloads |
+| Native controller TLS | **Unavailable** | Use a trusted reverse proxy or trusted isolated management LAN |
+| Cloud account or relay | **Unavailable** | Self-hosted only |
+| Multi-site/NAT traversal | **Unavailable by design** | Use an existing routed management network or VPN |
+| Controller running on a router | **Unsupported** | Not built, packaged, tested, or budgeted for OpenWrt-hosted operation |
+
+## Discovery, inspection, and adoption
+
+| Capability | v0.1.1 status | Important boundary |
+|---|---|---|
+| Add router by management address | **Shipped, hardware-verified** | Works without layer-2 discovery |
+| On-demand discovery | **Shipped** | ARP/mDNS coverage depends on host/container networking |
+| Read-only pre-adoption inspection | **Shipped, hardware-verified** | Authenticates to the router but creates no router/controller inventory state |
+| Explicit Gateway/AP/Switch function selection | **Shipped, hardware-verified** | A device may have multiple functions; function choice controls rendered intent |
+| Scoped controller login and ACL | **Shipped, hardware-verified** | Separate default-off consent; one login and one ACL file, no package/executable |
+| Capability probe and re-probe | **Shipped, hardware-verified** | Stores measured support/gaps; firmware changes do not have to leave stale capability truth forever |
+| SSH-free steady-state management | **Shipped** | Polling and Apply use ubus; SSH remains bounded bootstrap/cleanup/optional-capability transport |
+| Automatic package install during adoption | **Unavailable by design** | Optional capabilities use separate plan/consent |
+
+## Fleet visibility and telemetry
+
+| Capability | v0.1.1 status | Important boundary |
+|---|---|---|
+| Device inventory, health, model, firmware, uptime | **Shipped, hardware-verified** | Freshness and source gaps remain visible |
+| Interface throughput and durable metric history | **Shipped, hardware-verified** | Five-minute rollups for 14 days; hourly for 396 days |
+| Management-overhead readout | **Shipped, hardware-verified** | Reports poll interval, request rate/bytes, failures, installed-capability packages, and only measured attributable CPU estimates |
+| Per-device poll interval override | **Shipped** | UI offers 60 seconds to 15 minutes. `0` clears the override, and values below the controller default do not increase the effective poll rate |
+| OpenWrt log ingestion | **Shipped, hardware-verified** | Once per minute, bounded retention and explicit continuity gaps |
+| Live UI updates | **Shipped** | Bounded WebSocket `device.stats`; durable history remains SQLite-backed |
+| Application/DPI identification and flow history | **Unavailable** | No controller-authored router agent; DPI is outside the constrained-device budget |
+
+## Dashboard and WAN evidence
+
+| Capability | v0.1.1 status | Important boundary |
+|---|---|---|
+| Fleet status and warning/error summary | **Shipped** | Partial data is disclosed rather than flattened |
+| WAN reachability charts/table | **Shipped, hardware-verified** | Gateway sends three ICMP probes to fixed `1.1.1.1` at most once per minute; this is not full ISP uptime, HTTP, or DNS validation |
+| WAN/interface throughput | **Shipped** | Source and missing-sample provenance are shown |
+| Controller-host speed test | **Shipped** | Cloudflare endpoint, about 15 MiB, one active job, 30-second hard bound, three terminal results retained |
+| Gateway-run speed test | **Unavailable in v0.1.1** | Would need a separately approved router capability |
+| Loaded latency and loaded jitter | **Unavailable** | The controller-host method reports idle latency/jitter only |
+
+## Topology
+
+| Capability | v0.1.1 status | Important boundary |
+|---|---|---|
+| Internet → gateway → infrastructure → client graph | **Shipped, hardware-verified** | Inferred from route, FDB/neighbor, association, and optional LLDP evidence |
+| Current measured/inferred source labels | **Shipped** | Ambiguous links stay ambiguous; expired evidence can leave an online device unplaced |
+| Topology history | **Shipped** | Closed intervals retained for 31 days |
+| Baseline topology without extra package | **Shipped** | BusyBox FDB sources may lack VLAN identity |
+| LLDP adjacency enrichment | **Shipped optional workflow, hardware-verified** | Exact official-feed package/config/service plan, separate consent, durable rollback ledger |
+| Continuous physical truth without LLDP | **Unavailable** | Dynamic FDB evidence can age out |
+
+## Clients and observability
+
+| Capability | v0.1.1 status | Important boundary |
+|---|---|---|
+| Client inventory, address/name/vendor hints, association and connection source | **Shipped, hardware-verified** | Depends on host hints, DHCP/neighbor and wireless sources available on each router |
+| Current wireless signal/rates/retries | **Capability-dependent, hardware-verified** | Driver/hostapd source gaps are disclosed |
+| Client observability timeline | **Shipped, hardware-verified** | Joins bounded exact events, topology intervals, AP/radio/path evidence, and rollups at one cursor |
+| Wi-Fi experience score | **Shipped, capability-dependent** | Requires RSSI, retry delta, and TX-failure delta in one sample; missing inputs do not get reweighted |
+| Private-MAC indication | **Shipped** | Warning from the locally administered MAC bit, not identity proof |
+| Durable per-client application usage | **Unavailable** | Requires optional accounting/DPI not shipped as a v0.1.1 controller capability |
+
+## Radios and RF
+
+| Capability | v0.1.1 status | Important boundary |
+|---|---|---|
+| Radio inventory, band, channel, width, power, client count | **Shipped, hardware-verified** | Stable radio identity is separated from driver naming |
+| Channel-plan view | **Shipped, hardware-verified** | Shows In use, Enabled, Restricted, or Unknown from actual frequency evidence |
+| Channel utilization | **Shipped, hardware-verified** | Derived from deltas of driver `busy_time`/`active_time`, never absolute counters |
+| Noise/SNR | **Capability-dependent** | Hidden/unavailable when driver evidence is unstable or incorrectly encoded |
+| Interference and airtime split | **Capability-dependent** | Requires trustworthy RX/TX airtime; unavailable on the verified mwlwifi reference |
+| Manual RF scan | **Shipped, hardware-verified** | Explicit disruption acknowledgement, 45-second timeout, 4,096 BSS-row bound, newest terminal result retained; one C6 5 GHz validation scan found 14 BSS entries and suggested channel 44 |
+| Suggested channels | **Shipped, capability-dependent** | Requires scan no older than 24 hours, fresh radio state, and recent channel plan |
+| Continuous spectrum-analyzer waterfall | **Unavailable** | Requires radio/silicon capabilities not exposed as portable OpenWrt evidence |
+
+## Site configuration
+
+| Capability | v0.1.1 status | Important boundary |
+|---|---|---|
+| Site-wide WLANs and AP groups | **Shipped, hardware-verified** | Deterministic fan-out to selected APs; write-only secrets remain redacted after save |
+| 2.4/5/6 GHz and WPA2/WPA3/OWE/open WLAN fields | **Shipped, capability-dependent** | Includes PMF and 802.11r/k/v fields; hardware defects and missing support can block or warn |
+| Networks, VLANs, addressing, and DHCP intent | **Shipped** | Rendered only to devices with the required Gateway/Switch function and capabilities |
+| Firewall zones and directed forwarding | **Shipped** | Controller-owned firewall4 sections only |
+| IPv4 policy records, static routes, and port forwards | **Shipped** | Preview/gates remain authoritative; application-based matching is unavailable without DPI |
+| Client block and fixed-IPv4 desired policy | **Shipped** | Per-client rate limiting, QoS/SQM, and application/DPI policy backends are unavailable in v0.1.1 |
+| Per-device overrides | **Shipped** | Limited to WLAN publication, hidden beacon, isolation, and client limit; SSID/key/security/PMF/roaming settings cannot diverge per AP |
+| Preview and multi-device Apply | **Shipped, hardware-verified** | Full-fleet preflight, OpenWrt rollback timer, runtime verification, durable receipts |
+| Automatic silent reconciliation of every desired edit | **Unavailable by design** | Saving does not Apply; operator review remains required |
+
+## Roaming, mesh, and uplink
+
+The site model and controller include 802.11k neighbour distribution, WLAN
+roaming fields, mesh/backhaul records, uplinks, and health surfaces. The
+published two-router evidence verifies WLAN fan-out and client reassociation
+between the reference APs. Controller-managed 802.11k neighbour distribution is
+built and source-tested, not physically proven by that record. The roam also
+does not prove that 802.11r Fast Transition was used.
+
+The following release boundaries remain:
+
+- three-or-more-AP fan-out is **unverified**;
+- real mesh backhaul is **unverified**;
+- wireless uplink is **unverified**; and
+- the controller does not claim to replace hardware/driver-specific steering
+  behavior with its own router agent.
+
+## Accounts, backup, and diagnostics
+
+| Capability | v0.1.1 status | Important boundary |
+|---|---|---|
+| Owner, Administrator, Operator, Read-only roles | **Shipped** | Server-enforced; see [Permissions](../concepts/permissions.md) |
+| Session inventory/revocation and password step-up | **Shipped** | Sessions are in memory and end on restart |
+| Redacted diagnostics ZIP | **Shipped** | Stored evidence only; no router calls; Administrator+ |
+| Encrypted `.oowrtbak` export | **Shipped** | Separate unrecoverable export passphrase; Owner + recent reauth |
+| Staged restore preview | **Shipped** | Disposable validation/migration before replacement |
+| Confirmed restore with safety artifact and write suppression | **Shipped** | No automatic router Apply; all sessions revoked |
+
+## Published hardware evidence
+
+The stable-release documentation carries physical evidence for Linksys WRT3200ACM and
+TP-Link Archer C6 v2 on OpenWrt 25.12.5. The Archer C6 v2 passed the 60-minute
+class-C polling/resource budget: 209 poll batches, no failures, and no observed
+overlay write. That fresh-start evidence was produced through the pre-stable/RC
+workflow and underlies the stable release; v0.1.1 did not rerun the entire
+hardware procedure, and its router-operation code was unchanged.
+
+That evidence is deliberately specific. It does not prove all ath79, mwlwifi,
+MT7621, Filogic, DSA, swconfig, mesh, or multi-AP combinations. Review the
+[fresh-start validation record](../FRESH-START-VALIDATION.md) for exact evidence
+and accepted gaps.
+
+The WRT3200ACM evidence also records a severe board/driver boundary: its Marvell
+88W8964/mwlwifi setup can wedge under WPA3/SAE or PMF until a physical cold power
+cycle. The safely demonstrated configuration was WPA2-only, PMF disabled, FT
+disabled, and 802.11k/v enabled after cold boot. Do not generalize a WLAN option
+being present in the model into proof that this router can run it safely.
+
+The current controller serves REST/WebSocket routes under `/api/v1`, but v0.1.1
+does not publish a stable third-party API compatibility guarantee. Treat that
+surface as the controller/UI contract unless a future release documents one.
+
+## Related reference
+
+- [Requirements](./requirements.md)
+- [Safety model](../concepts/safety.md)
+- [Feature parity and evidence matrix](../PARITY-MATRIX.md)
+- [Troubleshooting](./troubleshooting.md)
+- [Roadmap](../ROADMAP.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,239 @@
+---
+title: CLI and environment reference
+description: Exact oonfeewrtd and recovery helper flags, environment variables, defaults, and safe command examples for v0.1.1.
+---
+
+# CLI and environment reference
+
+This reference applies to the **v0.1.1** release executables
+`oonfeewrtd` and `oonfeewrt-recoverycheck`.
+
+## `oonfeewrtd`
+
+```text
+oonfeewrtd [flags]
+```
+
+### Flags
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `-data-dir <absolute-path>` | `/data`, or `OONFEE_DATA_DIR` | Directory containing `oonfeewrt.db`, `keyring.json`, logs, and private job/recovery directories |
+| `-listen <host:port>` | `:8080`, or `OONFEE_LISTEN` | HTTP bind address |
+| `-passphrase-file <path>` | unset, or `OONFEE_PASSPHRASE_FILE` | Read runtime passphrase from a protected regular file instead of prompting |
+| `-log-level <level>` | `info` | One of `debug`, `info`, `warn`, `error` |
+| `-healthcheck` | false | Probe the configured listener's `/healthz` and exit without opening controller data |
+| `-version` | false | Print the embedded version and exit without opening controller data |
+| `-h`, `-help` | — | Print standard flag help; v0.1.1 then exits non-zero (a known CLI quirk) |
+
+Flags are parsed after environment configuration, so an explicit flag overrides
+a valid corresponding environment value. Environment loading/validation happens
+first; an invalid non-empty environment setting fails before flags are parsed.
+
+### Environment variables
+
+| Variable | Accepted value | Notes |
+|---|---|---|
+| `OONFEE_DATA_DIR` | Absolute directory path | Default `/data` |
+| `OONFEE_LISTEN` | Go-style `host:port` | Default `:8080` |
+| `OONFEE_PASSPHRASE_FILE` | Path to protected regular file | Used for unattended startup and recovery tooling |
+| `OONFEE_PASSPHRASE` | **Rejected** | A passphrase value must never be supplied through the environment |
+
+`OONFEE_PASSPHRASE` fails startup because environment values can be exposed
+through process inspection, child processes, crash reports, and
+`docker inspect`.
+
+### Data-directory rules
+
+`-data-dir` must be absolute. A relative path is rejected so a working-directory
+change cannot silently create a second empty controller.
+
+The process secures the data directory to mode `0700` and newly created SQLite
+database/WAL/SHM files to `0600`. Run it as the operating-system user that owns
+the state. The container defaults to UID `65532`; bind-mounted deployments may
+instead explicitly run as the owning host UID/GID.
+
+### Passphrase-file rules
+
+The file must:
+
+- be a regular file, not a directory or device;
+- not be group- or world-readable;
+- be non-empty; and
+- be readable by the controller process.
+
+One trailing LF or CRLF sequence is removed; other whitespace is retained. Mode
+`0600` is the documented choice.
+
+The first interactive start, with no passphrase file, prompts twice to create
+the keyring. Later interactive starts prompt once. A non-interactive process
+without `-passphrase-file` has no passphrase source and fails instead of
+starting with an empty keyring.
+
+## Common daemon commands
+
+### Print the version
+
+```sh
+oonfeewrtd -version
+```
+
+For release v0.1.1 the output must be:
+
+```text
+v0.1.1
+```
+
+### Interactive local start
+
+```sh
+install -d -m 0700 "$PWD/data"
+oonfeewrtd \
+  -data-dir "$PWD/data" \
+  -listen 127.0.0.1:8080
+```
+
+Open `http://127.0.0.1:8080` after the controller reports that it is listening.
+
+### Unattended local start
+
+```sh
+install -d -m 0700 "$HOME/.local/share/oonfeewrt" "$HOME/.config/oonfeewrt"
+umask 077
+head -c 32 /dev/urandom | base64 > "$HOME/.config/oonfeewrt/passphrase"
+chmod 600 "$HOME/.config/oonfeewrt/passphrase"
+
+oonfeewrtd \
+  -data-dir "$HOME/.local/share/oonfeewrt" \
+  -passphrase-file "$HOME/.config/oonfeewrt/passphrase" \
+  -listen 127.0.0.1:8080
+```
+
+The generated passphrase file is now the unattended unlock secret, not an
+independent second factor. Back it up and protect it accordingly.
+
+### Set environment configuration
+
+```sh
+export OONFEE_DATA_DIR=/absolute/path/to/oonfeewrt-data
+export OONFEE_LISTEN=127.0.0.1:8080
+export OONFEE_PASSPHRASE_FILE=/absolute/path/to/mode-600-passphrase
+oonfeewrtd
+```
+
+Do not export the passphrase value itself.
+
+### Change log level
+
+```sh
+oonfeewrtd \
+  -data-dir /absolute/path/to/oonfeewrt-data \
+  -passphrase-file /absolute/path/to/mode-600-passphrase \
+  -listen 127.0.0.1:8080 \
+  -log-level debug
+```
+
+Debug logging can contain more operational detail. Reproduce the problem,
+collect a diagnostics bundle if appropriate, then return to `info`.
+
+## Healthcheck
+
+```sh
+oonfeewrtd -listen 127.0.0.1:8080 -healthcheck
+```
+
+The healthcheck:
+
+- derives `http://<listener>/healthz` from the configured listener;
+- converts wildcard `0.0.0.0` to `127.0.0.1` and `::` to `::1`;
+- uses a four-second timeout;
+- does not use ambient HTTP proxy variables;
+- expects status `200` and body exactly `ok`; and
+- does not open the database, keyring, data directory, or passphrase file.
+
+It checks process HTTP liveness, not router reachability, database backup
+quality, or full fleet health.
+
+Container example:
+
+```sh
+docker exec oonfeewrt /oonfeewrtd -healthcheck
+```
+
+The release container uses this executable healthcheck internally.
+
+## Signals and shutdown
+
+`SIGINT` and `SIGTERM` start graceful shutdown. The controller stops accepting
+work, drains bounded requests/background jobs, lets an Apply that reached its
+critical stage resolve its confirm/rollback outcome, flushes complete metric
+windows, checkpoints SQLite, and exits.
+
+Do not use `SIGKILL` for routine upgrades. The supplied container uses a
+150-second stop timeout to give Apply and storage work room to finish.
+
+## `oonfeewrt-recoverycheck`
+
+The release archive includes a read-only recovery helper:
+
+```text
+oonfeewrt-recoverycheck /path/to/recovery/oonfeewrt.db
+```
+
+It has no data/listen flags. Set `OONFEE_PASSPHRASE_FILE` to the controller
+runtime passphrase file:
+
+```sh
+OONFEE_PASSPHRASE_FILE=/absolute/path/to/mode-600-passphrase \
+  oonfeewrt-recoverycheck /absolute/path/to/backup/oonfeewrt.db
+```
+
+The helper requires:
+
+- exactly one database path;
+- a regular, non-symlink database file;
+- a regular, non-symlink sibling `keyring.json`;
+- no non-empty `oonfeewrt.db-wal` or `oonfeewrt.db-journal` sidecar;
+- a current-schema database; and
+- the passphrase that opens that exact keyring.
+
+It opens SQLite through the read-only recovery boundary and makes no network
+call. A successful result has this shape:
+
+```text
+schema=19 devices=<n> credentials=<n> owned_sections=<n> wlans=<n> meshes=<n>
+```
+
+Those counts prove that the pair can be opened and its recovery invariants are
+readable. They do not prove that every router is reachable or currently matches
+the stored desired state.
+
+## Manual backup verification example
+
+For a live binary installation, use SQLite's online backup API and copy the
+matching keyring:
+
+```sh
+install -d -m 0700 /absolute/path/to/private-backup
+sqlite3 /absolute/path/to/live/oonfeewrt.db \
+  ".backup '/absolute/path/to/private-backup/oonfeewrt.db'"
+cp -p /absolute/path/to/live/keyring.json \
+  /absolute/path/to/private-backup/keyring.json
+
+OONFEE_PASSPHRASE_FILE=/absolute/path/to/mode-600-passphrase \
+  oonfeewrt-recoverycheck /absolute/path/to/private-backup/oonfeewrt.db
+```
+
+Do not copy only the live main SQLite file while WAL mode is active.
+
+## Exit behavior
+
+- Normal `-version`, successful `-healthcheck`, and clean daemon shutdown exit
+  successfully.
+- Configuration, startup, listener, passphrase, or healthcheck failures print
+  an `oonfeewrtd:` error to standard error and exit non-zero.
+- `oonfeewrt-recoverycheck` exits `2` for invocation/path errors and `1` when
+  the selected recovery pair fails validation.
+
+See [Requirements](./requirements.md), [Data and retention](../concepts/data-retention.md),
+and [Troubleshooting](./troubleshooting.md).

--- a/docs/reference/engineering.md
+++ b/docs/reference/engineering.md
@@ -1,0 +1,303 @@
+---
+title: Engineering reference
+description: Repository layout, build/test commands, invariants, evidence, and release workflow for oonfeeWRT contributors.
+---
+
+# Engineering reference
+
+This page orients contributors to the **v0.1.1** codebase. The repository's
+long-form specifications remain authoritative for invariants and measured
+hardware behavior.
+
+## Toolchain
+
+| Layer | Current choice |
+|---|---|
+| Go | Module declares Go 1.25 semantics and pins toolchain `go1.26.6` |
+| Database | Pure-Go `modernc.org/sqlite`; cgo is not used |
+| HTTP | Standard-library `net/http` pattern mux |
+| WebSocket | `github.com/coder/websocket` |
+| Secrets | Argon2id and XChaCha20-Poly1305 through `golang.org/x/crypto` |
+| UI | React 19, TypeScript 5.9, Vite 7 |
+| Charts | uPlot |
+| Tests | Go test/race/vet; Vitest; Playwright browser tests |
+| Release runtime | Static Go binary; non-root `scratch` container |
+
+Use Go **1.26.6** and Node.js **22** to match release and CI.
+
+## Repository map
+
+```text
+cmd/oonfeewrtd/          flags, environment, logging, signals, healthcheck
+internal/api/            REST, WebSocket, auth/RBAC, jobs and operation admission
+internal/ubus/           OpenWrt JSON-RPC transport and typed decoding
+internal/adoption/       bounded SSH bootstrap/cleanup transport
+internal/capability/     per-device probing, defects and capability diffing
+internal/model/          validated site, function, zone, policy and observability models
+internal/render/         deterministic site intent → per-device UCI operations
+internal/applyengine/    preview/apply/verify/confirm state machine
+internal/collector/      polling, snapshots and collection scheduling
+internal/telemetry/      counter deltas and experience calculations
+internal/topology/       route/FDB/neighbor/association/LLDP graph inference
+internal/store/          SQLite schema, migrations, queries, retention and recovery
+internal/secrets/        keyring, sealing and password hashing
+internal/diagnostics/    bounded, redacted stored-evidence bundle generation
+internal/portablebackup/ encrypted portable-backup format
+internal/controllerrestore/ staged restore validation/preparation
+internal/restoreswap/    crash-safe live-state replacement and suppression
+ui/src/components/       shared accessible controls, grids and charts
+ui/src/screens/          product workspaces
+ui/src/lib/              API client, WebSocket client, columns and tokens
+deploy/                  Dockerfile, Compose, ACL template and release contracts
+tools/                   probes, mocks, release checks, recovery helper, secret scans
+docs/                    user documentation, architecture, evidence and specifications
+```
+
+Use the code as the final source of truth for behavior, but preserve the reasons
+recorded in [`ARCHITECTURE.md`](../ARCHITECTURE.md),
+[`IMPLEMENTATION.md`](../IMPLEMENTATION.md), and
+[`DEVICE-BUDGET.md`](../DEVICE-BUDGET.md). When hardware evidence contradicts
+an assumption, update the implementation and documentation together.
+
+## Build and test
+
+### Fast local gates
+
+```sh
+make check
+```
+
+`make check`:
+
+1. installs UI dependencies and builds the embedded UI;
+2. verifies Go modules and checks `go mod tidy -diff`;
+3. runs all normal Go tests;
+4. runs `go vet`;
+5. runs UI unit tests;
+6. enforces the gzipped UI bundle budget; and
+7. scans the working tree for repository-specific secret patterns.
+
+It does not run the Go race detector, Playwright suite, `govulncheck`, full
+history secret scan, reproducible-build check, or physical-router tests. CI and
+release gates add those.
+
+### Individual commands
+
+```sh
+npm --prefix ui ci
+npm --prefix ui test
+npm --prefix ui run build
+go test -count=1 ./...
+go vet ./...
+```
+
+Browser suite:
+
+```sh
+npm --prefix ui run test:browser:install
+npm --prefix ui run test:browser
+```
+
+Race suite:
+
+```sh
+go test -race -count=1 ./...
+```
+
+Build a host binary:
+
+```sh
+make build
+./oonfeewrtd -version
+```
+
+The UI must be built before the Go binary so `ui/dist` can be embedded. A
+`.gitkeep` lets Go compile a development binary without a built app, but such a
+binary serves the API with an explicit “no UI embedded” log and is not a release
+artifact.
+
+## Local development
+
+Run the controller on loopback:
+
+```sh
+make build
+./oonfeewrtd \
+  -data-dir "$PWD/.run" \
+  -listen 127.0.0.1:8080
+```
+
+In another terminal, the Vite development server proxies `/api` to
+`127.0.0.1:8080`:
+
+```sh
+npm --prefix ui run dev
+```
+
+Use disposable state for development. Never point tests or dev helpers at a
+production data directory unless the helper explicitly documents a read-only
+boundary and you have a verified backup.
+
+## Core invariants
+
+### No controller code on routers
+
+The controller may call stock ubus/rpcd methods and, after explicit approval,
+manage one ACL/login plus separately planned official-feed capabilities. It
+must not ship an oonfeeWRT daemon, executable, firmware, cron job, init script,
+or package feed to routers.
+
+### Capability evidence is tri-state-plus
+
+Unknown, unavailable, stale, partial, observed-empty, and observed data are not
+interchangeable. Decoders retain field presence; UI/API changes must not turn a
+failed or absent source into a real zero/false/empty collection.
+
+### Foreign UCI is read-only
+
+Render/apply/cleanup operates only on controller-owned sections. A conflicting
+foreign section is a gate. Ownership and cleanup tests are security and data-loss
+tests, not formatting tests.
+
+### Preview does not authorize a changed plan
+
+Apply authorization is bound to rendered desired state, fleet, capabilities,
+and acknowledgements. Full-fleet preflight occurs before the first write.
+Durable operation state must survive browser cancellation/reload without
+reissuing the mutation.
+
+### OpenWrt rollback is part of correctness
+
+Once Apply is staged, the engine must continue through health/confirm or a
+proved rollback outcome. Shutdown must not close the database or exit under an
+in-flight critical Apply merely to stop quickly.
+
+### Secrets never become ordinary strings at boundaries
+
+The runtime passphrase is prompted or read from a protected file, never accepted
+as an environment value. Device administrator credentials are ephemeral.
+Authenticated WLAN/mesh reads expose `has_key`, not secret values. Diagnostic,
+backup, event, log, and error paths have explicit redaction/size tests.
+
+### SQLite backups are paired and consistent
+
+Never copy a live WAL main file alone. Recovery requires a consistent database,
+matching sibling keyring, and passphrase. Restore validates disposable state
+before replacement and activates a durable router-write fence.
+
+## Test layers
+
+| Layer | Primary proof |
+|---|---|
+| Models/rendering | Table/golden/property tests for validation, deterministic output, and ownership |
+| ubus/capability | Mock JSON-RPC, bounded decoders, denial/session behavior, hardware defect fixtures |
+| Apply engine | State-machine and integration tests for preflight, rollback, confirmation, cancellation, restart receipts |
+| Store | Schema attestation, migration, retention, recovery, WAL snapshot, concurrency/integrity tests |
+| API/auth | `httptest`, complete route-role matrix, CSRF/session/step-up/race tests |
+| UI | Vitest component/screen tests plus Playwright dark/light, desktop/narrow-width and keyboard coverage |
+| Packaging | Release-contract, archive, container-smoke, signature/provenance and reproducibility checks |
+| Hardware | Operator-authorized integration tests and published fresh-start evidence |
+
+`tools/mock_ubus.py` models staged versus committed UCI, Apply rollback/confirm,
+session behavior, and known driver defects. It is a contract fixture, not proof
+that an arbitrary physical router behaves the same.
+
+## Hardware tests are opt-in
+
+Integration tests use explicit environment gates such as `OONFEE_TEST_*`; tests
+that can write a router require a dedicated opt-in variable. Do not run a broad
+`-tags=integration` command against production credentials without reading the
+target test first.
+
+The release resource gate is the 60-minute class-C harness documented in
+[`DEVICE-BUDGET.md`](../DEVICE-BUDGET.md). Its preferred mode opens a current
+controller database/keyring read-only to obtain the scoped credential, while
+separate root SSH reads measure whole-device resources and flash evidence. It
+must run on an otherwise idle, explicitly selected lab router.
+
+Published physical behavior and accepted gaps live in
+[`FRESH-START-VALIDATION.md`](../FRESH-START-VALIDATION.md). Do not promote a
+source-only pass to “hardware verified.”
+
+## UI constraints
+
+- The static output is embedded, so Vite uses relative asset paths.
+- The total JS/CSS/HTML bundle ceiling is 1.5 MiB gzipped.
+- Dark and light themes are separate validated token sets.
+- Warnings, authorization, and Apply safety details remain inline; passive
+  explanations may use progressive disclosure.
+- Keyboard focus, readable status without color alone, correct table semantics,
+  and narrow-width behavior are release gates.
+- Virtualized grids must disclose that browser find sees rendered rows only.
+
+See [`UI-SPEC.md`](../UI-SPEC.md) before changing visual tokens, charts, grids,
+or Apply interaction.
+
+## CI and release
+
+Pull requests and main-branch pushes run:
+
+- Go module verification, tests, vet, and `govulncheck`;
+- the full Go race suite;
+- UI unit/browser tests, dependency audit, production build, and bundle budget;
+- reproducible release archive and container restore smoke checks;
+- multi-platform container build without publishing; and
+- tree/history secret scans.
+
+A `v*` tag triggers the release workflow. It requires strict SemVer on `main`,
+repeats the complete gates at the tagged SHA, builds reproducible Linux/macOS
+amd64/arm64 archives, builds and publishes the linux/amd64+arm64 OCI image,
+attaches SBOM/provenance, signs the immutable digest with GitHub Actions OIDC,
+verifies public aliases, and finally publishes the GitHub release.
+
+Use:
+
+```sh
+make release-check RELEASE_VERSION=v0.1.1
+```
+
+only from the exact intended clean release tree. A local build from another
+commit is not the published release even if its version string is changed.
+
+## Documentation and evidence discipline
+
+Build the documentation site before submitting a content change:
+
+```sh
+npm --prefix docs ci
+npm --prefix docs audit --audit-level=high
+npm --prefix docs run build
+```
+
+For a local authoring server:
+
+```sh
+npm --prefix docs run dev
+```
+
+VitePress checks internal links during the production build. Also inspect the
+changed pages in both themes and at desktop and narrow widths; a successful
+Markdown render does not prove a table, callout, or navigation label remains
+usable on mobile.
+
+- User docs describe released behavior, not roadmap intent.
+- Name the exact release and evidence status.
+- Separate source-tested, simulated, hardware-verified, and unavailable claims.
+- Include prerequisites, expected result, verification, and recovery for every
+  operation that can change routers or controller recovery state.
+- Do not paste live credentials, SSIDs, addresses, tokens, database/keyring
+  files, or unredacted diagnostics into examples.
+- Run `./tools/secret-scan.sh` before committing and treat any historical secret
+  as compromised even after removing it from the current tree.
+
+## Key documents
+
+- [Architecture concept](../concepts/architecture.md)
+- [Safety model](../concepts/safety.md)
+- [Implementation specification](../IMPLEMENTATION.md)
+- [Device resource budget](../DEVICE-BUDGET.md)
+- [UI specification](../UI-SPEC.md)
+- [Feature parity/evidence](../PARITY-MATRIX.md)
+- [Fresh-start hardware validation](../FRESH-START-VALIDATION.md)
+- [Risk register](../RISKS.md)
+- [Roadmap](../ROADMAP.md)

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -1,0 +1,217 @@
+---
+title: Frequently asked questions
+description: Direct answers about deployment, router changes, compatibility, security, backup, and current limits.
+---
+
+# Frequently asked questions
+
+Answers below describe **oonfeeWRT v0.1.1**.
+
+## What is oonfeeWRT?
+
+It is a self-hosted controller for stock OpenWrt. It provides one interface for
+fleet visibility, site configuration, safe Apply/rollback, topology, clients,
+radios, events, accounts, diagnostics, and controller backup/restore.
+
+## Is oonfeeWRT firmware?
+
+No. It does not build, replace, patch, or upgrade OpenWrt firmware. Managed
+routers stay on stock OpenWrt and continue to work with LuCI.
+
+## Does the controller run on a router?
+
+No supported release does. Run the controller on a 64-bit Linux or macOS host,
+NAS, mini-PC, SBC, server, or Docker host. OpenWrt-hosted operation is not built,
+packaged, tested, or budgeted.
+
+## Is Docker required?
+
+No. The standalone binary and container run the same controller and embedded
+UI. Release binaries support Linux/macOS on amd64/arm64; the image supports
+Linux amd64/arm64.
+
+## Does it require the cloud?
+
+No. Controller state and accounts are local. Remote sites require an existing
+routed management network or VPN; oonfeeWRT does not provide cloud relay or NAT
+traversal.
+
+Internet access is still needed for actions that inherently use it, such as
+downloading releases/images, reaching OpenWrt package feeds for an explicitly
+approved optional capability, or running the Cloudflare speed test.
+
+## Can it manage non-OpenWrt or UniFi devices?
+
+No. Its transport, capability model, and renderer target OpenWrt. It does not
+implement vendor inform protocols or proprietary device APIs.
+
+## Does adoption install software on my router?
+
+Adoption never installs a package, executable, daemon, service, firmware, or
+custom controller code. With explicit default-off consent, it creates/replaces
+one rpcd ACL JSON file and creates one scoped `oonfeewrt` login.
+
+The optional LLDP capability is a separate workflow. It may install official
+OpenWrt feed packages only after showing and binding an exact plan to separate
+acknowledgements.
+
+## Why does adoption ask for SSH?
+
+Stock rpcd cannot create its own scoped login or write an ACL file through ubus,
+even when the ubus caller is root. SSH is therefore used for the approved
+bootstrap transaction. Normal polling and configuration use scoped ubus.
+
+The device administrator credential is used for the transaction and is not
+stored.
+
+## Can I keep using LuCI and SSH?
+
+Yes. oonfeeWRT writes only sections it owns and leaves foreign/human-managed
+sections alone. If a foreign section conflicts with desired state, Preview
+blocks or reports the conflict instead of silently taking it over.
+
+Avoid editing the same controller-owned section simultaneously through LuCI.
+Finish or abandon one change path, then generate a fresh Preview.
+
+## Does saving a WLAN or network immediately change routers?
+
+No. Saving changes controller desired state only. Preview computes exact
+per-device changes; Apply is a separate reviewed action.
+
+## What happens if Apply breaks connectivity?
+
+oonfeeWRT stages UCI with OpenWrt rollback enabled. It confirms only after
+reconnecting and verifying expected runtime state. If connectivity or health
+verification fails, the router's rollback timer is left to restore the previous
+state.
+
+Keep independent LuCI/SSH access and start with one non-critical device. See the
+[Safety model](../concepts/safety.md).
+
+## Does it support every OpenWrt device?
+
+No universal claim is possible. Hardware, drivers, switch architecture, rpcd
+modules, and package sets vary. The controller probes each device and reports
+unsupported, unavailable, stale, and partial facts.
+
+The stable release's published physical record covers a Linksys WRT3200ACM and
+TP-Link Archer C6 v2 on OpenWrt 25.12.5. It came from the pre-stable/RC workflow
+underlying v0.1.1; the patch release did not rerun the whole procedure. Other
+devices may work with different gaps.
+
+## Why are some values “Unavailable” instead of zero?
+
+Zero is a measurement. Unavailable means the controller could not obtain or
+trust the measurement. Treating a missing driver counter or failed RPC as zero
+would produce confident but false charts and health claims.
+
+## Why is an online device “Unplaced” in Topology?
+
+Online proves controller reachability. It does not prove a current physical
+parent. Dynamic FDB or neighbor evidence can expire, and some stock BusyBox
+sources omit VLAN/port identity. The graph refuses to invent a link.
+
+Optional LLDP can provide stronger managed adjacency, at the cost of an
+explicit official-package/service workflow.
+
+## Does RF scanning run automatically?
+
+No. A serving-radio scan can disrupt clients, so it requires an explicit
+acknowledgement and is never scheduled. Capability refresh/re-probe does not run
+a scan.
+
+## Where does the speed test run?
+
+From the controller host or container through Cloudflare. It does not call or
+modify a router, but its traffic follows the normal WAN path. The test uses
+about 15 MiB, is bounded to 30 seconds, and can temporarily saturate the WAN.
+
+Gateway-run testing, loaded latency, and loaded jitter are unavailable in
+v0.1.1.
+
+## Does the controller have HTTPS?
+
+Not natively in v0.1.1. Bind it to loopback or a trusted isolated management
+LAN and use a trusted reverse proxy for TLS. Do not expose port 8080 directly to
+the Internet.
+
+## What account roles are available?
+
+Owner, Administrator, Operator, and Read-only. Owners manage accounts and
+portable backup/restore; Administrators manage devices/configuration and
+diagnostics; Operators run approved operational tests; Read-only users view
+state. See [Permissions](../concepts/permissions.md).
+
+## Where are credentials stored?
+
+Router and Wi-Fi credentials are sealed in SQLite using a random data key from
+`keyring.json`. The runtime passphrase unwraps that key. The device
+administrator credential supplied for bootstrap/cleanup is not stored.
+
+Authenticated WLAN/mesh reads report only whether a key exists; there is no
+reveal endpoint.
+
+## What must I back up?
+
+For filesystem recovery:
+
+- a consistent `oonfeewrt.db` snapshot;
+- its exact sibling `keyring.json`; and
+- the runtime passphrase/passphrase file, kept separately.
+
+The database, keyring, and passphrase cannot recreate one another. Do not copy
+only a live WAL-mode database main file.
+
+Alternatively, an Owner can export encrypted `.oowrtbak` controller state with
+a separate export passphrase. See [Data and retention](../concepts/data-retention.md).
+
+## Does portable restore change routers?
+
+No router is contacted or automatically configured during restore. Successful
+restore restarts the controller, revokes sessions, creates a pre-restore safety
+artifact, and suppresses router writes until an Owner reviews state and types
+`RESUME ROUTER WRITES` after reauthentication.
+
+## What is in a diagnostics bundle?
+
+Bounded stored controller evidence: controller health/version/schema, stored
+device model/firmware/capability facts, coverage state, bounded events, and a
+redacted controller-log tail. Generation makes zero live router management
+calls.
+
+It excludes passwords, password hashes, sessions/CSRF tokens, router
+credentials, Wi-Fi keys, private keys/certificates, raw database/keyring, client
+notes, and fixed-address assignments.
+
+## How long is history kept?
+
+Defaults include five-minute metrics for 14 days, hourly metrics for 396 days,
+OpenWrt logs for 24 hours, closed topology intervals for 31 days, 100,000
+controller/audit events, and the newest three terminal speed tests. See the
+complete [retention table](../concepts/data-retention.md).
+
+## Can I downgrade from v0.1.1?
+
+v0.1.1 and v0.1.0 both use schema 19, so a clean binary/image rollback is
+schema-compatible; preserve the v0.1.1 data pair first.
+
+Historical `v0.1.0-rc.1` uses schema 17. Rolling back that far requires the
+untouched pre-upgrade schema-17 database, matching keyring, prior passphrase,
+and old binary/image together. Do not open schema-19 data with the RC daemon.
+
+## What is deliberately out of scope?
+
+- controller-authored router agents/daemons;
+- custom firmware, forks, or package feeds;
+- non-OpenWrt device adoption;
+- cloud remote access, SSO brokering, multi-site, and automatic NAT traversal;
+- native mobile apps;
+- continuous proprietary spectrum analysis, paid threat feeds, and branded AI
+  features; and
+- DPI/application flow history on constrained routers in v0.1.1.
+
+## Where should I start?
+
+Read [Requirements](./requirements.md), follow [`INSTALL.md`](../INSTALL.md),
+and adopt one non-critical router. For a failure, use
+[Troubleshooting](./troubleshooting.md) before changing the router manually.

--- a/docs/reference/releases.md
+++ b/docs/reference/releases.md
@@ -1,0 +1,40 @@
+# Release notes
+
+The documentation describes the current patch release, **v0.1.1**. Release
+artifacts, checksums, container digests, signatures, and attached notes on the
+GitHub release are the publication source of truth.
+
+## Current release
+
+- [v0.1.1 release and downloads](https://github.com/aiden0rchad/oonfeeWRT/releases/tag/v0.1.1)
+- [v0.1.1 notes in the repository](https://github.com/aiden0rchad/oonfeeWRT/blob/main/RELEASE-NOTES-v0.1.1.md)
+- [All GitHub releases](https://github.com/aiden0rchad/oonfeeWRT/releases)
+
+## Earlier release
+
+- [v0.1.0 notes](https://github.com/aiden0rchad/oonfeeWRT/blob/main/RELEASE-NOTES-v0.1.0.md)
+
+Before upgrading, read both the release notes and [Upgrade and roll back](../installation/upgrades.md).
+
+## Verify what you run
+
+For a standalone archive, verify its entry in `SHA256SUMS` before extracting
+or installing it. For the OCI image, pin `v0.1.1` or the immutable digest and
+verify the GitHub Actions keyless signature as shown in the [Docker Compose
+guide](../installation/docker.md).
+
+The macOS binary is not Developer ID signed or notarized. A checksum mismatch
+is never an instruction to bypass the check.
+
+## Version and schema boundaries
+
+The daemon prints its build version with:
+
+```sh
+oonfeewrtd -version
+```
+
+The current documentation targets database schema 19. The controller migrates
+supported older state at startup and refuses unsupported downgrades. A rollback
+across a schema boundary restores the matching pre-upgrade database and
+`keyring.json`; changing only the binary or image tag is not a data rollback.

--- a/docs/reference/requirements.md
+++ b/docs/reference/requirements.md
@@ -1,0 +1,222 @@
+---
+title: Requirements and compatibility
+description: Controller host, network, OpenWrt, storage, and security requirements for oonfeeWRT v0.1.1.
+---
+
+# Requirements and compatibility
+
+Use this checklist before installing or adopting a router with **oonfeeWRT
+v0.1.1**.
+
+## Controller host
+
+The controller runs separately from managed routers.
+
+| Installation | Supported release platforms |
+|---|---|
+| Standalone binary | `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64` |
+| Container image | `linux/amd64`, `linux/arm64` |
+
+Running the controller on an OpenWrt router is not supported or packaged. Use an
+always-on 64-bit computer, NAS, mini-PC, SBC, server, or Mac.
+
+Practical starting capacity:
+
+- 1 GiB RAM;
+- 2 GiB free storage; and
+- a persistent local filesystem for the data directory.
+
+The engineering envelope is at most 256 MiB steady-state RSS at 25 devices, 2%
+of one modern CPU core for an idle fleet, and 2 GiB disk at full 13-month metric
+retention. Twenty-five devices is a sizing/evidence target, not a hard adoption
+cap. These are release targets, not a promise that every workload or diagnostic
+export stays below them.
+
+## Managed OpenWrt devices
+
+The documented minimum is OpenWrt **21.02 or newer** with:
+
+- SSH reachable from the controller host for approved bootstrap and cleanup;
+- `rpcd`;
+- `uhttpd`; and
+- the `uhttpd` ubus handler at `/ubus`.
+
+OpenWrt 24.10 and the 25.12 series are the primary current assumptions. Actual
+support is capability-driven because rpcd modules, switch architectures,
+wireless drivers, and board packaging differ.
+
+For adoption, prepare:
+
+- the router's management IP address or resolvable name;
+- an existing device-administrator login, normally `root`;
+- a non-empty router administrator password; and
+- independent LuCI or SSH access for recovery.
+
+A factory-default passwordless root account is unsafe. oonfeeWRT warns rather
+than blocking an explicitly trusted lab device, but production adoption should
+start only after setting a password.
+
+### Capability-dependent OpenWrt components
+
+Base rpcd and netifd provide core authentication, UCI, system, interface, and
+network state. Richer views may depend on existing official OpenWrt components
+such as `rpcd-mod-luci` or `rpcd-mod-iwinfo`, and on hostapd/driver methods.
+
+Missing components are reported as unavailable or unsupported. Adoption does
+not silently install them. The only shipped optional-package workflow is LLDP,
+which separately plans and may install official-feed `lldpd` packages after
+explicit approval. See [Capabilities](./capabilities.md).
+
+## Network reachability
+
+The controller host must be able to reach every router's management address.
+Normal operation is outbound L3 communication from controller to router; remote
+sites therefore need an existing routed management path or VPN.
+
+oonfeeWRT does not provide:
+
+- a cloud relay;
+- automatic NAT traversal;
+- multi-site dial-out agents; or
+- its own VPN.
+
+Use an existing WireGuard or other routed management network for remote sites.
+
+Common ports are:
+
+| Direction | Port/service | Purpose |
+|---|---|---|
+| Browser → controller | TCP 8080 by default | Bare daemon defaults to `:8080` on all interfaces; supplied Compose publishes host loopback only |
+| Controller → router | TCP 22 by default | Explicitly approved SSH bootstrap, cleanup, ACL refresh, or optional capability work |
+| Controller → router | Router `uhttpd` HTTP/HTTPS port | `/ubus` polling and configuration |
+| Controller host → Internet | HTTPS, when used | Operator release/image downloads and the explicitly run Cloudflare speed test |
+| Router → package feed | Feed HTTP/HTTPS port, when used | Package-index/install traffic only during an explicitly approved optional-capability workflow |
+
+Router endpoints may use a non-default port when included in the management
+address. Firewall rules must permit the actual configured endpoint.
+
+## Container networking
+
+The supplied Compose setup uses bridge networking and publishes
+`127.0.0.1:8080:8080`. In bridge mode:
+
+- add-by-address, adoption, polling, and Apply work over normal routed L3;
+- subnet TCP discovery can work where routing permits; and
+- ARP-table and mDNS discovery do not cross the container bridge.
+
+Linux host networking is an explicit opt-in for full local layer-2 discovery.
+Docker Desktop does not provide equivalent true host networking for this use;
+add routers by address. Discovery is a convenience, never an adoption
+requirement.
+
+## Browser-to-controller security
+
+v0.1.1 has no native TLS listener. Choose one of these deployments:
+
+1. bind to `127.0.0.1:8080` and use it only from the host;
+2. keep the controller on loopback and publish it through a trusted TLS reverse
+   proxy; or
+3. deliberately bind it to an isolated, trusted management LAN.
+
+Do not expose port 8080 directly to the Internet. A reverse proxy must preserve
+WebSocket upgrades and `X-Forwarded-Proto: https` so session cookies are marked
+`Secure`. The [installation guide](../INSTALL.md#put-tls-in-front) includes a
+minimal Caddy configuration.
+
+## Persistent data and secrets
+
+The data directory must:
+
+- use an absolute path;
+- be writable by the controller's operating-system user;
+- persist across restarts and container replacement; and
+- remain private (`0700` is recommended).
+
+The controller creates `oonfeewrt.db`, `keyring.json`, and private working
+directories there. Preserve the database and matching keyring together. The
+runtime passphrase must also be recoverable from separate protected storage.
+
+For unattended startup, point `-passphrase-file` or
+`OONFEE_PASSPHRASE_FILE` at a regular file that is not group- or world-readable
+(`0600` is the documented mode). `OONFEE_PASSPHRASE` is intentionally rejected;
+do not put the passphrase value in the environment, Compose file, command line,
+or process arguments.
+
+See [Data and retention](../concepts/data-retention.md) before designing backup
+or volume snapshots.
+
+## Installation artifacts
+
+For v0.1.1:
+
+- download release archives and `SHA256SUMS` from the v0.1.1 GitHub release;
+- reject any checksum mismatch;
+- note that macOS binaries are not Developer ID signed or notarized; and
+- verify the OCI image's keyless signature before first use where `cosign` is
+  available.
+
+The immutable image is `ghcr.io/aiden0rchad/oonfeewrt:v0.1.1`. Stable aliases
+exist, but deployments should pin the exact version or digest.
+
+## Source-build requirements
+
+Building is not required to run a release. To build the repository:
+
+- Go toolchain **1.26.6** (declared by `go.mod`);
+- Node.js **22**;
+- npm; and
+- a POSIX shell for repository scripts.
+
+Container image builds additionally require Docker Buildx. Browser tests need
+the pinned Playwright Chromium installed by `npm --prefix ui run
+test:browser:install`.
+
+See [Engineering reference](./engineering.md).
+
+## Verified hardware boundary
+
+The stable release's published hardware record covers:
+
+- Linksys WRT3200ACM; and
+- TP-Link Archer C6 v2;
+
+both on OpenWrt 25.12.5. Three-or-more-AP fan-out, real mesh backhaul, wireless
+uplink, MT7621, and MT7981/Filogic remain unverified for the release. The Archer
+C6 v2 also passed the full 60-minute class-C polling/resource budget harness.
+The record was produced through the pre-stable/RC workflow that underlies
+v0.1.1; the patch release did not rerun the complete hardware procedure, and
+its router-operation code was unchanged.
+
+This is evidence, not an allow-list. Another OpenWrt device may work, partially
+work, or expose driver-specific gaps. Adopt one non-critical device first and
+read its capability report.
+
+## Pre-adoption checklist
+
+- [ ] Controller runs `v0.1.1` (`oonfeewrtd -version`).
+- [ ] Data directory and matching passphrase backup are protected.
+- [ ] Controller healthcheck passes.
+- [ ] Browser access is loopback-only, trusted-LAN-only, or behind trusted TLS.
+- [ ] Controller host reaches router SSH and `/ubus` endpoints.
+- [ ] Router runs supported OpenWrt with `rpcd` and the `uhttpd` ubus handler.
+- [ ] Router administrator password is set.
+- [ ] OpenWrt configuration backup exists.
+- [ ] Independent LuCI/SSH recovery path is available.
+- [ ] The first target is non-critical.
+- [ ] You understand the access payload and will review capability gaps before
+      Apply.
+
+## Verify the controller host
+
+```sh
+oonfeewrtd -version
+oonfeewrtd \
+  -listen 127.0.0.1:8080 \
+  -healthcheck
+```
+
+The healthcheck must exit successfully and the running controller's `/healthz`
+body must be exactly `ok`. Then sign in, open **Devices**, and use read-only
+Inspect before authorizing adoption.
+
+For failures, use [Troubleshooting](./troubleshooting.md).

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -1,0 +1,336 @@
+---
+title: Troubleshooting
+description: Symptom-based diagnosis, verification, and recovery for oonfeeWRT v0.1.1.
+---
+
+# Troubleshooting
+
+Start with the smallest read-only check that separates controller, network,
+credential, capability, and router-state failures. Do not retry a router write
+until you know the previous operation's terminal state.
+
+## First five checks
+
+1. Confirm the executable version:
+
+   ```sh
+   oonfeewrtd -version
+   ```
+
+   Expected for this guide: `v0.1.1`.
+
+2. Check controller liveness using the same listener configuration as the
+   running process:
+
+   ```sh
+   oonfeewrtd -listen 127.0.0.1:8080 -healthcheck
+   ```
+
+3. Read controller logs. For a container:
+
+   ```sh
+   docker logs --tail 200 oonfeewrt
+   ```
+
+4. Confirm the data directory, keyring, and passphrase file still refer to the
+   same controller.
+5. If the controller runs but fleet data is wrong, open the relevant device and
+   read its freshness, source coverage, and capability gaps before changing it.
+
+## Controller does not start
+
+### `data directory ... must be an absolute path`
+
+Use an absolute path:
+
+```sh
+oonfeewrtd -data-dir /absolute/path/to/oonfeewrt-data
+```
+
+This guard prevents an unexpected working directory from creating a second
+empty controller.
+
+### `listen ... address already in use`
+
+Another process owns the configured address. Stop the duplicate controller or
+choose a different listener. Make the same change in the healthcheck, reverse
+proxy, and container mapping. Do not start two controllers against the same
+data directory.
+
+### `OONFEE_PASSPHRASE is set`
+
+Remove that environment value and put the passphrase in a protected file:
+
+```sh
+unset OONFEE_PASSPHRASE
+chmod 600 /absolute/path/to/passphrase
+export OONFEE_PASSPHRASE_FILE=/absolute/path/to/passphrase
+```
+
+### Passphrase file is not accepted
+
+Check that it is a non-empty regular file, readable by the daemon user, and not
+group/world-readable:
+
+```sh
+ls -l /absolute/path/to/passphrase
+chmod 600 /absolute/path/to/passphrase
+```
+
+For the supplied container, the file must be readable by UID `65532` unless the
+container is explicitly run as another UID/GID.
+
+### Wrong passphrase or keyring error
+
+Stop. Do not delete `keyring.json` or let the controller initialize a new data
+directory beside the existing database. A new keyring cannot decrypt existing
+credentials.
+
+Restore the exact matching set:
+
+- `oonfeewrt.db`;
+- sibling `keyring.json`; and
+- the passphrase/passphrase file that opens that keyring.
+
+Validate an isolated copy with [the recovery helper](./cli.md#oonfeewrt-recoverycheck).
+
+## Healthcheck fails but the process appears to run
+
+`-healthcheck` probes the listener passed through `-listen` or
+`OONFEE_LISTEN`; it does not discover another process's flags. Use the same
+address/port as the running controller. If a reverse proxy is healthy but the
+direct check fails, diagnose the controller listener before the proxy.
+
+The check expects HTTP 200 and body exactly `ok` within four seconds. It does
+not require the passphrase or open the database, so a successful healthcheck is
+only HTTP liveness—not proof that sign-in, storage, or routers work.
+
+## Browser cannot connect or repeatedly returns to sign-in
+
+1. Verify `/healthz` directly from the browser host.
+2. Check that the proxy forwards ordinary HTTP and WebSocket upgrades.
+3. For TLS termination, preserve `X-Forwarded-Proto: https` so Secure cookies
+   are issued correctly.
+4. Do not mix access through an IP address and DNS hostname; cookies are scoped
+   to a host/domain and path. Keep scheme, host, and port consistent as well,
+   because the controller separately enforces same-origin checks on mutations.
+5. Remember that sessions are intentionally lost on controller restart and
+   expire after 12 idle hours or seven absolute days.
+
+If a password was changed, account disabled/deleted, role changed, or session
+revoked, signing out is expected. Ask an Owner to inspect the account/session
+state rather than repeatedly attempting credentials.
+
+## Discovery finds no routers
+
+The default container bridge does not carry LAN ARP or mDNS. This is expected,
+not a router failure.
+
+- Use **Adopt a device → add by address**.
+- Ensure the container host can route to the management IP.
+- On Linux only, opt into host networking if layer-2 discovery is required and
+  you accept the listener/firewall implications.
+- On Docker Desktop, use add-by-address.
+
+Discovery is not required for adoption, polling, or Apply.
+
+## Inspect or adoption cannot reach a router
+
+From the controller host, verify:
+
+- the management address is correct;
+- SSH is reachable on the configured/default port;
+- `uhttpd` exposes the ubus handler;
+- the supplied device administrator username/password works;
+- a firewall or management VLAN is not blocking the controller; and
+- the address does not point to a different device.
+
+Inspect is read-only. Use it to confirm model, firmware, interface, and
+capability facts before authorizing adoption. Do not weaken router authentication
+or expose SSH publicly to make the check pass.
+
+### SSH host key or device fingerprint changed
+
+Treat an unexpected identity change as a security event or device replacement.
+Verify the current key/fingerprint through an independent trusted path such as
+local LuCI, physical access, or a known console. Re-adopt only after establishing
+why it changed (for example, a deliberate reflash). Never accept the change
+blindly.
+
+## A feature says unavailable, unsupported, partial, or stale
+
+These states mean different things:
+
+- **unsupported/unavailable:** the router, driver, package, or ACL did not
+  expose the fact;
+- **partial:** some sources answered, but not enough for a complete claim;
+- **stale:** prior evidence exists but a current poll did not refresh it;
+- **empty:** a source answered successfully with no rows.
+
+Use **Re-probe capabilities** after an intentional firmware/package/ACL change.
+Read the exact source reason. Do not install packages manually merely to remove
+an unavailable badge; adoption promises not to do that, and optional capability
+state needs a recorded plan and rollback.
+
+## Preview is blocked
+
+Read the named gate. Common causes include:
+
+- a device is unreachable;
+- capability evidence is missing or stale;
+- a foreign/human-managed section conflicts with desired state;
+- uncommitted router edits are present;
+- the change touches the controller's management path;
+- hardware/driver facts do not prove a requested option; or
+- the Preview was generated for older desired/router state.
+
+Resolve the condition and generate a fresh Preview. A prior preview/acknowledgement
+does not authorize a changed plan.
+
+## Apply failed or its outcome is uncertain
+
+Do not click Apply again immediately.
+
+1. Read the durable operation and per-device receipt.
+2. Wait through the displayed OpenWrt rollback window.
+3. Test the management address from the controller host.
+4. Use independent LuCI/SSH access to inspect pending UCI and named owned
+   sections.
+5. Determine whether OpenWrt reverted or the controller confirmed.
+6. After the device is stable, generate a new Preview.
+7. Download diagnostics if evidence remains unclear.
+
+The operation continues independently of the browser request. A reload should
+read status, not duplicate the write. See [Safety model](../concepts/safety.md#recovery-after-an-uncertain-apply).
+
+## Device is online but topology shows “Unplaced”
+
+Online status proves controller reachability, not a current physical parent.
+Dynamic bridge FDB/neighbor evidence can age out, and BusyBox FDB output may not
+identify VLAN provenance. The topology deliberately avoids inventing a link.
+
+Check source coverage and last-observed times. If durable physical adjacency is
+worth a router package/service, review the optional LLDP plan. Do not install
+`lldpd` outside the controller and then expect its rollback ledger to be
+accurate.
+
+## Charts are initially empty after startup or adoption
+
+Many charts use completed five-minute rollups. A current poll can prove a
+device is online before the first complete durable bucket exists. Counter-based
+metrics also need a baseline and a later sample before a delta is meaningful.
+
+Wait for a complete collection window and check source freshness. Do not
+interpret missing points as zero traffic, zero utilization, or zero clients.
+
+## RF scan cannot run or has no suggestion
+
+A scan requires the selected radio/source capability, fresh identity, and an
+explicit disruption acknowledgement. It may take the serving radio off-channel
+and is never scheduled automatically.
+
+A channel suggestion additionally requires:
+
+- a completed scan no older than 24 hours;
+- non-stale radio state; and
+- a channel plan observed within 15 minutes.
+
+An ACL refresh or capability probe does not run a scan. The published hardware
+evidence includes one explicitly authorized C6 5 GHz scan (14 BSS entries,
+suggested channel 44); it does not authorize future scans or prove identical
+behavior on another radio.
+
+## WRT3200ACM configuration is present but no BSS comes on air
+
+The published Marvell 88W8964/mwlwifi evidence found that WPA3/SAE and PMF can
+wedge the radio until a physical cold power cycle. A valid UCI section or
+reported-enabled interface is not independent on-air proof.
+
+Inspect OpenWrt logs for missing `AP-ENABLED`/hostapd failures, let any active
+rollback finish, then use a known-safe configuration. The demonstrated boundary
+was WPA2-only, PMF disabled, FT disabled, and 802.11k/v enabled after cold boot.
+Do not manufacture repeated Applies while the radio is wedged.
+
+## Controller-host speed test fails or affects users
+
+The test runs from the controller/container through Cloudflare, not from a
+router. It can use about 15 MiB and temporarily saturate the WAN for up to 30
+seconds. Only one test may be active.
+
+- Wait for or cancel the active job before starting another.
+- Verify the controller host/container has HTTPS and DNS access to the provider.
+- Run during a quiet period if saturation affects clients.
+- Do not interpret the result as router-local forwarding performance.
+- Loaded latency and jitter are unavailable in v0.1.1.
+
+## Diagnostics or backup download expired
+
+Completed diagnostics and backup-export downloads expire after 15 minutes.
+Restore upload/preview working state expires after 30 minutes. Start a new job;
+do not search temporary controller directories for an expired artifact.
+
+Diagnostics makes no live router call. Portable backup contains sensitive
+controller state and should be transferred only over loopback or trusted TLS.
+
+## Recovery helper rejects a backup
+
+`oonfeewrt-recoverycheck` requires a current-schema, isolated database with its
+exact sibling keyring. Common failures:
+
+- `OONFEE_PASSPHRASE_FILE` is missing, unreadable, or wrong;
+- `keyring.json` is absent or belongs to another snapshot;
+- the database or keyring is a symlink;
+- a non-empty `-wal` or `-journal` indicates an unsafe/incomplete copy; or
+- the database schema is older/newer than the helper supports.
+
+Create a consistent SQLite `.backup` or stop the controller cleanly before
+copying. Never “repair” the pair by deleting sidecars from the live controller;
+work on an isolated copy and preserve the originals.
+
+## Router writes remain suppressed after restore
+
+This is expected. Read-only monitoring may resume, but restored desired state
+is not automatically Applied. An Owner must:
+
+1. inspect the restored devices, credentials, WLANs, networks, policies, and
+   operation history;
+2. reauthenticate with the current controller account password;
+3. understand that automatic 802.11k neighbour maintenance resumes too; and
+4. enter exact `RESUME ROUTER WRITES` for the matching restore.
+
+Do not remove the gate merely to clear the banner.
+
+## Un-adoption is blocked
+
+An optional LLDP capability ledger may still own packages/configuration/service
+state. Review and complete its rollback first. This prevents un-adoption from
+orphaning package residue.
+
+If the router is permanently lost, forced controller removal may be the only
+remaining inventory action. Preserve the exact manual cleanup recipe and audit
+record; forced removal cannot prove the inaccessible router is clean.
+
+## Upgrade or rollback trouble
+
+v0.1.1 and v0.1.0 both use schema 19. A clean binary/image rollback from
+v0.1.1 to v0.1.0 is schema-compatible, but keep the v0.1.1 data pair first.
+
+Rollback to historical `v0.1.0-rc.1` is different: that daemon uses schema 17
+and must not open schema-19 state. Stop the controller and restore the untouched
+pre-upgrade schema-17 database, matching keyring, passphrase file, and old
+binary/image together. Migration/rollback does not revert router configuration.
+
+## Escalation bundle
+
+Before reporting a problem, collect:
+
+- exact `oonfeewrtd -version` output;
+- installation method and host platform;
+- controller logs around the event;
+- affected router model and OpenWrt version;
+- the UI's capability/source reason and timestamps;
+- the durable Apply/scan/speed-test/backup/restore job ID if relevant; and
+- a freshly generated redacted diagnostics ZIP.
+
+Do not include the database, keyring, passphrase, router administrator password,
+Wi-Fi key, session cookies, or unredacted private logs in a public issue.

--- a/internal/store/rollup_test.go
+++ b/internal/store/rollup_test.go
@@ -44,7 +44,7 @@ func TestWriteRollupsCreatesSeriesOnce(t *testing.T) {
 	db := open(t)
 	seedDevices(t, db, 1)
 
-	base := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC).Unix()
+	base := time.Now().UTC().Add(-time.Hour).Truncate(5 * time.Minute).Unix()
 	in := rows(1, "iface_rx_bps", "eth0", base,
 		[4]float64{100, 50, 150, 12},
 		[4]float64{200, 100, 300, 12})
@@ -141,7 +141,7 @@ func TestWriteRollupsIsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	db := open(t)
 	seedDevices(t, db, 1)
-	base := time.Date(2026, 8, 13, 0, 0, 0, 0, time.UTC).Unix()
+	base := time.Now().UTC().Add(-time.Hour).Truncate(5 * time.Minute).Unix()
 	in := rows(1, "sys_load1", "", base, [4]float64{1, 1, 1, 5})
 
 	for range 3 {


### PR DESCRIPTION
## Summary
- add a detailed VitePress documentation portal covering setup, capabilities, operations, safety, troubleshooting, and engineering reference
- add responsive light/dark themes, local search, clean navigation, and accessible styling
- link the portal from README and deploy it through GitHub Pages

## Validation
- npm --prefix docs ci
- npm --prefix docs audit --audit-level=high
- npm --prefix docs run build
- all 40 generated routes return HTTP 200
- make check
- desktop/mobile light/dark browser QA