### PR TITLE
ci: make dependency audit reliable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,8 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: ui/package-lock.json
+      - name: Use supported npm audit client
+        run: npm install --global npm@11.6.4
       - name: Build and verify archives
         run: |
           ./tools/reproducible-build-check.sh v0.0.0-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,18 +75,18 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: ui/package-lock.json
-      - name: Use supported npm audit client
+      - name: Use pinned npm client
         run: npm install --global npm@11.6.4
       - name: Install dependencies
-        run: npm --prefix ui ci
+        run: npm --prefix ui ci --no-audit
+      - name: Audit dependencies
+        run: ./tools/osv-audit.sh ui/package-lock.json
       - name: Install pinned browser
         run: npm --prefix ui run test:browser:install
       - name: Test
         run: |
           npm --prefix ui test
           npm --prefix ui run test:browser
-      - name: Audit dependencies
-        run: npm --prefix ui audit --audit-level=high
       - name: Build
         run: npm --prefix ui run build
       - name: Check bundle budget
@@ -113,7 +113,7 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: ui/package-lock.json
-      - name: Use supported npm audit client
+      - name: Use pinned npm client
         run: npm install --global npm@11.6.4
       - name: Build and verify archives
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: ui/package-lock.json
+      - name: Use supported npm audit client
+        run: npm install --global npm@11.6.4
       - name: Install dependencies
         run: npm --prefix ui ci
       - name: Install pinned browser

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
       - "docs/**"
       - "README.md"
       - ".github/workflows/docs.yml"
+      - "tools/osv-audit.sh"
   push:
     branches:
       - main
@@ -13,6 +14,7 @@ on:
       - "docs/**"
       - "README.md"
       - ".github/workflows/docs.yml"
+      - "tools/osv-audit.sh"
   workflow_dispatch:
 
 permissions:
@@ -41,12 +43,12 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: docs/package-lock.json
-      - name: Use supported npm audit client
+      - name: Use pinned npm client
         run: npm install --global npm@11.6.4
       - name: Install dependencies
-        run: npm --prefix docs ci
+        run: npm --prefix docs ci --no-audit
       - name: Audit dependencies
-        run: npm --prefix docs audit --audit-level=high
+        run: ./tools/osv-audit.sh docs/package-lock.json
       - name: Build documentation
         run: npm --prefix docs run build
       - name: Configure GitHub Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: ui/package-lock.json
+      - name: Use supported npm audit client
+        run: npm install --global npm@11.6.4
       - name: Verify Go modules
         run: |
           go mod verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: ui/package-lock.json
-      - name: Use supported npm audit client
+      - name: Use pinned npm client
         run: npm install --global npm@11.6.4
       - name: Verify Go modules
         run: |
@@ -61,14 +61,15 @@ jobs:
           go vet ./...
       - name: Test Go with race detector
         run: go test -race -count=1 ./...
-      - name: Install and test UI
+      - name: Install UI dependencies
+        run: npm --prefix ui ci --no-audit
+      - name: Audit UI dependencies
+        run: ./tools/osv-audit.sh ui/package-lock.json
+      - name: Install browser and test UI
         run: |
-          npm --prefix ui ci
           npm --prefix ui run test:browser:install
           npm --prefix ui test
           npm --prefix ui run test:browser
-      - name: Audit UI dependencies
-        run: npm --prefix ui audit --audit-level=high
       - name: Build UI and check budget
         run: |
           npm --prefix ui run build

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ test: ui
 	npm --prefix ui test
 
 check: ui
+	./tools/osv-audit.sh ui/package-lock.json
 	go mod verify
 	go mod tidy -diff
 	go test -count=1 ./...
@@ -60,5 +61,6 @@ release-check:
 	@cmp -s "RELEASE-NOTES-$(RELEASE_VERSION).md" RELEASE-NOTES.md || { \
 		echo 'release-check: versioned notes differ from RELEASE-NOTES.md' >&2; exit 2; \
 	}
+	./tools/osv-audit.sh ui/package-lock.json
 	./tools/secret-scan.sh
 	./tools/reproducible-build-check.sh "$(RELEASE_VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 		'make release-check RELEASE_VERSION=  require a clean, reproducible release tree'
 
 ui:
-	npm --prefix ui ci
+	npm --prefix ui ci --no-audit
 	npm --prefix ui run build
 
 build: ui

--- a/README.md
+++ b/README.md
@@ -371,7 +371,8 @@ responsible for what the project ships.
 
 AI output is not treated as evidence that the software is correct or secure.
 CI runs Go tests, `go vet`, the race detector, `govulncheck`, UI unit and browser
