### PR TITLE
test: await session confirmation dialog

### DIFF
--- a/ui/src/screens/Accounts.test.tsx
+++ b/ui/src/screens/Accounts.test.tsx
@@ -178,7 +178,7 @@ describe('Accounts', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Revoke 192.168.1.22' }))
 
     expect(api.revokeManagedAccountSession).not.toHaveBeenCalled()
-    fireEvent.click(screen.getByRole('button', { name: /revoke 192\.168\.1\.22 for.*router-operator/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /revoke 192\.168\.1\.22 for.*router-operator/i }))
     await waitFor(() => expect(api.revokeManagedAccountSession).toHaveBeenCalledWith(2, 'opaque-session-id'))
   })
 })


### PR DESCRIPTION
## Summary

- await the asynchronously rendered managed-session confirmation before clicking it
- remove the timing race exposed by the post-merge Vitest 4 run

## Verification

- targeted confirmation test passed 20 consecutive runs
- full UI suite passed: 16 files, 412 tests
- `git diff --check`