### PR TITLE
docs: add project support links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+custom:
+  - https://buymeacoffee.com/aiden0rchad

--- a/README.md
+++ b/README.md
@@ -355,6 +355,13 @@ oonfeeWRT rejects passphrases supplied through environment variables.
 - [Roadmap](docs/ROADMAP.md)
 - [Risk register](docs/RISKS.md)
 
+## Support future development
+
+If oonfeeWRT is useful to you, you can support future development, hands-on
+testing across more OpenWrt hardware, and careful release validation.
+
+[![Buy me a coffee](https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&emoji=&slug=aiden0rchad&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff)](https://buymeacoffee.com/aiden0rchad)
+
 ## License
 
 Apache License 2.0. See [LICENSE](LICENSE), [NOTICE](NOTICE), and

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -209,6 +209,58 @@ body {
   font-weight: 650;
 }
 
+.support-card {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  justify-content: space-between;
+  margin: 24px 0;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgb(255 221 0 / 14%), var(--vp-c-bg-elv) 48%);
+  padding: 20px;
+}
+
+.dark .support-card {
+  background: linear-gradient(135deg, rgb(255 221 0 / 10%), var(--vp-c-bg-elv) 48%);
+}
+
+.support-card p {
+  margin: 0;
+  color: var(--vp-c-text-2);
+  line-height: 1.55;
+}
+
+.support-button {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  border: 1px solid #000;
+  border-radius: 10px;
+  background: #ffdd00;
+  box-shadow: 0 3px 0 rgb(0 0 0 / 85%);
+  padding: 0 22px;
+  color: #000 !important;
+  font-weight: 750;
+  line-height: 1;
+  text-decoration: none !important;
+  white-space: nowrap;
+  transition: background-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.support-button:hover {
+  background: #ffe43b;
+  box-shadow: 0 4px 0 rgb(0 0 0 / 85%);
+  transform: translateY(-1px);
+}
+
+.support-button:active {
+  box-shadow: 0 1px 0 rgb(0 0 0 / 85%);
+  transform: translateY(2px);
+}
+
 .docs-screenshot {
   margin: 28px 0;
 }
@@ -262,6 +314,15 @@ body {
 
   .write-impact {
     display: block;
+  }
+
+  .support-card {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .support-button {
+    width: 100%;
   }
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -200,3 +200,10 @@ your router, create the first owner, add one non-critical OpenWrt device by
 address, inspect it, and adopt only the functions you need.
 
 [Start the guided setup →](/getting-started/)
+
+## Support future development
+
+<div class="support-card">
+  <p>If oonfeeWRT is useful to you, you can support future development, hands-on testing across more OpenWrt hardware, and careful release validation.</p>
+  <a class="support-button" href="https://buymeacoffee.com/aiden0rchad" target="_blank" rel="noopener noreferrer" aria-label="Buy me a coffee to support oonfeeWRT (opens in a new tab)">Buy me a coffee</a>
+</div>


### PR DESCRIPTION
## Summary

- add a Buy Me a Coffee call-to-action to the README
- add a responsive support card to the documentation home page for light and dark themes
- register the support page through GitHub funding metadata
- use a native link instead of the legacy document-writing widget so GitHub and VitePress render it safely

## Validation

- `npm --prefix docs ci --no-audit`
- `./tools/osv-audit.sh docs/package-lock.json`
- `npm --prefix docs run build`
- `git diff --check`
- visually checked desktop and mobile layouts in light and dark modes
- verified no browser console warnings or errors
- verified the README button through GitHub Markdown rendering