-tests, `npm audit`, release smoke tests, and repository/history secret scans.
+tests, OSV dependency scans, release smoke tests, and repository/history secret
+scans.
 Hardware behavior is checked separately against physical OpenWrt devices and
 the known coverage gaps are published above.
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -13,7 +13,7 @@
 FROM --platform=$BUILDPLATFORM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS ui
 WORKDIR /src/ui
 COPY ui/package.json ui/package-lock.json ./
-RUN npm ci
+RUN npm ci --no-audit
 COPY ui/ ./
 # vite build emits ui/dist plus precompressed .gz siblings (vite plugin);
 # budget: ≤ 1.5 MB gzipped total (checked again in CI by tools/budget_check.sh)

--- a/deploy/workflow_release_contract_test.go
+++ b/deploy/workflow_release_contract_test.go
@@ -91,6 +91,15 @@ func TestReleaseWorkflowContract(t *testing.T) {
 			t.Errorf("documentation workflow lost %q", required)
 		}
 	}
+	for path, required := range map[string]string{
+		"../Makefile":               "npm --prefix ui ci --no-audit",
+		"../tools/release-build.sh": "npm --prefix ui ci --no-audit",
+		"Dockerfile":                "RUN npm ci --no-audit",
+	} {
+		if content := readWorkflow(t, path); !strings.Contains(content, required) {
+			t.Errorf("%s lost non-auditing install %q", path, required)
+		}
+	}
 	for name, workflow := range map[string]string{"ci": ci, "docs": docs, "release": release} {
 		setups := strings.Count(workflow, "uses: actions/setup-node@")
 		pins := strings.Count(workflow, "npm install --global npm@11.6.4")

--- a/deploy/workflow_release_contract_test.go
+++ b/deploy/workflow_release_contract_test.go
@@ -10,17 +10,19 @@ import (
 
 func TestReleaseWorkflowContract(t *testing.T) {
 	release := readWorkflow(t, "../.github/workflows/release.yml")
+	docs := readWorkflow(t, "../.github/workflows/docs.yml")
 	for _, required := range []string{
 		"gate:\n    name: Exact-SHA release gate",
 		"ref: ${{ github.sha }}",
 		"go test -count=1 ./...",
 		"go vet ./...",
 		"go test -race -count=1 ./...",
+		"npm --prefix ui ci --no-audit",
 		"npm --prefix ui test",
 		"npm --prefix ui run test:browser:install",
 		"npm --prefix ui run test:browser",
 		"npm install --global npm@11.6.4",
-		"npm --prefix ui audit --audit-level=high",
+		"./tools/osv-audit.sh ui/package-lock.json",
 		"./tools/budget_check.sh",
 		"govulncheck@v1.7.0",
 		"./tools/secret-scan.sh",
@@ -65,7 +67,8 @@ func TestReleaseWorkflowContract(t *testing.T) {
 		"./tools/reproducible-build-check.sh v0.0.0-ci",
 		"govulncheck@v1.7.0",
 		"npm install --global npm@11.6.4",
-		"npm --prefix ui audit --audit-level=high",
+		"npm --prefix ui ci --no-audit",
+		"./tools/osv-audit.sh ui/package-lock.json",
 		"npm --prefix ui run test:browser:install",
 		"npm --prefix ui run test:browser",
 		"./tools/secret-scan.sh",
@@ -79,7 +82,16 @@ func TestReleaseWorkflowContract(t *testing.T) {
 	if strings.Contains(ci, "\n  vulnerabilities:\n") {
 		t.Error("vulnerability scans must remain inside the five protected CI job contexts")
 	}
-	for name, workflow := range map[string]string{"ci": ci, "release": release} {
+	for _, required := range []string{
+		"npm --prefix docs ci --no-audit",
+		"./tools/osv-audit.sh docs/package-lock.json",
+		`- "tools/osv-audit.sh"`,
+	} {
+		if !strings.Contains(docs, required) {
+			t.Errorf("documentation workflow lost %q", required)
+		}
+	}
+	for name, workflow := range map[string]string{"ci": ci, "docs": docs, "release": release} {
 		setups := strings.Count(workflow, "uses: actions/setup-node@")
 		pins := strings.Count(workflow, "npm install --global npm@11.6.4")
 		if pins != setups {
@@ -88,7 +100,7 @@ func TestReleaseWorkflowContract(t *testing.T) {
 	}
 
 	pinned := regexp.MustCompile(`^uses: (actions|docker|sigstore)/[^@[:space:]]+@[0-9a-f]{40}(?:[[:space:]]+#.*)?$`)
-	for name, workflow := range map[string]string{"ci": ci, "release": release} {
+	for name, workflow := range map[string]string{"ci": ci, "docs": docs, "release": release} {
 		scanner := bufio.NewScanner(strings.NewReader(workflow))
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())

--- a/deploy/workflow_release_contract_test.go
+++ b/deploy/workflow_release_contract_test.go
@@ -79,6 +79,13 @@ func TestReleaseWorkflowContract(t *testing.T) {
 	if strings.Contains(ci, "\n  vulnerabilities:\n") {
 		t.Error("vulnerability scans must remain inside the five protected CI job contexts")
 	}
+	for name, workflow := range map[string]string{"ci": ci, "release": release} {
+		setups := strings.Count(workflow, "uses: actions/setup-node@")
+		pins := strings.Count(workflow, "npm install --global npm@11.6.4")
+		if pins != setups {
+			t.Errorf("%s workflow must pin npm 11.6.4 after every Node setup: got %d pins for %d setups", name, pins, setups)
+		}
+	}
 
 	pinned := regexp.MustCompile(`^uses: (actions|docker|sigstore)/[^@[:space:]]+@[0-9a-f]{40}(?:[[:space:]]+#.*)?$`)
 	for name, workflow := range map[string]string{"ci": ci, "release": release} {

--- a/deploy/workflow_release_contract_test.go
+++ b/deploy/workflow_release_contract_test.go
@@ -100,6 +100,9 @@ func TestReleaseWorkflowContract(t *testing.T) {
 			t.Errorf("%s lost non-auditing install %q", path, required)
 		}
 	}
+	if count := strings.Count(readWorkflow(t, "../Makefile"), "./tools/osv-audit.sh ui/package-lock.json"); count != 2 {
+		t.Errorf("Makefile must scan dependencies in check and release-check: got %d OSV invocations", count)
+	}
 	for name, workflow := range map[string]string{"ci": ci, "docs": docs, "release": release} {
 		setups := strings.Count(workflow, "uses: actions/setup-node@")
 		pins := strings.Count(workflow, "npm install --global npm@11.6.4")

--- a/deploy/workflow_release_contract_test.go
+++ b/deploy/workflow_release_contract_test.go
@@ -19,6 +19,7 @@ func TestReleaseWorkflowContract(t *testing.T) {
 		"npm --prefix ui test",
 		"npm --prefix ui run test:browser:install",
 		"npm --prefix ui run test:browser",
+		"npm install --global npm@11.6.4",
 		"npm --prefix ui audit --audit-level=high",
 		"./tools/budget_check.sh",
 		"govulncheck@v1.7.0",
@@ -63,6 +64,7 @@ func TestReleaseWorkflowContract(t *testing.T) {
 	for _, required := range []string{
 		"./tools/reproducible-build-check.sh v0.0.0-ci",
 		"govulncheck@v1.7.0",
+		"npm install --global npm@11.6.4",
 		"npm --prefix ui audit --audit-level=high",
 		"npm --prefix ui run test:browser:install",
 		"npm --prefix ui run test:browser",

--- a/docs/reference/engineering.md
+++ b/docs/reference/engineering.md
@@ -71,12 +71,13 @@ make check
 `make check`:
 
 1. installs UI dependencies and builds the embedded UI;
-2. verifies Go modules and checks `go mod tidy -diff`;
-3. runs all normal Go tests;
-4. runs `go vet`;
-5. runs UI unit tests;
-6. enforces the gzipped UI bundle budget; and
-7. scans the working tree for repository-specific secret patterns.
+2. scans the complete UI lockfile against the OSV vulnerability database;
+3. verifies Go modules and checks `go mod tidy -diff`;
+4. runs all normal Go tests;
+5. runs `go vet`;
+6. runs UI unit tests;
+7. enforces the gzipped UI bundle budget; and
+8. scans the working tree for repository-specific secret patterns.
 
 It does not run the Go race detector, Playwright suite, `govulncheck`, full
 history secret scan, reproducible-build check, or physical-router tests. CI and
@@ -283,10 +284,16 @@ Pull requests and main-branch pushes run:
 
 - Go module verification, tests, vet, and `govulncheck`;
 - the full Go race suite;
-- UI unit/browser tests, dependency audit, production build, and bundle budget;
+- UI unit/browser tests, a fail-closed OSV lockfile scan, production build, and
+  bundle budget;
 - reproducible release archive and container restore smoke checks;
 - multi-platform container build without publishing; and
 - tree/history secret scans.
+
+The OSV gate is intentionally strict: any known vulnerability match, download
+or checksum failure, package-extraction failure, or scanner/API error fails the
+job. It replaces npm's unavailable audit service without weakening dependency
+screening and checks all severities rather than only high and critical results.
 
 A `v*` tag triggers the release workflow. It requires strict SemVer on `main`,
 repeats the complete gates at the tagged SHA, builds reproducible Linux/macOS

--- a/docs/reference/engineering.md
+++ b/docs/reference/engineering.md
@@ -85,7 +85,8 @@ release gates add those.
 ### Individual commands
 
 ```sh
-npm --prefix ui ci
+npm --prefix ui ci --no-audit
+./tools/osv-audit.sh ui/package-lock.json
 npm --prefix ui test
 npm --prefix ui run build
 go test -count=1 ./...
@@ -307,8 +308,8 @@ commit is not the published release even if its version string is changed.
 Build the documentation site before submitting a content change:
 
 ```sh
-npm --prefix docs ci
-npm --prefix docs audit --audit-level=high
+npm --prefix docs ci --no-audit
+./tools/osv-audit.sh docs/package-lock.json
 npm --prefix docs run build
 ```
 

--- a/tools/osv-audit.sh
+++ b/tools/osv-audit.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Scan one lockfile with a pinned, checksum-verified OSV-Scanner release.
+set -eu
+
+if [ "$#" -ne 1 ] || [ ! -f "$1" ]; then
+  echo "usage: tools/osv-audit.sh <existing-lockfile>" >&2
+  exit 2
+fi
+
+version=2.4.0
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)
+    asset=osv-scanner_linux_amd64
+    checksum=15314940c10d26af9c6649f150b8a47c1262e8fc7e17b1d1029b0e479e8ed8a0
+    ;;
+  Linux-aarch64|Linux-arm64)
+    asset=osv-scanner_linux_arm64
+    checksum=44e580752910f0ff36ec99aff59af20f65df1e859aa31e5605a8f0d055b496e9
+    ;;
+  Darwin-x86_64)
+    asset=osv-scanner_darwin_amd64
+    checksum=088119325156321c34c456ac3703d6013538fd71cbac82b891ab34db491e4d66
+    ;;
+  Darwin-arm64)
+    asset=osv-scanner_darwin_arm64
+    checksum=9ca3185ad63e9ab54f7cb90f46a7362be02d80e37f0123d095a54355ea202f5d
+    ;;
+  *)
+    echo "osv-audit: unsupported platform $(uname -s)-$(uname -m)" >&2
+    exit 2
+    ;;
+esac
+
+umask 077
+temp_root=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+scan_dir=$(mktemp -d "$temp_root/oonfeewrt-osv.XXXXXX")
+case "$scan_dir" in
+  "$temp_root"/oonfeewrt-osv.*) ;;
+  *) echo "osv-audit: unsafe temporary path" >&2; exit 2 ;;
+esac
+trap 'find "$scan_dir" -depth -delete' EXIT
+trap 'exit 130' HUP INT TERM
+
+scanner=$scan_dir/$asset
+curl --fail --silent --show-error --location \
+  --proto '=https' --tlsv1.2 --connect-timeout 10 --max-time 120 \
+  --retry 3 --retry-all-errors \
+  --output "$scanner" \
+  "https://github.com/google/osv-scanner/releases/download/v$version/$asset"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual=$(sha256sum "$scanner" | awk '{print $1}')
+else
+  actual=$(shasum -a 256 "$scanner" | awk '{print $1}')
+fi
+if [ "$actual" != "$checksum" ]; then
+  echo "osv-audit: checksum mismatch for $asset" >&2
+  exit 1
+fi
+
+chmod 0700 "$scanner"
+"$scanner" scan --lockfile="$1"

--- a/tools/release-build.sh
+++ b/tools/release-build.sh
@@ -31,7 +31,7 @@ out=$(cd "$out" && pwd)
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/oonfeewrt-package.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 
-npm --prefix ui ci
+npm --prefix ui ci --no-audit
 npm --prefix ui run build
 test -f ui/dist/index.html || {
   echo "release build: UI build produced no index.html" >&2


### PR DESCRIPTION
## Why

CI #52 passed all 412 UI unit tests and 14 browser tests, then npm 10.9.8 fell back to the retired Quick Audit endpoint and received HTTP 400. Pinning npm 11.6.4 removed that fallback, but the supported bulk endpoint then timed out for five minutes from both GitHub Actions and a local raw request. This is upstream audit-service failure, not lockfile corruption or a project test failure.

## What changed

- pin npm 11.6.4 after every Node setup for deterministic installs
- disable npm ci's duplicate, non-gating automatic audit requests
- replace explicit npm audit calls with Google OSV-Scanner v2.4.0
- download the official per-platform binary over HTTPS and verify its published SHA-256 before execution
- scan UI and documentation lockfiles in CI, release, and documentation workflows
- keep dependency scans fail-closed when vulnerabilities or scanner errors occur
- add workflow contract coverage and keep documentation workflow path filters in sync
- update README and engineering guidance

## Local validation

- OSV UI lockfile scan: no issues
- OSV documentation lockfile scan: no issues
- workflow contract test: pass
- every GitHub Actions YAML file parses
- documentation production build: pass
- UI production build and bundle budget: pass
- git diff check: pass